### PR TITLE
DEX-726 Order assets in BalanceNotEnough Error

### DIFF
--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/matchers/ItMatchers.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/matchers/ItMatchers.scala
@@ -1,7 +1,11 @@
 package com.wavesplatform.dex.it.matchers
 
+import com.wavesplatform.dex.domain.asset.Asset
+import com.wavesplatform.dex.domain.model.Denormalization
 import com.wavesplatform.dex.it.api.responses.dex.MatcherError
 import org.scalatest.matchers.Matcher
+
+import scala.Ordered._
 
 trait ItMatchers {
 
@@ -10,5 +14,27 @@ trait ItMatchers {
 
   def failWith(errorCode: Int, containsParams: MatcherError.Params): Matcher[Either[MatcherError, Any]] = {
     new FailWith(errorCode, None, containsParams)
+  }
+
+  def failWithBalanceNotEnough(required: Map[Asset, Long] = Map.empty, available: Map[Asset, Long] = Map.empty)(
+      implicit assetDecimalsMap: Map[Asset, Int]): Matcher[Either[MatcherError, Any]] = {
+
+    def stringifyBalances(map: Map[Asset, Long]): String = {
+      map.toList
+        .sortWith { (l, r) =>
+          l._1.compatId < r._1.compatId
+        }
+        .map { case (a, b) => s"${Denormalization.denormalizeAmountAndFee(b, assetDecimalsMap(a))} ${a.toString}" }
+        .mkString(" and ")
+    }
+
+    lazy val requiredStr  = stringifyBalances(required)
+    lazy val availableStr = stringifyBalances(available)
+
+    val errorMsg =
+      if (required.isEmpty) availableStr
+      else s"Not enough tradable balance. The order requires at least $requiredStr on balance, but available are $availableStr"
+
+    failWith(3147270, errorMsg)
   }
 }

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/MarketOrderTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/MarketOrderTestSuite.scala
@@ -382,9 +382,8 @@ class MarketOrderTestSuite extends MatcherSuiteBase {
 
       placeOrders(alice, wavesUsdPair, SELL)(amount -> price)
 
-      dex1.api.tryPlaceMarket(mkOrder(account, wavesUsdPair, BUY, amount, price, fixedFee)) should failWith(
-        3147270, // BalanceNotEnough
-        s"0.003 WAVES and 0.01 ${UsdId.toString}"
+      dex1.api.tryPlaceMarket(mkOrder(account, wavesUsdPair, BUY, amount, price, fixedFee)) should failWithBalanceNotEnough(
+        required = Map(Waves -> fixedFee, usd -> 0.01.usd)
       )
     }
 
@@ -403,10 +402,8 @@ class MarketOrderTestSuite extends MatcherSuiteBase {
 
       placeAndAwaitAtDex { mkOrder(bob, wavesUsdPair, SELL, amount, price, fixedFee, feeAsset = btc, version = 3) }
 
-      dex1.api.tryPlaceMarket(mkOrder(account, wavesUsdPair, BUY, amount, price, fixedFee, feeAsset = btc)) should failWith(
-        3147270,
-        s"0.003 ${BtcId.toString}"
-      )
+      dex1.api.tryPlaceMarket(mkOrder(account, wavesUsdPair, BUY, amount, price, fixedFee, feeAsset = btc)) should failWithBalanceNotEnough(
+        required = Map(btc -> fixedFee, usd -> 0.01.usd))
     }
   }
 
@@ -425,10 +422,7 @@ class MarketOrderTestSuite extends MatcherSuiteBase {
     dex1.api.reservedBalance(carol) should matchTo(Map[Asset, Long](Waves -> 10.waves))
     wavesNode1.api.balance(carol, Waves) shouldBe 10.waves
 
-    dex1.api.tryPlaceMarket(order2) should failWith(
-      3147270,
-      "Not enough tradable balance"
-    )
+    dex1.api.tryPlaceMarket(order2) should failWithBalanceNotEnough()
   }
 
   "Market order should be executed even if sender balance isn't enough to cover order value" in {

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/MarketOrderTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/MarketOrderTestSuite.scala
@@ -384,7 +384,7 @@ class MarketOrderTestSuite extends MatcherSuiteBase {
 
       dex1.api.tryPlaceMarket(mkOrder(account, wavesUsdPair, BUY, amount, price, fixedFee)) should failWith(
         3147270, // BalanceNotEnough
-        s"0.01 ${UsdId.toString} and 0.003 WAVES"
+        s"0.003 WAVES and 0.01 ${UsdId.toString}"
       )
     }
 

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/OrderPercentFeeAmountTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/OrderPercentFeeAmountTestSuite.scala
@@ -131,7 +131,7 @@ abstract class OrderPercentFeeAmountTestSuite(version: Byte) extends OrderFeeBas
           version = version
         )) should failWith(
         3147270,
-        s"Not enough tradable balance. The order requires at least 18 ${UsdId} and 3.75 WAVES on balance, but available are 18 ${UsdId} and 0 WAVES"
+        s"Not enough tradable balance. The order requires at least 3.75 WAVES and 18 ${UsdId} on balance, but available are 0 WAVES and 18 ${UsdId}"
       )
     }
 

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/OrderPercentFeeAmountTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/OrderPercentFeeAmountTestSuite.scala
@@ -19,7 +19,8 @@ class V3OrderPercentFeeAmountTestSuite extends OrderPercentFeeAmountTestSuite(3.
         price,
         minimalFeeWaves,
         usd
-      )) should failWith(9441540) // UnexpectedFeeAsset
+      )
+    ) should failWith(9441540) // UnexpectedFeeAsset
   }
 
   s"sell order should be rejected is fee Asset not equal WAVES when fee asset-type = $assetType" in {
@@ -32,7 +33,8 @@ class V3OrderPercentFeeAmountTestSuite extends OrderPercentFeeAmountTestSuite(3.
         price,
         minimalFeeWaves,
         usd
-      )) should failWith(9441540) // UnexpectedFeeAsset
+      )
+    ) should failWith(9441540) // UnexpectedFeeAsset
   }
 }
 
@@ -129,10 +131,8 @@ abstract class OrderPercentFeeAmountTestSuite(version: Byte) extends OrderFeeBas
           price,
           minimalFeeWaves,
           version = version
-        )) should failWith(
-        3147270,
-        s"Not enough tradable balance. The order requires at least 3.75 WAVES and 18 ${UsdId} on balance, but available are 0 WAVES and 18 ${UsdId}"
-      )
+        )
+      ) should failWithBalanceNotEnough(required = Map(Waves -> 3.75.waves, usd -> 18.usd), available = Map(Waves -> 0.waves, usd -> 18.usd))
     }
 
     s"buy order should be rejected if fee less then minimum possible fee when fee asset-type = $assetType" in {
@@ -145,7 +145,8 @@ abstract class OrderPercentFeeAmountTestSuite(version: Byte) extends OrderFeeBas
           price,
           tooLowFeeWaves,
           version = version
-        )) should failWith(
+        )
+      ) should failWith(
         9441542, // FeeNotEnough
         "Required 2.1 WAVES as fee for this order, but given 2.09 WAVES"
       )
@@ -159,7 +160,8 @@ abstract class OrderPercentFeeAmountTestSuite(version: Byte) extends OrderFeeBas
                 fullyAmountWaves,
                 price,
                 tooLowFeeWaves,
-                version = version)) should failWith(
+                version = version)
+      ) should failWith(
         9441542, // FeeNotEnough
         "Required 2.1 WAVES as fee for this order, but given 2.09 WAVES"
       )

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/OrderPercentFeePriceTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/OrderPercentFeePriceTestSuite.scala
@@ -125,10 +125,8 @@ class OrderPercentFeePriceTestSuite extends OrderFeeBaseTestSuite {
           minimalFee,
           version = version,
           feeAsset = IssuedAsset(UsdId)
-        )) should failWith(
-        3147270,
-        s"Not enough tradable balance. The order requires at least 22.5 ${UsdId} on balance, but available are 18 ${UsdId}"
-      )
+        )
+      ) should failWithBalanceNotEnough(required = Map(usd -> 22.5.usd), available = Map(usd -> 18.usd))
     }
 
     s"buy order should be rejected if fee less then minimum possible fee when fee asset-type = $assetType" in {
@@ -143,7 +141,8 @@ class OrderPercentFeePriceTestSuite extends OrderFeeBaseTestSuite {
             tooLowFee,
             version = version,
             feeAsset = IssuedAsset(UsdId)
-          )) should failWith(9441542, s"Required 2.52 ${UsdId.toString} as fee for this order, but given 2.51 ${UsdId.toString}")
+          )
+        ) should failWith(9441542, s"Required 2.52 ${UsdId.toString} as fee for this order, but given 2.51 ${UsdId.toString}")
     }
 
     s"sell order should be rejected if fee less then minimum possible fee when fee asset-type = $assetType" in {

--- a/dex/src/main/scala/com/wavesplatform/dex/error/MatcherError.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/error/MatcherError.scala
@@ -184,7 +184,7 @@ object BalanceNotEnough {
     input
       .map { case (id, v) => Amount(id, Denormalization.denormalizeAmountAndFee(v, efc.assetDecimals(id))) }
       .toList
-      .sortBy(x => x.asset.toString)
+      .sortBy(x => x.volume)
 }
 
 case class ActiveOrdersLimitReached(maxActiveOrders: Long)

--- a/dex/src/main/scala/com/wavesplatform/dex/error/MatcherError.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/error/MatcherError.scala
@@ -180,11 +180,13 @@ object BalanceNotEnough {
   def apply(required: Map[Asset, Long], actual: Map[Asset, Long])(implicit efc: ErrorFormatterContext): BalanceNotEnough =
     new BalanceNotEnough(mk(required), mk(actual))
 
-  private def mk(input: Map[Asset, Long])(implicit efc: ErrorFormatterContext): List[Amount] =
+  private def mk(input: Map[Asset, Long])(implicit efc: ErrorFormatterContext): List[Amount] = {
+    import Ordered._
     input
       .map { case (id, v) => Amount(id, Denormalization.denormalizeAmountAndFee(v, efc.assetDecimals(id))) }
       .toList
-      .sortBy(x => x.volume)
+      .sortWith((l, r) => l.asset.compatId < r.asset.compatId)
+  }
 }
 
 case class ActiveOrdersLimitReached(maxActiveOrders: Long)


### PR DESCRIPTION
 * BalanceNotEnough error now has determined order of assets
 * failWithBalanceNotEnough matcher introduced
 * Integration tests fixed