### PR TITLE
DEX-699 Errors during WebSocket connection

### DIFF
--- a/dex/src/main/scala/com/wavesplatform/dex/market/OrderBookActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/market/OrderBookActor.scala
@@ -127,6 +127,7 @@ class OrderBookActor(settings: Settings,
               process(request.timestamp, orderBook.cancelAll(request.timestamp))
               // We don't delete the snapshot, because it could be required after restart
               // snapshotStore ! OrderBookSnapshotStoreActor.Message.Delete(assetPair)
+              aggregatedRef ! AggregatedOrderBookActor.OrderBookRemoved
               context.stop(self)
           }
       }


### PR DESCRIPTION
* WsHandlerActor the closing logic changed, no deadletter messages now;
* AggregatedOrderBookActor - returned a previous way to notify clients about removed order book. The client will not receive a message about a deleted order book when the server is stopping;
* WsPingPongTestSuite: now checks that a client receives WsConnectionMaxLifetimeExceeded and WsConnectionPongTimeout before the connection is closed due to one of this reasons;