### PR TITLE
DEX-681 Closing all WS connections after order book deleting

### DIFF
--- a/dex/src/main/scala/com/wavesplatform/dex/OrderBookWsState.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/OrderBookWsState.scala
@@ -20,8 +20,6 @@ case class OrderBookWsState(wsConnections: Map[ActorRef[WsOrderBook], Long],
     if (wsConnections.size == 1) OrderBookWsState(Map.empty, Set.empty, Set.empty, None)
     else copy(wsConnections = wsConnections.filterKeys(_ != x))
 
-  def withoutSubscriptions: OrderBookWsState = copy(wsConnections = Map.empty)
-
   def hasSubscriptions: Boolean = wsConnections.nonEmpty
 
   def hasChanges: Boolean = changedAsks.nonEmpty || changedBids.nonEmpty || lastTrade.nonEmpty

--- a/dex/src/main/scala/com/wavesplatform/dex/actors/OrderBookAskAdapter.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/actors/OrderBookAskAdapter.scala
@@ -35,16 +35,16 @@ class OrderBookAskAdapter(orderBooks: AtomicReference[Map[AssetPair, Either[Unit
     get[Query.GetHttpView, HttpResponse](assetPair, Query.GetHttpView(format, depth, _))
 
   private val default = Future.successful(Right(None))
-  private def get[M <: Query, R: ClassTag](assetPair: AssetPair, message: ActorRef => M): Result[R] =
-    orderBooks.get().get(assetPair) match {
-      case None => default
-      case Some(ob) =>
-        ob match {
-          case Left(_) => Future.successful(error.OrderBookBroken(assetPair).asLeft)
-          case Right(ob) =>
-            val (askRef, r) = AskActor.mk[R](askTimeout)
-            ob ! message(askRef)
-            r.map(_.some.asRight)
-        }
-    }
+
+  private def get[M <: Query, R: ClassTag](assetPair: AssetPair, message: ActorRef => M): Result[R] = orderBooks.get().get(assetPair) match {
+    case None => default
+    case Some(ob) =>
+      ob match {
+        case Left(_) => Future.successful(error.OrderBookBroken(assetPair).asLeft)
+        case Right(ob) =>
+          val (askRef, r) = AskActor.mk[R](askTimeout)
+          ob ! message(askRef)
+          r.map(_.some.asRight)
+      }
+  }
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/api/MatcherWebSocketRoute.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/MatcherWebSocketRoute.scala
@@ -64,7 +64,7 @@ case class MatcherWebSocketRoute(addressDirectory: ActorRef,
     case Status.Success                        => CompletionStrategy.draining
   }
 
-  private val failureMatcher: PartialFunction[Any, Throwable] = { case Status.Failure(cause) => cause }
+  private val failureMatcher: PartialFunction[Any, Throwable] = { case WsMessage.CompleteWithFailure(cause) => cause }
 
   private def accountUpdatesSource(address: Address): Source[TextMessage.Strict, ConnectionSource] = {
     Source
@@ -86,7 +86,7 @@ case class MatcherWebSocketRoute(addressDirectory: ActorRef,
     ActorSource
       .actorRef[WsMessage](
         { case WsMessage.Complete => },
-        PartialFunction.empty,
+        failureMatcher,
         10,
         OverflowStrategy.fail
       )

--- a/dex/src/main/scala/com/wavesplatform/dex/api/MatcherWebSocketRoute.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/MatcherWebSocketRoute.scala
@@ -1,6 +1,7 @@
 package com.wavesplatform.dex.api
 
 import java.nio.charset.StandardCharsets
+import java.util.UUID
 import java.util.concurrent.TimeUnit
 
 import akka.Done
@@ -56,8 +57,8 @@ case class MatcherWebSocketRoute(addressDirectory: ActorRef,
 
   private implicit val trm: ToResponseMarshaller[MatcherResponse] = MatcherResponse.toResponseMarshaller
 
-  private val completionMatcher: PartialFunction[WsMessage, Unit] = { case WsMessage.Complete => }
-  private val failureMatcher: PartialFunction[Any, Throwable]     = PartialFunction.empty
+  private val completionMatcher: PartialFunction[WsMessage, Unit]   = { case WsMessage.Complete => }
+  private val failureMatcher: PartialFunction[WsMessage, Throwable] = PartialFunction.empty
 
   private def accountUpdatesSource(address: Address): Source[TextMessage.Strict, typed.ActorRef[WsMessage]] = {
     ActorSource
@@ -67,6 +68,7 @@ case class MatcherWebSocketRoute(addressDirectory: ActorRef,
         10,
         OverflowStrategy.fail
       )
+      .named(UUID.randomUUID.toString)
       .map(_.toStrictTextMessage)
       .mapMaterializedValue { sourceActor =>
         addressDirectory ! AddressDirectory.Envelope(address, AddressActor.WsCommand.AddWsSubscription(sourceActor))
@@ -83,6 +85,7 @@ case class MatcherWebSocketRoute(addressDirectory: ActorRef,
         10,
         OverflowStrategy.fail
       )
+      .named(UUID.randomUUID.toString)
       .map(_.toStrictTextMessage)
       .mapMaterializedValue { sourceActor =>
         matcher ! MatcherActor.AggregatedOrderBookEnvelope(pair, AggregatedOrderBookActor.WsCommand.AddWsSubscription(sourceActor))

--- a/dex/src/main/scala/com/wavesplatform/dex/api/MatcherWebSocketRoute.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/MatcherWebSocketRoute.scala
@@ -88,7 +88,7 @@ case class MatcherWebSocketRoute(addressDirectory: ActorRef,
       .named(UUID.randomUUID.toString)
       .map(_.toStrictTextMessage)
       .mapMaterializedValue { sourceActor =>
-        matcher ! MatcherActor.AggregatedOrderBookEnvelope(pair, AggregatedOrderBookActor.WsCommand.AddWsSubscription(sourceActor))
+        matcher ! MatcherActor.AggregatedOrderBookEnvelope(pair, AggregatedOrderBookActor.Command.AddWsSubscription(sourceActor))
         sourceActor
       }
       .watchTermination()(handleTermination)

--- a/dex/src/main/scala/com/wavesplatform/dex/api/MatcherWebSocketRoute.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/MatcherWebSocketRoute.scala
@@ -12,7 +12,7 @@ import akka.http.scaladsl.server.directives.FutureDirectives
 import akka.http.scaladsl.server.{Directive0, Directive1, Route, StandardRoute}
 import akka.stream.scaladsl.{Flow, Sink, Source}
 import akka.stream.typed.scaladsl.ActorSource
-import akka.stream.{CompletionStrategy, Materializer, OverflowStrategy}
+import akka.stream.{Materializer, OverflowStrategy}
 import cats.syntax.either._
 import cats.syntax.option._
 import com.google.common.primitives.Longs
@@ -22,7 +22,6 @@ import com.wavesplatform.dex.api.http.{ApiRoute, AuthRoute, `X-Api-Key`}
 import com.wavesplatform.dex.api.websockets.WsMessage
 import com.wavesplatform.dex.api.websockets.actors.SystemMessagesHandlerActor
 import com.wavesplatform.dex.api.websockets.actors.SystemMessagesHandlerActor.PingOrPong
-import com.wavesplatform.dex.api.websockets.statuses.TerminationStatus
 import com.wavesplatform.dex.domain.account.{Address, PublicKey}
 import com.wavesplatform.dex.domain.asset.AssetPair
 import com.wavesplatform.dex.domain.bytes.ByteStr
@@ -57,17 +56,11 @@ case class MatcherWebSocketRoute(addressDirectory: ActorRef,
 
   private implicit val trm: ToResponseMarshaller[MatcherResponse] = MatcherResponse.toResponseMarshaller
 
-  private val completionMatcher: PartialFunction[Any, CompletionStrategy] = {
-    case WsMessage.Complete                    => CompletionStrategy.immediately
-    case Status.Success(s: CompletionStrategy) => s
-    case Status.Success(_)                     => CompletionStrategy.draining
-    case Status.Success                        => CompletionStrategy.draining
-  }
+  private val completionMatcher: PartialFunction[WsMessage, Unit] = { case WsMessage.Complete => }
+  private val failureMatcher: PartialFunction[Any, Throwable]     = PartialFunction.empty
 
-  private val failureMatcher: PartialFunction[Any, Throwable] = { case WsMessage.CompleteWithFailure(cause) => cause }
-
-  private def accountUpdatesSource(address: Address): Source[TextMessage.Strict, ConnectionSource] = {
-    Source
+  private def accountUpdatesSource(address: Address): Source[TextMessage.Strict, typed.ActorRef[WsMessage]] = {
+    ActorSource
       .actorRef[WsMessage](
         completionMatcher,
         failureMatcher,
@@ -76,24 +69,24 @@ case class MatcherWebSocketRoute(addressDirectory: ActorRef,
       )
       .map(_.toStrictTextMessage)
       .mapMaterializedValue { sourceActor =>
-        addressDirectory.tell(AddressDirectory.Envelope(address, AddressActor.AddWsSubscription), sourceActor)
-        ConnectionSource.AddressUpdatesSource(sourceActor)
+        addressDirectory ! AddressDirectory.Envelope(address, AddressActor.WsCommand.AddWsSubscription(sourceActor))
+        sourceActor
       }
       .watchTermination()(handleTermination)
   }
 
-  private def orderBookUpdatesSource(pair: AssetPair): Source[TextMessage.Strict, ConnectionSource] = {
+  private def orderBookUpdatesSource(pair: AssetPair): Source[TextMessage.Strict, typed.ActorRef[WsMessage]] = {
     ActorSource
       .actorRef[WsMessage](
-        { case WsMessage.Complete => },
+        completionMatcher,
         failureMatcher,
         10,
         OverflowStrategy.fail
       )
       .map(_.toStrictTextMessage)
       .mapMaterializedValue { sourceActor =>
-        matcher ! MatcherActor.AggregatedOrderBookEnvelope(pair, AggregatedOrderBookActor.Command.AddWsSubscription(sourceActor))
-        ConnectionSource.OrderBookSource(sourceActor)
+        matcher ! MatcherActor.AggregatedOrderBookEnvelope(pair, AggregatedOrderBookActor.WsCommand.AddWsSubscription(sourceActor))
+        sourceActor
       }
       .watchTermination()(handleTermination)
   }
@@ -102,7 +95,7 @@ case class MatcherWebSocketRoute(addressDirectory: ActorRef,
   private lazy val binaryMessageUnsupportedFailure: Future[PingOrPong]  = mkPongFailure("Binary messages are not supported")
   private def unexpectedMessageFailure(msg: String): Future[PingOrPong] = mkPongFailure(s"Got unexpected message instead of pong: $msg")
 
-  private def createStreamFor(source: Source[TextMessage.Strict, ConnectionSource], expiration: Option[Long] = None): Route = {
+  private def createStreamFor(source: Source[TextMessage.Strict, typed.ActorRef[WsMessage]], expiration: Option[Long] = None): Route = {
 
     import webSocketSettings._
 
@@ -110,9 +103,9 @@ case class MatcherWebSocketRoute(addressDirectory: ActorRef,
       FiniteDuration(exp - System.currentTimeMillis, TimeUnit.MILLISECONDS).min(maxConnectionLifetime)
     }
 
-    val (connectionSource, matSource) = source.preMaterialize()
-    val systemMessagesHandler         = mat.system.actorOf(SystemMessagesHandlerActor.props(systemMessagesSettings, connectionLifetime, connectionSource))
-    val sinkActor                     = Sink.actorRef(ref = systemMessagesHandler, onCompleteMessage = (), onFailureMessage = _ => Status.Failure(_))
+    val (sourceActor, matSource) = source.preMaterialize()
+    val systemMessagesHandler    = mat.system.actorOf(SystemMessagesHandlerActor.props(systemMessagesSettings, connectionLifetime, sourceActor))
+    val sinkActor                = Sink.actorRef(ref = systemMessagesHandler, onCompleteMessage = (), onFailureMessage = _ => Status.Failure(_))
 
     val sink =
       Flow[Message]
@@ -191,40 +184,19 @@ case class MatcherWebSocketRoute(addressDirectory: ActorRef,
     case None    => complete(error.OrderBookStopped(p).toWsHttpResponse(StatusCodes.NotFound))
   }
 
-  private def handleTermination(cs: ConnectionSource, r: Future[Done]): ConnectionSource = {
+  private def handleTermination(client: typed.ActorRef[WsMessage], r: Future[Done]): typed.ActorRef[WsMessage] = {
+    val cn = client.path.name
     r.onComplete {
-      case Success(_) => log.trace(s"[${cs.name}] WebSocket connection successfully closed")
-      case Failure(e) =>
-        log.trace(s"[${cs.name}] WebSocket connection closed with an error: ${Option(e.getMessage).getOrElse(e.getClass.getName)}")
+      case Success(_) => log.trace(s"[$cn] WebSocket connection successfully closed")
+      case Failure(e) => log.trace(s"[$cn] WebSocket connection closed with an error: ${Option(e.getMessage).getOrElse(e.getClass.getName)}")
     }(mat.executionContext)
-    cs
+    client
   }
 }
 
 object MatcherWebSocketRoute {
 
   val balanceStreamPrefix: String = "au"
-
-  // Will be removed after migration to akka-typed
-  trait ConnectionSource {
-    def name: String
-    def ping(message: PingOrPong): Unit
-    def close(terminationStatus: TerminationStatus): Unit
-  }
-
-  object ConnectionSource {
-    final case class AddressUpdatesSource(ref: ActorRef) extends ConnectionSource {
-      override def name: String                                      = ref.path.name
-      override def ping(message: PingOrPong): Unit                   = ref ! message
-      override def close(terminationStatus: TerminationStatus): Unit = ref ! WsMessage.Complete
-    }
-
-    final case class OrderBookSource(ref: typed.ActorRef[WsMessage]) extends ConnectionSource {
-      override def name: String                                      = ref.path.name
-      override def ping(message: PingOrPong): Unit                   = ref ! message
-      override def close(terminationStatus: TerminationStatus): Unit = ref ! WsMessage.Complete
-    }
-  }
 
   final case class AuthParams(expirationTimestamp: Long, signature: ByteStr)
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/api/websockets/WsMessage.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/websockets/WsMessage.scala
@@ -8,9 +8,18 @@ trait WsMessage {
 }
 
 object WsMessage {
+
+  private val unusedStrictTextMessage = TextMessage.Strict("{}")
+  private val unusedTpe               = "unused"
+
   // Will be never propagated to a client
   case object Complete extends WsMessage {
-    override val toStrictTextMessage: TextMessage.Strict = TextMessage.Strict("{}")
-    override val tpe: String                             = "close"
+    override val toStrictTextMessage: TextMessage.Strict = unusedStrictTextMessage
+    override val tpe: String                             = unusedTpe
+  }
+
+  case class CompleteWithFailure(cause: Throwable) extends WsMessage {
+    override val toStrictTextMessage: TextMessage.Strict = unusedStrictTextMessage
+    override val tpe: String                             = unusedTpe
   }
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/api/websockets/WsMessage.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/websockets/WsMessage.scala
@@ -9,17 +9,9 @@ trait WsMessage {
 
 object WsMessage {
 
-  private val unusedStrictTextMessage = TextMessage.Strict("{}")
-  private val unusedTpe               = "unused"
-
   // Will be never propagated to a client
   case object Complete extends WsMessage {
-    override val toStrictTextMessage: TextMessage.Strict = unusedStrictTextMessage
-    override val tpe: String                             = unusedTpe
-  }
-
-  case class CompleteWithFailure(cause: Throwable) extends WsMessage {
-    override val toStrictTextMessage: TextMessage.Strict = unusedStrictTextMessage
-    override val tpe: String                             = unusedTpe
+    override val toStrictTextMessage: TextMessage.Strict = TextMessage.Strict("{}")
+    override val tpe: String                             = "unused"
   }
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/api/websockets/actors/SystemMessagesHandlerActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/websockets/actors/SystemMessagesHandlerActor.scala
@@ -1,30 +1,28 @@
 package com.wavesplatform.dex.api.websockets.actors
 
-import akka.actor.{Actor, Cancellable, Props}
+import akka.actor.{Actor, Cancellable, Props, typed}
 import akka.http.scaladsl.model.ws.TextMessage
 import cats.syntax.option._
-import com.wavesplatform.dex.api.MatcherWebSocketRoute.ConnectionSource
 import com.wavesplatform.dex.api.websockets.WsMessage
 import com.wavesplatform.dex.api.websockets.actors.SystemMessagesHandlerActor._
-import com.wavesplatform.dex.api.websockets.statuses.TerminationStatus
-import com.wavesplatform.dex.api.websockets.statuses.TerminationStatus._
 import com.wavesplatform.dex.domain.utils.ScorexLogging
+import com.wavesplatform.dex.error.{MatcherError, WsConnectionMaxLifetimeExceeded, WsConnectionPongTimeout}
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
 import scala.concurrent.duration._
 
-class SystemMessagesHandlerActor(settings: Settings, maxConnectionLifetime: FiniteDuration, connectionSource: ConnectionSource)
+class SystemMessagesHandlerActor(settings: Settings, maxConnectionLifetime: FiniteDuration, sourceActor: typed.ActorRef[WsMessage])
     extends Actor
     with ScorexLogging {
 
   import context.dispatcher
 
-  private val maxLifetimeExceeded = scheduleOnce(maxConnectionLifetime, CloseConnection(MaxLifetimeExceeded))
+  private val maxLifetimeExceeded = scheduleOnce(maxConnectionLifetime, CloseConnection(WsConnectionMaxLifetimeExceeded))
   private val firstPing           = scheduleOnce(settings.pingInterval, SendPing)
 
   private def scheduleOnce(delay: FiniteDuration, message: Any): Cancellable = context.system.scheduler.scheduleOnce(delay, self, message)
-  private def schedulePongTimeout(): Cancellable                             = scheduleOnce(settings.pongTimeout, CloseConnection(PongTimeout))
+  private def schedulePongTimeout(): Cancellable                             = scheduleOnce(settings.pongTimeout, CloseConnection(WsConnectionPongTimeout))
 
   private def awaitPong(maybeExpectedPong: Option[PingOrPong], pongTimeout: Cancellable, nextPing: Cancellable): Receive = {
 
@@ -41,25 +39,20 @@ class SystemMessagesHandlerActor(settings: Settings, maxConnectionLifetime: Fini
         } else log.trace(s"Got outdated pong: $pong")
       }
 
-    case CloseConnection(terminationStatus) =>
-      closeSourceAndCancelAllTasks(terminationStatus, List(nextPing, pongTimeout, maxLifetimeExceeded, firstPing))
+    case CloseConnection(reason) => closeSourceAndCancelAllTasks(reason, List(nextPing, pongTimeout, maxLifetimeExceeded, firstPing))
   }
 
-  private def closeSourceAndCancelAllTasks(terminationStatus: TerminationStatus, tasks: List[Cancellable]): Unit = {
+  private def closeSourceAndCancelAllTasks(reason: MatcherError, tasks: List[Cancellable]): Unit = {
     tasks.foreach { _.cancel() }
-    val reasonText = terminationStatus match {
-      case PongTimeout         => "WebSocket has reached pong timeout"
-      case MaxLifetimeExceeded => "WebSocket has reached max allowed lifetime"
-    }
-    log.trace(s"[${connectionSource.name}] $reasonText")
-    connectionSource.close(terminationStatus)
+    log.trace(s"[${sourceActor.path.name}] ${reason.message.text}")
+    sourceActor ! WsMessage.Complete
     context.stop(self)
   }
 
   private def sendPingAndScheduleNextOne(): (PingOrPong, Cancellable) = {
     val ping     = PingOrPong(System.currentTimeMillis)
     val nextPing = scheduleOnce(settings.pingInterval, SendPing)
-    connectionSource.ping(ping)
+    sourceActor ! ping
     ping -> nextPing
   }
 
@@ -69,7 +62,7 @@ class SystemMessagesHandlerActor(settings: Settings, maxConnectionLifetime: Fini
       val pongTimeout: Cancellable = schedulePongTimeout()
       context.become { awaitPong(expectedPong.some, pongTimeout, nextPing) }
 
-    case CloseConnection(terminationStatus) => closeSourceAndCancelAllTasks(terminationStatus, List(maxLifetimeExceeded, firstPing))
+    case CloseConnection(reason) => closeSourceAndCancelAllTasks(reason, List(maxLifetimeExceeded, firstPing))
   }
 }
 
@@ -77,12 +70,12 @@ object SystemMessagesHandlerActor {
 
   final case class Settings(pingInterval: FiniteDuration, pongTimeout: FiniteDuration)
 
-  def props(settings: Settings, maxConnectionLifetime: FiniteDuration, connectionSource: ConnectionSource): Props =
-    Props(new SystemMessagesHandlerActor(settings, maxConnectionLifetime: FiniteDuration, connectionSource))
+  def props(settings: Settings, maxConnectionLifetime: FiniteDuration, sourceActor: typed.ActorRef[WsMessage]): Props =
+    Props(new SystemMessagesHandlerActor(settings, maxConnectionLifetime: FiniteDuration, sourceActor))
 
   final case object SendPing
 
-  final case class CloseConnection(terminationStatus: TerminationStatus)
+  final case class CloseConnection(reason: MatcherError)
 
   final case class PingOrPong(timestamp: Long) extends WsMessage {
     override def toStrictTextMessage: TextMessage.Strict = TextMessage.Strict(PingOrPong.format.writes(this).toString)

--- a/dex/src/main/scala/com/wavesplatform/dex/api/websockets/statuses/TerminationStatus.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/websockets/statuses/TerminationStatus.scala
@@ -1,7 +1,0 @@
-package com.wavesplatform.dex.api.websockets.statuses
-
-sealed trait TerminationStatus
-object TerminationStatus {
-  case object PongTimeout         extends TerminationStatus
-  case object MaxLifetimeExceeded extends TerminationStatus
-}

--- a/dex/src/main/scala/com/wavesplatform/dex/error/MatcherError.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/error/MatcherError.scala
@@ -474,6 +474,10 @@ case class AddressAndPublicKeyAreIncompatible(address: Address, publicKey: Publi
 
 case object AuthIsRequired extends MatcherError(auth, params, notProvided, e"The authentication is required. Please read the documentation")
 
+case object WsConnectionPongTimeout extends MatcherError(webSocket, connectivity, timedOut, e"WebSocket has reached pong timeout")
+
+case object WsConnectionMaxLifetimeExceeded extends MatcherError(webSocket, connectivity, limitReached, e"WebSocket has reached max allowed lifetime")
+
 sealed abstract class Entity(val code: Int)
 object Entity {
   object common  extends Entity(0)
@@ -506,6 +510,7 @@ object Entity {
   object connectivity extends Entity(101)
   object auth         extends Entity(102)
   object params       extends Entity(103)
+  object webSocket    extends Entity(104)
 }
 
 sealed abstract class Class(val code: Int)

--- a/dex/src/test/scala/com/wavesplatform/dex/api/AggregatedOrderBookActorSpec.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/api/AggregatedOrderBookActorSpec.scala
@@ -21,7 +21,7 @@ import com.wavesplatform.dex.domain.bytes.ByteStr
 import com.wavesplatform.dex.domain.order.{Order, OrderType}
 import com.wavesplatform.dex.domain.utils.EitherExt2
 import com.wavesplatform.dex.gen.OrderBookGen
-import com.wavesplatform.dex.market.AggregatedOrderBookActor.{Command, Message, Query}
+import com.wavesplatform.dex.market.AggregatedOrderBookActor.{Message, Query, WsCommand}
 import com.wavesplatform.dex.market.OrderBookActor.MarketStatus
 import com.wavesplatform.dex.market._
 import com.wavesplatform.dex.model._
@@ -148,7 +148,7 @@ class AggregatedOrderBookActorSpec
           val ref       = mk(OrderBook.empty)
           val lastTrade = LastTrade(500L, 10L, OrderType.BUY)
 
-          ref ! Command.ApplyChanges(
+          ref ! WsCommand.ApplyChanges(
             levelChanges = LevelAmounts.empty.copy(
               asks = Map(2000L -> 99L)
             ),
@@ -170,7 +170,7 @@ class AggregatedOrderBookActorSpec
           val ref       = mk(OrderBook.empty)
           val lastTrade = LastTrade(500L, 10L, OrderType.BUY)
 
-          ref ! Command.ApplyChanges(
+          ref ! WsCommand.ApplyChanges(
             levelChanges = LevelAmounts.empty.copy(
               asks = Map(2000L -> 99L)
             ),
@@ -178,13 +178,13 @@ class AggregatedOrderBookActorSpec
             ts = 0L
           )
 
-          ref ! Command.ApplyChanges(
+          ref ! WsCommand.ApplyChanges(
             levelChanges = LevelAmounts.empty,
             lastTrade = Some(lastTrade),
             ts = 1L
           )
 
-          ref ! Command.ApplyChanges(
+          ref ! WsCommand.ApplyChanges(
             levelChanges = LevelAmounts.empty.copy(
               bids = Map(1000L -> 84L)
             ),
@@ -206,7 +206,7 @@ class AggregatedOrderBookActorSpec
       "aggregated snapshot after update" - {
         "once" in {
           val ref = mk(OrderBook.empty)
-          ref ! Command.ApplyChanges(
+          ref ! WsCommand.ApplyChanges(
             levelChanges = LevelAmounts(
               asks = Map(2100L -> 1L, 2000L  -> 99L),
               bids = Map(999L  -> 30L, 1000L -> 50L)
@@ -227,7 +227,7 @@ class AggregatedOrderBookActorSpec
         "multiple times" in {
           val ref = mk(OrderBook.empty)
 
-          ref ! Command.ApplyChanges(
+          ref ! WsCommand.ApplyChanges(
             levelChanges = LevelAmounts(
               asks = Map(2100L -> 1L),
               bids = Map.empty
@@ -236,7 +236,7 @@ class AggregatedOrderBookActorSpec
             ts = 0L
           )
 
-          ref ! Command.ApplyChanges(
+          ref ! WsCommand.ApplyChanges(
             levelChanges = LevelAmounts(
               asks = Map(2000L -> 99L),
               bids = Map.empty
@@ -245,7 +245,7 @@ class AggregatedOrderBookActorSpec
             ts = 1L
           )
 
-          ref ! Command.ApplyChanges(
+          ref ! WsCommand.ApplyChanges(
             levelChanges = LevelAmounts(
               asks = Map.empty,
               bids = Map(999L -> 30L, 1000L -> 50L)
@@ -254,7 +254,7 @@ class AggregatedOrderBookActorSpec
             ts = 2L
           )
 
-          ref ! Command.ApplyChanges(
+          ref ! WsCommand.ApplyChanges(
             levelChanges = LevelAmounts.empty,
             lastTrade = Some(LastTrade(500L, 10L, OrderType.BUY)),
             ts = 3L
@@ -273,7 +273,7 @@ class AggregatedOrderBookActorSpec
       "http response after update" - {
         "once" in {
           val ref = mk(OrderBook.empty)
-          ref ! Command.ApplyChanges(
+          ref ! WsCommand.ApplyChanges(
             levelChanges = LevelAmounts(
               asks = Map(2100L -> 1L, 2000L  -> 99L),
               bids = Map(999L  -> 30L, 1000L -> 50L)
@@ -297,7 +297,7 @@ class AggregatedOrderBookActorSpec
         "multiple times" in {
           val ref = mk(OrderBook.empty)
 
-          ref ! Command.ApplyChanges(
+          ref ! WsCommand.ApplyChanges(
             levelChanges = LevelAmounts(
               asks = Map(2100L -> 1L),
               bids = Map.empty
@@ -306,7 +306,7 @@ class AggregatedOrderBookActorSpec
             ts = 0L
           )
 
-          ref ! Command.ApplyChanges(
+          ref ! WsCommand.ApplyChanges(
             levelChanges = LevelAmounts(
               asks = Map(2000L -> 99L),
               bids = Map.empty
@@ -315,7 +315,7 @@ class AggregatedOrderBookActorSpec
             ts = 1L
           )
 
-          ref ! Command.ApplyChanges(
+          ref ! WsCommand.ApplyChanges(
             levelChanges = LevelAmounts(
               asks = Map.empty,
               bids = Map(999L -> 30L, 1000L -> 50L)
@@ -324,7 +324,7 @@ class AggregatedOrderBookActorSpec
             ts = 2L
           )
 
-          ref ! Command.ApplyChanges(
+          ref ! WsCommand.ApplyChanges(
             levelChanges = LevelAmounts.empty,
             lastTrade = Some(LastTrade(500L, 10L, OrderType.BUY)),
             ts = 3L

--- a/dex/src/test/scala/com/wavesplatform/dex/api/AggregatedOrderBookActorSpec.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/api/AggregatedOrderBookActorSpec.scala
@@ -21,7 +21,7 @@ import com.wavesplatform.dex.domain.bytes.ByteStr
 import com.wavesplatform.dex.domain.order.{Order, OrderType}
 import com.wavesplatform.dex.domain.utils.EitherExt2
 import com.wavesplatform.dex.gen.OrderBookGen
-import com.wavesplatform.dex.market.AggregatedOrderBookActor.{Message, Query, WsCommand}
+import com.wavesplatform.dex.market.AggregatedOrderBookActor.{Message, Query, Command}
 import com.wavesplatform.dex.market.OrderBookActor.MarketStatus
 import com.wavesplatform.dex.market._
 import com.wavesplatform.dex.model._
@@ -148,7 +148,7 @@ class AggregatedOrderBookActorSpec
           val ref       = mk(OrderBook.empty)
           val lastTrade = LastTrade(500L, 10L, OrderType.BUY)
 
-          ref ! WsCommand.ApplyChanges(
+          ref ! Command.ApplyChanges(
             levelChanges = LevelAmounts.empty.copy(
               asks = Map(2000L -> 99L)
             ),
@@ -170,7 +170,7 @@ class AggregatedOrderBookActorSpec
           val ref       = mk(OrderBook.empty)
           val lastTrade = LastTrade(500L, 10L, OrderType.BUY)
 
-          ref ! WsCommand.ApplyChanges(
+          ref ! Command.ApplyChanges(
             levelChanges = LevelAmounts.empty.copy(
               asks = Map(2000L -> 99L)
             ),
@@ -178,13 +178,13 @@ class AggregatedOrderBookActorSpec
             ts = 0L
           )
 
-          ref ! WsCommand.ApplyChanges(
+          ref ! Command.ApplyChanges(
             levelChanges = LevelAmounts.empty,
             lastTrade = Some(lastTrade),
             ts = 1L
           )
 
-          ref ! WsCommand.ApplyChanges(
+          ref ! Command.ApplyChanges(
             levelChanges = LevelAmounts.empty.copy(
               bids = Map(1000L -> 84L)
             ),
@@ -206,7 +206,7 @@ class AggregatedOrderBookActorSpec
       "aggregated snapshot after update" - {
         "once" in {
           val ref = mk(OrderBook.empty)
-          ref ! WsCommand.ApplyChanges(
+          ref ! Command.ApplyChanges(
             levelChanges = LevelAmounts(
               asks = Map(2100L -> 1L, 2000L  -> 99L),
               bids = Map(999L  -> 30L, 1000L -> 50L)
@@ -227,7 +227,7 @@ class AggregatedOrderBookActorSpec
         "multiple times" in {
           val ref = mk(OrderBook.empty)
 
-          ref ! WsCommand.ApplyChanges(
+          ref ! Command.ApplyChanges(
             levelChanges = LevelAmounts(
               asks = Map(2100L -> 1L),
               bids = Map.empty
@@ -236,7 +236,7 @@ class AggregatedOrderBookActorSpec
             ts = 0L
           )
 
-          ref ! WsCommand.ApplyChanges(
+          ref ! Command.ApplyChanges(
             levelChanges = LevelAmounts(
               asks = Map(2000L -> 99L),
               bids = Map.empty
@@ -245,7 +245,7 @@ class AggregatedOrderBookActorSpec
             ts = 1L
           )
 
-          ref ! WsCommand.ApplyChanges(
+          ref ! Command.ApplyChanges(
             levelChanges = LevelAmounts(
               asks = Map.empty,
               bids = Map(999L -> 30L, 1000L -> 50L)
@@ -254,7 +254,7 @@ class AggregatedOrderBookActorSpec
             ts = 2L
           )
 
-          ref ! WsCommand.ApplyChanges(
+          ref ! Command.ApplyChanges(
             levelChanges = LevelAmounts.empty,
             lastTrade = Some(LastTrade(500L, 10L, OrderType.BUY)),
             ts = 3L
@@ -273,7 +273,7 @@ class AggregatedOrderBookActorSpec
       "http response after update" - {
         "once" in {
           val ref = mk(OrderBook.empty)
-          ref ! WsCommand.ApplyChanges(
+          ref ! Command.ApplyChanges(
             levelChanges = LevelAmounts(
               asks = Map(2100L -> 1L, 2000L  -> 99L),
               bids = Map(999L  -> 30L, 1000L -> 50L)
@@ -297,7 +297,7 @@ class AggregatedOrderBookActorSpec
         "multiple times" in {
           val ref = mk(OrderBook.empty)
 
-          ref ! WsCommand.ApplyChanges(
+          ref ! Command.ApplyChanges(
             levelChanges = LevelAmounts(
               asks = Map(2100L -> 1L),
               bids = Map.empty
@@ -306,7 +306,7 @@ class AggregatedOrderBookActorSpec
             ts = 0L
           )
 
-          ref ! WsCommand.ApplyChanges(
+          ref ! Command.ApplyChanges(
             levelChanges = LevelAmounts(
               asks = Map(2000L -> 99L),
               bids = Map.empty
@@ -315,7 +315,7 @@ class AggregatedOrderBookActorSpec
             ts = 1L
           )
 
-          ref ! WsCommand.ApplyChanges(
+          ref ! Command.ApplyChanges(
             levelChanges = LevelAmounts(
               asks = Map.empty,
               bids = Map(999L -> 30L, 1000L -> 50L)
@@ -324,7 +324,7 @@ class AggregatedOrderBookActorSpec
             ts = 2L
           )
 
-          ref ! WsCommand.ApplyChanges(
+          ref ! Command.ApplyChanges(
             levelChanges = LevelAmounts.empty,
             lastTrade = Some(LastTrade(500L, 10L, OrderType.BUY)),
             ts = 3L

--- a/dex/src/test/scala/com/wavesplatform/dex/api/http/OrderBookHttpInfoSpec.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/api/http/OrderBookHttpInfoSpec.scala
@@ -40,7 +40,7 @@ class OrderBookHttpInfoSpec extends AnyFreeSpec with Matchers with SystemTime wi
         val now         = time.getTimestamp()
 
         (1 to 10).foreach { i =>
-          aggOrderBookRef ! AggregatedOrderBookActor.Command.ApplyChanges(
+          aggOrderBookRef ! AggregatedOrderBookActor.WsCommand.ApplyChanges(
             LevelAmounts(
               asks = Map((middlePrice + i) -> i * 2L),
               bids = Map((middlePrice - i) -> i * 3L)

--- a/dex/src/test/scala/com/wavesplatform/dex/api/http/OrderBookHttpInfoSpec.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/api/http/OrderBookHttpInfoSpec.scala
@@ -40,7 +40,7 @@ class OrderBookHttpInfoSpec extends AnyFreeSpec with Matchers with SystemTime wi
         val now         = time.getTimestamp()
 
         (1 to 10).foreach { i =>
-          aggOrderBookRef ! AggregatedOrderBookActor.WsCommand.ApplyChanges(
+          aggOrderBookRef ! AggregatedOrderBookActor.Command.ApplyChanges(
             LevelAmounts(
               asks = Map((middlePrice + i) -> i * 2L),
               bids = Map((middlePrice - i) -> i * 3L)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -104,12 +104,14 @@ object Dependencies {
   private val janino               = "org.codehaus.janino" % "janino" % Version.janino
   private val kamonCore            = kamonModule("core", Version.kamonCore)
   private val wavesProtobufSchemas = ("com.wavesplatform" % "protobuf-schemas" % Version.wavesProtobufSchemas classifier "proto") % "protobuf" // for teamcity
+
   private val wavesJ = "com.wavesplatform" % "wavesj" % Version.wavesJ excludeAll (
     // Conflicts with specified gRPC. This is the problem for waves-integration-it.
     // Also, wavesj doesn't use gRPC, so it is safe.
     ExclusionRule(organization = "io.grpc"),
     ExclusionRule("com.wavesplatform", "protobuf-schemas")
   )
+
   private val toxiProxy     = "org.testcontainers" % "toxiproxy" % Version.testContainersToxiProxy
   private val googleGuava   = "com.google.guava" % "guava" % Version.googleGuava
   private val kafka         = "org.apache.kafka" % "kafka-clients" % Version.kafka
@@ -145,6 +147,7 @@ object Dependencies {
   private val testKit: Seq[ModuleID] = Seq(
     akkaModule("akka-testkit", Version.akka),
     akkaModule("akka-http-testkit", Version.akkaHttp),
+    akkaModule("akka-actor-testkit-typed", Version.akka),
     scalaTest,
     scalaCheck,
     scalaTestPlusCheck,


### PR DESCRIPTION
 * AggregatedOrderBookActor closes all WS connections on PostStop signal
 * ConnectionSource removed, typed ActorRef is used instead
 * TerminationStatus removed, MatcherError is used instead
 * WsConnectionPongTimeout and WsConnectionMaxLifetimeExceeded matcher errors introduced
 * Used typed actor as a recipient of changes in AddressActor
 * ActorsWebSocketInteractionsSpecification rewritten in typed ActorRef style
 * WS connections now have a UUID in names
 * Integration test added