### PR TITLE
DEX-733 Address subscription cancelling after JWT expiration

### DIFF
--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/websockets/HasJwt.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/websockets/HasJwt.scala
@@ -10,7 +10,10 @@ import com.wavesplatform.dex.auth.JwtUtils
 import com.wavesplatform.dex.domain.account.KeyPair
 import play.api.libs.json.Json
 
+import scala.concurrent.duration.{FiniteDuration, _}
+
 trait HasJwt extends JwtUtils {
+
   protected val authServiceKeyPair: security.KeyPair = {
     val kpg = KeyPairGenerator.getInstance("RSA")
     kpg.initialize(2048)
@@ -25,5 +28,8 @@ trait HasJwt extends JwtUtils {
   )
 
   protected def mkJwt(payload: JwtPayload): String = mkJwt(authServiceKeyPair, Json.toJsObject(payload))
-  protected def mkJwt(clientKeyPair: KeyPair): String = mkJwt(mkJwtSignedPayload(clientKeyPair))
+
+  protected def mkJwt(clientKeyPair: KeyPair, lifetime: FiniteDuration = 1.hour): String = {
+    mkJwt(mkJwtSignedPayload(clientKeyPair, lifetime = lifetime))
+  }
 }

--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/websockets/HasWebSockets.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/websockets/HasWebSockets.scala
@@ -36,8 +36,8 @@ trait HasWebSockets extends BeforeAndAfterAll with HasJwt with WsConnectionOps w
   protected def mkWsAddressConnection(client: KeyPair,
                                       dex: DexContainer,
                                       keepAlive: Boolean = true,
-                                      connectionLifetime: FiniteDuration = 1.hour): WsConnection = {
-    val jwt        = mkJwt(mkJwtSignedPayload(client, lifetime = connectionLifetime))
+                                      subscriptionLifetime: FiniteDuration = 1.hour): WsConnection = {
+    val jwt        = mkJwt(client, lifetime = subscriptionLifetime)
     val connection = mkWsConnection(dex, keepAlive)
     connection.send(WsAddressSubscribe(client.toAddress, WsAddressSubscribe.defaultAuthType, jwt))
     connection

--- a/dex-it/src/test/scala/com/wavesplatform/it/WsSuiteBase.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/WsSuiteBase.scala
@@ -1,12 +1,16 @@
 package com.wavesplatform.it
 
-import com.wavesplatform.dex.api.websockets.WsServerMessage
+import com.softwaremill.diffx.{Derived, Diff}
+import com.wavesplatform.dex.api.websockets.{WsError, WsServerMessage}
 import com.wavesplatform.dex.it.api.websockets.{HasWebSockets, WsConnection}
 
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.reflect.ClassTag
 
 trait WsSuiteBase extends MatcherSuiteBase with HasWebSockets {
+
+  protected implicit val wsErrorDiff: Diff[WsError] = Derived[Diff[WsError]].ignore[Long](_.timestamp)
+
   final implicit class WsConnectionOps(val self: WsConnection) {
     def receiveAtLeastN[T <: WsServerMessage: ClassTag](n: Int): List[T] = {
       val r = eventually {

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/api/ws/WsConnectionTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/api/ws/WsConnectionTestSuite.scala
@@ -1,7 +1,7 @@
 package com.wavesplatform.it.sync.api.ws
 
 import com.typesafe.config.{Config, ConfigFactory}
-import com.wavesplatform.dex.api.websockets.{WsAddressState, WsAddressSubscribe, WsOrderBook, WsOrderBookSubscribe, WsUnsubscribe}
+import com.wavesplatform.dex.api.websockets._
 import com.wavesplatform.dex.domain.order.OrderType.SELL
 import com.wavesplatform.it.WsSuiteBase
 

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/api/ws/WsOrderBookStreamTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/api/ws/WsOrderBookStreamTestSuite.scala
@@ -78,13 +78,13 @@ class WsOrderBookStreamTestSuite extends WsSuiteBase {
       val wsc = mkWsConnection(dex1)
       wsc.send(WsOrderBookSubscribe(invalidAssetPair, 1))
 
-      val errors = wsc.receiveAtLeastN[WsError](1)
-      errors.head.copy(timestamp = 0L) should matchTo(
+      wsc.receiveAtLeastN[WsError](1).head should matchTo(
         WsError(
-          timestamp = 0L,
+          timestamp = 0L, // ignored
           code = 9440771, // OrderAssetPairReversed
           message = s"The $invalidAssetPair asset pair should be reversed"
-        ))
+        )
+      )
 
       wsc.close()
     }
@@ -403,10 +403,11 @@ class WsOrderBookStreamTestSuite extends WsSuiteBase {
       dex1.api.tryDeleteOrderBook(assetPair)
 
       val expectedMessage = WsError(
-        timestamp = 0L,
+        timestamp = 0L, // ignored
         code = 8388624, // OrderBookStopped
         message = s"The order book for $assetPair is stopped, please contact with the administrator"
       )
+
       wscs.foreach { wsc =>
         wsc.receiveAtLeastN[WsError](1).head.copy(timestamp = 0L) should matchTo(expectedMessage)
         wsc.close()

--- a/dex/src/main/scala/com/wavesplatform/dex/AddressWsMutableState.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/AddressWsMutableState.scala
@@ -29,7 +29,7 @@ case class AddressWsMutableState(activeWsConnections: Map[ActorRef[WsAddressStat
 
   def removeSubscription(subscriber: ActorRef[WsAddressState]): AddressWsMutableState = {
     if (activeWsConnections.size == 1) copy(activeWsConnections = Map.empty).cleanChanges()
-    else copy(activeWsConnections = activeWsConnections.filterKeys(_ != subscriber))
+    else copy(activeWsConnections = activeWsConnections - subscriber)
   }
 
   def putReservedAssets(diff: Set[Asset]): AddressWsMutableState  = copy(changedReservableAssets = changedReservableAssets ++ diff)

--- a/dex/src/main/scala/com/wavesplatform/dex/OrderBookWsState.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/OrderBookWsState.scala
@@ -22,9 +22,9 @@ case class OrderBookWsState(wsConnections: Map[ActorRef[WsOrderBook], Long],
 
   def addSubscription(x: ActorRef[WsOrderBook]): OrderBookWsState = copy(wsConnections = wsConnections.updated(x, 0L))
 
-  def withoutSubscription(x: ActorRef[Nothing]): OrderBookWsState =
+  def withoutSubscription(x: ActorRef[WsOrderBook]): OrderBookWsState =
     if (wsConnections.size == 1) OrderBookWsState(Map.empty, Set.empty, Set.empty, None, None)
-    else copy(wsConnections = wsConnections.filterKeys(_ != x))
+    else copy(wsConnections = wsConnections - x)
 
   def hasSubscriptions: Boolean = wsConnections.nonEmpty
 

--- a/dex/src/main/scala/com/wavesplatform/dex/api/websockets/WsAddressSubscribe.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/websockets/WsAddressSubscribe.scala
@@ -30,7 +30,7 @@ final case class WsAddressSubscribe(key: Address, authType: String, jwt: String)
         )
         .toEither
         .left
-        .map(toMatcherError)
+        .map(toMatcherError(_, key))
       payload <- rawJsonPayload.validate[JwtPayload].asEither.leftMap(_ => error.JwtPayloadBroken)
       _ <- {
         val given = payload.networkByte.head.toByte
@@ -86,9 +86,9 @@ object WsAddressSubscribe {
     )(JwtPayload.apply, unlift(JwtPayload.unapply))
   }
 
-  def toMatcherError(e: Throwable): MatcherError = e match {
+  def toMatcherError(e: Throwable, address: Address): MatcherError = e match {
     case _: JwtLengthException     => error.JwtBroken
-    case _: JwtExpirationException => error.SubscriptionTokenExpired
+    case _: JwtExpirationException => error.SubscriptionTokenExpired(address)
     case _                         => error.JwtCommonError(e.getMessage)
   }
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/error/MatcherError.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/error/MatcherError.scala
@@ -497,7 +497,8 @@ case object JwtPayloadBroken extends MatcherError(token, payload, broken, e"JWT 
 
 case object InvalidJwtPayloadSignature extends MatcherError(token, signature, broken, e"The token payload signature is invalid")
 
-case object SubscriptionTokenExpired extends MatcherError(token, expiration, commonClass, e"The subscription token expired")
+case class SubscriptionTokenExpired(address: Address)
+    extends MatcherError(token, expiration, commonClass, e"The subscription token for address ${'address -> address} expired")
 
 case class TokenNetworkUnexpected(required: Byte, given: Byte)
     extends MatcherError(token, network, unexpected, e"The required network is ${'required -> required}, but given ${'given -> given}")

--- a/dex/src/main/scala/com/wavesplatform/dex/market/AggregatedOrderBookActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/market/AggregatedOrderBookActor.scala
@@ -135,7 +135,7 @@ object AggregatedOrderBookActor {
               Behaviors.stopped
           }
           .receiveSignal {
-            case (_, Terminated(ws)) => default { state.modifyWs(_ withoutSubscription ws) }
+            case (_, Terminated(ws)) => default { state.modifyWs(_ withoutSubscription ws.unsafeUpcast[WsOrderBook]) }
           }
 
       default(init)


### PR DESCRIPTION
Main:

  * Cancelling of the address subscription schedules right after subscribe request;
  * Subscription lifetime can be extended by updated jwt token in new subscribe request;
  * CancelAddressSubscription command in WsHandlerActor introduced;
  * Unit and integration tests added;
  * Minor improvements in AddressWsMutableState and OrderBookWsState

Errors:

  * SubscriptionTokenExpired got address argument

Tests:

  * WsError timestamp is ignored in WsSuiteBase