### PR TITLE
DEX-720 Order book settings in public WS API stream

### DIFF
--- a/dex/src/main/scala/com/wavesplatform/dex/Matcher.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/Matcher.scala
@@ -118,7 +118,8 @@ class Matcher(settings: MatcherSettings)(implicit val actorSystem: ActorSystem) 
       matchingRules = matchingRulesCache.getMatchingRules(assetPair, assetDecimals),
       updateCurrentMatchingRules = actualMatchingRule => matchingRulesCache.updateCurrentMatchingRule(assetPair, actualMatchingRule),
       normalizeMatchingRule = denormalizedMatchingRule => denormalizedMatchingRule.normalize(assetPair, assetDecimals),
-      Fee.getMakerTakerFeeByOffset(orderFeeSettingsCache)
+      Fee.getMakerTakerFeeByOffset(orderFeeSettingsCache),
+      settings.orderRestrictions.get(assetPair)
     )
   }
 
@@ -163,7 +164,7 @@ class Matcher(settings: MatcherSettings)(implicit val actorSystem: ActorSystem) 
         matcherPublicKey.toAddress,
         time,
         actualOrderFeeSettings,
-        settings.orderRestrictions,
+        settings.orderRestrictions.get(o.assetPair),
         orderAssetsDescriptions,
         rateCache,
         hasMatcherAccountScript

--- a/dex/src/main/scala/com/wavesplatform/dex/OrderBookWsState.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/OrderBookWsState.scala
@@ -1,39 +1,33 @@
 package com.wavesplatform.dex
 
 import akka.actor.typed.ActorRef
+import cats.syntax.option._
 import com.wavesplatform.dex.AddressWsMutableState.getNextUpdateId
-import com.wavesplatform.dex.api.websockets.{WsLastTrade, WsOrderBook}
+import com.wavesplatform.dex.api.websockets.{WsLastTrade, WsOrderBook, WsOrderBookSettings}
 import com.wavesplatform.dex.domain.model.Denormalization.{denormalizeAmountAndFee, denormalizePrice}
 import com.wavesplatform.dex.domain.model.{Amount, Price}
 import com.wavesplatform.dex.model.{LastTrade, LevelAmounts}
+import monocle.macros.GenLens
 
 import scala.collection.immutable.TreeMap
 
 case class OrderBookWsState(wsConnections: Map[ActorRef[WsOrderBook], Long],
                             changedAsks: Set[Price],
                             changedBids: Set[Price],
-                            lastTrade: Option[LastTrade]) {
+                            lastTrade: Option[LastTrade],
+                            changedTickSize: Option[Double]) {
+
+  private val genLens: GenLens[OrderBookWsState] = GenLens[OrderBookWsState]
 
   def addSubscription(x: ActorRef[WsOrderBook]): OrderBookWsState = copy(wsConnections = wsConnections.updated(x, 0L))
 
   def withoutSubscription(x: ActorRef[Nothing]): OrderBookWsState =
-    if (wsConnections.size == 1) OrderBookWsState(Map.empty, Set.empty, Set.empty, None)
+    if (wsConnections.size == 1) OrderBookWsState(Map.empty, Set.empty, Set.empty, None, None)
     else copy(wsConnections = wsConnections.filterKeys(_ != x))
 
   def hasSubscriptions: Boolean = wsConnections.nonEmpty
 
-  def hasChanges: Boolean = changedAsks.nonEmpty || changedBids.nonEmpty || lastTrade.nonEmpty
-
-  def withLastTrade(x: LastTrade): OrderBookWsState =
-    if (hasSubscriptions) copy(lastTrade = Some(x)) else this
-
-  def withLevelChanges(xs: LevelAmounts): OrderBookWsState =
-    if (hasSubscriptions)
-      copy(
-        changedAsks = changedAsks ++ xs.asks.keySet,
-        changedBids = changedBids ++ xs.bids.keySet,
-      )
-    else this
+  def hasChanges: Boolean = changedAsks.nonEmpty || changedBids.nonEmpty || lastTrade.nonEmpty || changedTickSize.nonEmpty
 
   def denormalized(amountDecimals: Int, priceDecimals: Int, xs: TreeMap[Price, Amount]): TreeMap[Double, Double] = xs.map {
     case (price, amount) =>
@@ -52,14 +46,15 @@ case class OrderBookWsState(wsConnections: Map[ActorRef[WsOrderBook], Long],
               bids: TreeMap[Price, Amount],
               timestamp: Long): OrderBookWsState = copy(
     wsConnections = if (hasChanges) {
-      val changes = WsOrderBook(
-        asks = denormalized(amountDecimals, priceDecimals, take(asks, changedAsks)),
-        bids = denormalized(amountDecimals, priceDecimals, take(bids, changedBids)),
-        lastTrade = lastTrade.map(lastTrade(amountDecimals, priceDecimals, _)),
-        updateId = 0L, // Will be changed below
-        timestamp = timestamp,
-        settings = None
-      )
+      val changes =
+        WsOrderBook(
+          asks = denormalized(amountDecimals, priceDecimals, take(asks, changedAsks)),
+          bids = denormalized(amountDecimals, priceDecimals, take(bids, changedBids)),
+          lastTrade = lastTrade.map(lastTrade(amountDecimals, priceDecimals, _)),
+          updateId = 0L, // Will be changed below
+          timestamp = timestamp,
+          settings = if (changedTickSize.isDefined) WsOrderBookSettings(None, changedTickSize).some else None
+        )
       wsConnections.map {
         case (conn, updateId) =>
           val newUpdateId = getNextUpdateId(updateId)
@@ -69,7 +64,8 @@ case class OrderBookWsState(wsConnections: Map[ActorRef[WsOrderBook], Long],
     } else wsConnections,
     changedAsks = Set.empty,
     changedBids = Set.empty,
-    lastTrade = None
+    lastTrade = None,
+    changedTickSize = None
   )
 
   def take(xs: TreeMap[Price, Amount], levels: Set[Price]): TreeMap[Price, Amount] = {
@@ -81,4 +77,14 @@ case class OrderBookWsState(wsConnections: Map[ActorRef[WsOrderBook], Long],
     }
     r.result()
   }
+
+  def accumulateChanges(lc: LevelAmounts, lt: Option[LastTrade], ts: Option[Double]): OrderBookWsState =
+    if (hasSubscriptions) {
+      (
+        genLens(_.changedAsks).modify(_ ++ lc.asks.keySet) andThen
+          genLens(_.changedBids).modify(_ ++ lc.bids.keySet) andThen
+          genLens(_.lastTrade).modify { if (lt.isEmpty) _ else lt } andThen
+          genLens(_.changedTickSize).modify { if (ts.isEmpty) _ else ts }
+      )(this)
+    } else this
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/OrderBookWsState.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/OrderBookWsState.scala
@@ -57,7 +57,8 @@ case class OrderBookWsState(wsConnections: Map[ActorRef[WsOrderBook], Long],
         bids = denormalized(amountDecimals, priceDecimals, take(bids, changedBids)),
         lastTrade = lastTrade.map(lastTrade(amountDecimals, priceDecimals, _)),
         updateId = 0L, // Will be changed below
-        timestamp = timestamp
+        timestamp = timestamp,
+        settings = None
       )
       wsConnections.map {
         case (conn, updateId) =>

--- a/dex/src/main/scala/com/wavesplatform/dex/api/websockets/WsOrderBookSettings.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/websockets/WsOrderBookSettings.scala
@@ -1,0 +1,40 @@
+package com.wavesplatform.dex.api.websockets
+
+import com.wavesplatform.dex.settings.OrderRestrictionsSettings
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+
+case class WsOrderBookSettings(restrictions: Option[OrderRestrictionsSettings], tickSize: Option[Double])
+
+object WsOrderBookSettings {
+
+  private val amountField = "a"
+  private val priceField  = "p"
+
+  private implicit val doubleFormat: Format[Double] = doubleAsStringFormat
+
+  implicit val orderRestrictionsSettingsFormat: Format[OrderRestrictionsSettings] = Format(
+    fjs = Reads {
+      case JsObject(restrictions) if restrictions.keySet == Set(amountField, priceField) =>
+        def getRestrictions(restricted: String): (Double, Double, Double) = Reads.Tuple3R[Double, Double, Double].reads(restrictions(restricted)).get
+        val (minAmount, stepAmount, maxAmount)                            = getRestrictions(amountField)
+        val (minPrice, stepPrice, maxPrice)                               = getRestrictions(priceField)
+        JsSuccess(OrderRestrictionsSettings(stepAmount, minAmount, maxAmount, stepPrice, minPrice, maxPrice))
+      case x => JsError(JsPath, s"Cannot parse OrderRestrictionsSettings from ${x.getClass.getName}")
+    },
+    tjs = Writes { ors =>
+      Json.obj(
+        amountField -> Json.arr(ors.minAmount, ors.stepAmount, ors.maxAmount),
+        priceField  -> Json.arr(ors.minPrice, ors.stepPrice, ors.maxPrice)
+      )
+    }
+  )
+
+  implicit val format: Format[WsOrderBookSettings] = (
+    (__ \ "r").formatNullable[OrderRestrictionsSettings] and
+      (__ \ "m" \ "t").formatNullable[Double]
+  )(
+    (restrictions, tickSize) => WsOrderBookSettings(restrictions, tickSize),
+    unlift(WsOrderBookSettings.unapply)
+  )
+}

--- a/dex/src/test/scala/com/wavesplatform/dex/api/http/OrderBookHttpInfoSpec.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/api/http/OrderBookHttpInfoSpec.scala
@@ -13,6 +13,7 @@ import com.wavesplatform.dex.domain.bytes.ByteStr
 import com.wavesplatform.dex.domain.order.OrderType
 import com.wavesplatform.dex.market.{AggregatedOrderBookActor, MatcherSpecLike}
 import com.wavesplatform.dex.model.{LastTrade, LevelAmounts, MatcherModel, OrderBook, OrderBookResult}
+import com.wavesplatform.dex.settings.DenormalizedMatchingRule
 import com.wavesplatform.dex.time.SystemTime
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
@@ -135,6 +136,8 @@ object OrderBookHttpInfoSpec {
         pair,
         8,
         8,
+        None,
+        DenormalizedMatchingRule.DefaultTickSize.toDouble,
         AggregatedOrderBookActor.State.fromOrderBook(OrderBook.empty)
       ),
       "aggregated"

--- a/dex/src/test/scala/com/wavesplatform/dex/api/http/OrderBookHttpInfoSpec.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/api/http/OrderBookHttpInfoSpec.scala
@@ -47,6 +47,7 @@ class OrderBookHttpInfoSpec extends AnyFreeSpec with Matchers with SystemTime wi
               bids = Map((middlePrice - i) -> i * 3L)
             ),
             lastTrade = Some(LastTrade(middlePrice, 5, OrderType.SELL)),
+            tickSize = None,
             ts = now + i
           )
         }

--- a/dex/src/test/scala/com/wavesplatform/dex/api/websockets/WebSocketMessagesSerdeSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/api/websockets/WebSocketMessagesSerdeSpecification.scala
@@ -10,6 +10,7 @@ import com.wavesplatform.dex.domain.model.Denormalization
 import com.wavesplatform.dex.domain.order.Order
 import com.wavesplatform.dex.error.ErrorFormatterContext
 import com.wavesplatform.dex.model.{LimitOrder, MarketOrder}
+import com.wavesplatform.dex.settings.OrderRestrictionsSettings
 import com.wavesplatform.dex.{AddressActor, MatcherSpecBase}
 import org.scalacheck.Gen
 import org.scalatest.freespec.AnyFreeSpec
@@ -85,6 +86,28 @@ class WebSocketMessagesSerdeSpecification extends AnyFreeSpec with ScalaCheckDri
   private val amountDecimals = 8
   private val priceDecimals  = 2
 
+  private val orderBookSettingsGen: Gen[WsOrderBookSettings] = {
+
+    def getDenormalizedValueInRange(min: Long, max: Long): Gen[Double] = Gen.choose(min, max).map { BigDecimal(_) / Order.PriceConstant toDouble }
+
+    val restrictionsGen =
+      for {
+        stepAmount <- getDenormalizedValueInRange(1, 10)
+        minAmount  <- getDenormalizedValueInRange(1, 10)
+        maxAmount  <- getDenormalizedValueInRange(1 * Order.PriceConstant, 10 * Order.PriceConstant)
+        stepPrice  <- getDenormalizedValueInRange(1, 10)
+        minPrice   <- getDenormalizedValueInRange(1, 10)
+        maxPrice   <- getDenormalizedValueInRange(1 * Order.PriceConstant, 10 * Order.PriceConstant)
+      } yield OrderRestrictionsSettings(stepAmount, minAmount, maxAmount, stepPrice, minPrice, maxPrice)
+
+    val tickSizeGen = getDenormalizedValueInRange(10, 50)
+
+    for {
+      restrictions <- Gen.option(restrictionsGen)
+      tickSize     <- Gen.option(tickSizeGen)
+    } yield WsOrderBookSettings(restrictions, tickSize)
+  }
+
   private val lastTradeGen: Gen[WsLastTrade] = for {
     price     <- Gen.chooseNum(1, Long.MaxValue)
     amount    <- Gen.chooseNum(1, Long.MaxValue)
@@ -97,12 +120,13 @@ class WebSocketMessagesSerdeSpecification extends AnyFreeSpec with ScalaCheckDri
     )
 
   private val wsOrderBookGen: Gen[WsOrderBook] = for {
-    asks      <- wsSide(askPricesGen)
-    bids      <- wsSide(bidPricesGen)
-    lastTrade <- Gen.oneOf[Option[WsLastTrade]](None, lastTradeGen.map(Option(_)))
-    updateId  <- Gen.choose(0L, Long.MaxValue)
-    ts        <- Gen.choose(0L, Long.MaxValue)
-  } yield WsOrderBook(asks, bids, lastTrade, updateId, ts)
+    asks              <- wsSide(askPricesGen)
+    bids              <- wsSide(bidPricesGen)
+    lastTrade         <- Gen.oneOf[Option[WsLastTrade]](None, lastTradeGen.map(Option(_)))
+    updateId          <- Gen.choose(0L, Long.MaxValue)
+    ts                <- Gen.choose(0L, Long.MaxValue)
+    orderBookSettings <- Gen.option(orderBookSettingsGen)
+  } yield WsOrderBook(asks, bids, lastTrade, updateId, orderBookSettings, ts)
 
   private def wsSide(pricesGen: Gen[Long]): Gen[WsSide] = {
     val itemGen = Gen.zip(pricesGen, amountGen)

--- a/dex/src/test/scala/com/wavesplatform/dex/market/MatcherActorSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/market/MatcherActorSpecification.scala
@@ -429,7 +429,8 @@ class MatcherActorSpecification
             NonEmptyList.one(DenormalizedMatchingRule(0, 0.00000001)),
             _ => {},
             _ => MatchingRule.DefaultRule,
-            _ => makerTakerPartialFee
+            _ => makerTakerPartialFee,
+            None
         ),
         assetDescription
       )

--- a/dex/src/test/scala/com/wavesplatform/dex/market/OrderBookActorSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/market/OrderBookActorSpecification.scala
@@ -90,7 +90,8 @@ class OrderBookActorSpecification
         matchingRules,
         _ => (),
         raw => MatchingRule(raw.startOffset, (raw.tickSize * BigDecimal(10).pow(8)).toLongExact),
-        makerTakerFeeAtOffset
+        makerTakerFeeAtOffset,
+        None
       ) with RestartableActor)
 
     f(pair, orderBookActor, tp)

--- a/dex/src/test/scala/com/wavesplatform/dex/model/OrderValidatorSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/model/OrderValidatorSpecification.scala
@@ -925,7 +925,7 @@ class OrderValidatorSpecification
         MatcherAccount,
         time,
         DynamicSettings.symmetric(matcherFee),
-        matcherSettings.orderRestrictions,
+        matcherSettings.orderRestrictions.get(order.assetPair),
         assetDescriptions,
         rateCache,
         hasMatcherAccountScript = false
@@ -1036,7 +1036,7 @@ class OrderValidatorSpecification
         MatcherAccount.toAddress,
         time,
         orderFeeSettings,
-        orderRestrictions,
+        orderRestrictions.get(order.assetPair),
         assetDescriptions = assetsDescriptions,
         rateCache,
         matcherAccountScript.nonEmpty

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -69,6 +69,8 @@ object Dependencies {
     val influxDb    = "2.17"
 
     val commonsNet = "3.6"
+
+    val monocle = "2.0.4"
   }
 
   private def akkaModule(module: String, version: String): ModuleID  = "com.typesafe.akka"             %% module            % version
@@ -127,6 +129,11 @@ object Dependencies {
   private val jniLevelDb    = "org.ethereum" % "leveldbjni-all" % Version.jniLevelDb
   private val influxDb      = "org.influxdb" % "influxdb-java" % Version.influxDb
   private val commonsNet    = "commons-net" % "commons-net" % Version.commonsNet
+
+  private val monocle: Seq[ModuleID] = Seq(
+    "com.github.julien-truffaut" %% "monocle-core"  % Version.monocle,
+    "com.github.julien-truffaut" %% "monocle-macro" % Version.monocle
+  )
 
   private val silencer: Seq[ModuleID] = Seq(
     compilerPlugin("com.github.ghik" %% "silencer-plugin" % Version.silencer cross CrossVersion.full),
@@ -212,7 +219,7 @@ object Dependencies {
       influxDb,
       commonsNet,
       swaggerUi
-    ) ++ testKit ++ quill ++ silencer
+    ) ++ testKit ++ quill ++ silencer ++ monocle
 
     lazy val dexIt: Seq[ModuleID] = integrationTestKit
 


### PR DESCRIPTION
 * Order book settings are sent in snapshot
   - WsOrderBookSettings introduced
   - Unit and integration tests added
   - Using of OrderRestrictionsSettings in OrderValidator refactored
 * Changes of tick-size are sent to WS API public stream
   - Using lenses for modifying of AggregatedOrderBookActor state
 * Unit and integration tests added