### PR TITLE
DEX-686 Empty balances for new accounts in WS private streams

### DIFF
--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/api/ws/WebSocketPrivateStreamTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/api/ws/WebSocketPrivateStreamTestSuite.scala
@@ -71,7 +71,8 @@ class WebSocketPrivateStreamTestSuite extends MatcherSuiteBase with HasWebSocket
 
       "when account is empty" in {
         val wsac = mkWsConnection(mkKeyPair("Test"), method)
-        assertChanges(wsac, squash = false)(Map(Waves -> WsBalances(0, 0)))()
+        eventually { wsac.getMessagesBuffer should have size 1 }
+        assertChanges(wsac, squash = false)()()
         wsac.close()
       }
 

--- a/dex/src/main/scala/com/wavesplatform/dex/api/websockets/WsAddressState.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/websockets/WsAddressState.scala
@@ -18,8 +18,6 @@ object WsAddressState {
   def wsUnapply(arg: WsAddressState): Option[(String, Long, Long, Map[Asset, WsBalances], Seq[WsOrder])] =
     (arg.tpe, arg.timestamp, arg.updateId, arg.balances, arg.orders).some
 
-  val empty: WsAddressState = WsAddressState(Map(Waves -> WsBalances(0, 0)), Seq.empty, 0)
-
   implicit val balancesMapFormat: Format[Map[Asset, WsBalances]] = Format(
     { // TODO use reads for Map[Asset, T]!
       case JsObject(ab) => JsSuccess(ab.toMap.map { case (a, b) => AssetPair.extractAsset(a).get -> WsBalances.format.reads(b).get })

--- a/waves-ext/src/main/scala/com/wavesplatform/dex/grpc/integration/services/WavesBlockchainApiGrpcService.scala
+++ b/waves-ext/src/main/scala/com/wavesplatform/dex/grpc/integration/services/WavesBlockchainApiGrpcService.scala
@@ -216,8 +216,13 @@ class WavesBlockchainApiGrpcService(context: ExtensionContext, balanceChangesBat
       val address              = request.address.toVanillaAddress
       val pessimisticPortfolio = context.blockchain.portfolio(address) |+| context.utx.pessimisticPortfolio(address)
 
+      val pessimisticPortfolioNonZeroBalances = {
+        if (pessimisticPortfolio.balance == 0) pessimisticPortfolio.assets
+        else pessimisticPortfolio.assets ++ Map(Waves -> pessimisticPortfolio.balance)
+      }
+
       AllAssetsSpendableBalanceResponse(
-        (pessimisticPortfolio.assets ++ Map(Waves -> pessimisticPortfolio.balance)).map {
+        pessimisticPortfolioNonZeroBalances.map {
           case (a, b) => AllAssetsSpendableBalanceResponse.Record(a.toPB, b)
         }.toSeq
       )


### PR DESCRIPTION
 * Method allAssetsSpendableBalance in WavesBlockchainApiGrpcService returns only nonzero balances
 * Unit and integration tests added