### PR TITLE
DEX-695 Fix of query parameter loss during redirect

### DIFF
--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/dex/DexApi.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/dex/DexApi.scala
@@ -286,7 +286,7 @@ object DexApi {
       override def tryOrderBook(assetPair: AssetPair, depth: Int): F[Either[MatcherError, OrderBookResponse]] = tryParseJson {
         sttp
           .get(uri"$apiUri/orderbook/${assetPair.amountAssetStr}/${assetPair.priceAssetStr}?depth=$depth")
-          .followRedirects(false)
+          .followRedirects(true)
       }
 
       override def tryOrderBookInfo(assetPair: AssetPair): F[Either[MatcherError, OrderBookInfo]] = tryParseJson {

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/api/GetOrderBookTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/api/GetOrderBookTestSuite.scala
@@ -1,18 +1,20 @@
 package com.wavesplatform.it.sync.api
 
 import com.typesafe.config.{Config, ConfigFactory}
+import com.wavesplatform.dex.domain.asset.Asset.Waves
+import com.wavesplatform.dex.domain.asset.AssetPair
 import com.wavesplatform.dex.domain.order.OrderType.{BUY, SELL}
+import com.wavesplatform.dex.it.api.responses.dex.OrderBookResponse
 import com.wavesplatform.it.MatcherSuiteBase
 
 class GetOrderBookTestSuite extends MatcherSuiteBase {
 
-  val ordersCount = 0
+  private val ordersCount = 150
 
   override protected val dexInitialSuiteConfig: Config =
     ConfigFactory.parseString(
       s"""waves.dex {
-         |  price-assets = [ "$UsdId", "WAVES" ]
-         |  allowed-order-versions = [1, 2, 3]
+         |  price-assets = [ "$UsdId", "WAVES", $EthId ]
          |  order-book-snapshot-http-cache {
          |    cache-timeout = 5s
          |    depth-ranges = [10, 20, 40, 41, 43, 100, 1000]
@@ -23,37 +25,53 @@ class GetOrderBookTestSuite extends MatcherSuiteBase {
 
   override protected def beforeAll(): Unit = {
     wavesNode1.start()
-    broadcastAndAwait(IssueUsdTx)
+    broadcastAndAwait(IssueUsdTx, IssueEthTx)
     dex1.start()
   }
 
-  def checkDepth(depth: Int, array: Array[Int] = Array()): Unit = {
-    val orderBook = dex1.api.orderBook(wavesUsdPair, depth)
+  def checkDepth(forTheseDepths: Array[Int] = Array(), thisDepthWillBePicked: Int): Unit = {
+    val orderBook: OrderBookResponse = dex1.api.orderBook(wavesUsdPair, thisDepthWillBePicked)
 
-    if (depth < ordersCount) {
-      orderBook.asks.size shouldBe depth
-      orderBook.bids.size shouldBe depth
+    if (thisDepthWillBePicked < ordersCount) {
+      orderBook.asks.size shouldBe thisDepthWillBePicked
+      orderBook.bids.size shouldBe thisDepthWillBePicked
     }
 
-    array.foreach(depth => dex1.api.orderBook(wavesUsdPair, depth) should matchTo(orderBook))
+    forTheseDepths.foreach(depth => dex1.api.orderBook(wavesUsdPair, depth) should matchTo(orderBook))
   }
 
   "response order book should contain right count of bids and asks" in {
 
     for (i <- 1 to ordersCount) {
-      dex1.api.place(mkOrder(alice, wavesUsdPair, BUY, 1.waves, i, 300000, version = 3))
-      dex1.api.place(mkOrder(alice, wavesUsdPair, SELL, 1.waves, i + 51, 300000, version = 3))
+      dex1.api.place(mkOrder(alice, wavesUsdPair, BUY, 1.waves, i))
+      dex1.api.place(mkOrder(alice, wavesUsdPair, SELL, 1.waves, i + ordersCount + 1))
     }
 
-    checkDepth(10, Array(0, 1, 8, 9))
-    checkDepth(20, Array(11, 12, 19))
-    checkDepth(50)
-    checkDepth(101, Array(102, 103, 999, 9999))
+    checkDepth(forTheseDepths = Array(0, 1, 8, 9), thisDepthWillBePicked = 10)
+    checkDepth(forTheseDepths = Array(11, 12, 19), thisDepthWillBePicked = 20)
+    checkDepth(forTheseDepths = Array(31, 32, 39), thisDepthWillBePicked = 40)
+    checkDepth(forTheseDepths = Array(42), thisDepthWillBePicked = 43)
+    checkDepth(forTheseDepths = Array(102, 103, 999, 9999), thisDepthWillBePicked = 1000)
 
     withClue("check default depth value") {
       val defaultOrderBook = dex1.api.orderBook(wavesUsdPair)
       defaultOrderBook shouldBe dex1.api.orderBook(wavesUsdPair, 100)
       Array(44, 45, 60, 98, 99).foreach(depth => dex1.api.orderBook(wavesUsdPair, depth) shouldBe defaultOrderBook)
     }
+  }
+
+  "query parameters should not be lost during redirect to well-ordered pair" in {
+
+    val depth               = 10
+    val ethWavesOrdersCount = 20
+
+    (1 to ethWavesOrdersCount) foreach { i =>
+      dex1.api.place(mkOrder(alice, ethWavesPair, BUY, 1.waves, i * 100))
+      dex1.api.place(mkOrder(alice, ethWavesPair, SELL, 1.waves, (i + ethWavesOrdersCount + 1) * 100))
+    }
+
+    val orderBook = dex1.api.orderBook(AssetPair(Waves, eth), depth)
+    orderBook.asks should have size depth
+    orderBook.asks should have size depth
   }
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/api/MatcherApiRoute.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/MatcherApiRoute.scala
@@ -323,7 +323,7 @@ case class MatcherApiRoute(assetPairBuilder: AssetPairBuilder,
   )
   def getOrderBook: Route = (path("orderbook" / AssetPairPM) & get) { p =>
     parameters('depth.as[Int].?) { depth =>
-      withAssetPair(p, redirectToInverse = true) { pair =>
+      withAssetPair(p, redirectToInverse = true, depth.fold("")(d => s"?depth=$d")) { pair =>
         complete { orderBookSnapshot.get(pair, depth) }
       }
     }


### PR DESCRIPTION
 * Loss of query parameter `depth` during redirect (orderBook endpoint) fixed
 * Integration test added
 * GetOrderBookTestSuite fixed