### PR TITLE
DEX-740 Get snapshot error handling

### DIFF
--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/networking/DexClientFaultToleranceTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/networking/DexClientFaultToleranceTestSuite.scala
@@ -2,6 +2,7 @@ package com.wavesplatform.it.sync.networking
 
 import cats.Id
 import com.typesafe.config.{Config, ConfigFactory}
+import com.wavesplatform.dex.domain.asset.Asset
 import com.wavesplatform.dex.domain.order.OrderType
 import com.wavesplatform.dex.it.api.HasToxiProxy
 import com.wavesplatform.dex.it.api.node.NodeApi
@@ -130,6 +131,7 @@ class DexClientFaultToleranceTestSuite extends MatcherSuiteBase with HasToxiProx
 
     dex1.api.waitForOrderPlacement(order)
     dex1.api.waitForOrderStatus(order, OrderStatus.Accepted)
+    dex1.api.tradableBalance(mkKeyPair("random"), wavesUsdPair) should matchTo { Map.empty[Asset, Long] }
   }
 
   private def usdBalancesShouldBe(wavesNodeApi: NodeApi[Id], expectedAliceBalance: Long, expectedBobBalance: Long): Unit = {

--- a/dex/src/main/scala/com/wavesplatform/dex/market/AggregatedOrderBookActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/market/AggregatedOrderBookActor.scala
@@ -4,7 +4,7 @@ import akka.actor.Cancellable
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.{ActorRef, Behavior, Terminated}
 import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpResponse}
-import com.wavesplatform.dex.api.websockets.{WsError, WsMessage, WsOrderBook}
+import com.wavesplatform.dex.api.websockets.{WsError, WsOrderBook, WsServerMessage}
 import com.wavesplatform.dex.domain.asset.AssetPair
 import com.wavesplatform.dex.domain.model.{Amount, Price}
 import com.wavesplatform.dex.market.OrderBookActor.MarketStatus
@@ -130,7 +130,7 @@ object AggregatedOrderBookActor {
                     client.path.name.asInstanceOf[Any],
                     reason.message.text.asInstanceOf[Any]
                   )
-                  client.unsafeUpcast[WsMessage] ! WsError.from(reason, time.getTimestamp())
+                  client.unsafeUpcast[WsServerMessage] ! WsError.from(reason, time.getTimestamp())
               }
               Behaviors.stopped
           }

--- a/dex/src/test/scala/com/wavesplatform/dex/MatcherSpecBase.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/MatcherSpecBase.scala
@@ -6,6 +6,8 @@ import java.util.concurrent.atomic.AtomicLong
 
 import com.google.common.base.Charsets
 import com.google.common.primitives.{Bytes, Ints}
+import com.softwaremill.diffx.{Derived, Diff}
+import com.wavesplatform.dex.api.websockets.WsError
 import com.wavesplatform.dex.asset.DoubleOps
 import com.wavesplatform.dex.caches.RateCache
 import com.wavesplatform.dex.domain.account.KeyPair
@@ -38,6 +40,8 @@ import scala.concurrent.{Await, Future}
 import scala.util.Random
 
 trait MatcherSpecBase extends SystemTime with DiffMatcherWithImplicits with DoubleOps with WavesFeeConstants { _: Suite =>
+
+  protected implicit val wsErrorDiff: Diff[WsError] = Derived[Diff[WsError]].ignore[Long](_.timestamp)
 
   private val WalletSeed: ByteStr      = ByteStr("Matcher".getBytes("utf-8"))
   private val MatcherSeed: Array[Byte] = wcrypto.secureHash(Bytes.concat(Ints.toByteArray(0), WalletSeed.arr))

--- a/dex/src/test/scala/com/wavesplatform/dex/api/websockets/WsHandlerActorSpec.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/api/websockets/WsHandlerActorSpec.scala
@@ -8,7 +8,6 @@ import akka.actor.typed.ActorRef
 import akka.actor.typed.scaladsl.adapter._
 import akka.testkit.TestProbe
 import cats.syntax.either._
-import com.softwaremill.diffx.{Derived, Diff}
 import com.wavesplatform.dex._
 import com.wavesplatform.dex.api.websockets.actors.WsHandlerActor
 import com.wavesplatform.dex.api.websockets.actors.WsHandlerActor.Command.ProcessClientMessage
@@ -29,8 +28,7 @@ class WsHandlerActorSpec extends AnyFreeSpecLike with Matchers with MatcherSpecB
 
   private val testKit = ActorTestKit()
 
-  private implicit val ec                         = testKit.system.executionContext
-  private implicit val wsErrorDiff: Diff[WsError] = Derived[Diff[WsError]].ignore[Long](_.timestamp)
+  private implicit val ec = testKit.system.executionContext
 
   private val issuedAsset   = IssuedAsset(ByteStr("issuedAsset".getBytes(StandardCharsets.UTF_8)))
   private val assetPair     = AssetPair(issuedAsset, Waves)


### PR DESCRIPTION
 Main:

  * SpendableBalancesActor.Reply.GetSnapshot contains Either
  * SpendableBalancesActor handles errors during snapshot obtaining from Waves Node
  * AddressActor sends WsError with WavesNodeConnectionBroken error to all pending subscriptions, then cancels them
  * Unit test added
  * AddressWsMutableState: connections renamed to subscriptions

 Tests:

  * wsErrorDiff (ignored timestamp in WsError) moved to MatcherSpecBase