### PR TITLE
DEX-735 WS subscriptions limits

### DIFF
--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/api/ws/WsConnectionTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/api/ws/WsConnectionTestSuite.scala
@@ -5,6 +5,9 @@ import com.wavesplatform.dex.api.websockets._
 import com.wavesplatform.dex.domain.order.OrderType.SELL
 import com.wavesplatform.it.WsSuiteBase
 
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
+
 class WsConnectionTestSuite extends WsSuiteBase {
 
   override protected val dexInitialSuiteConfig: Config = ConfigFactory
@@ -46,5 +49,12 @@ class WsConnectionTestSuite extends WsSuiteBase {
     wsc.receiveNoMessagesOf[WsAddressState]()
 
     wsc.close()
+  }
+
+  "Matcher should handle many connections simultaneously" in {
+    Await.result(Future.traverse((1 to 200).toList)(_ => Future(mkWsConnection(dex1))), 25.seconds).foreach { wsc =>
+      wsc.isClosed shouldBe false
+      wsc.close()
+    }
   }
 }

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/api/ws/WsOrderBookStreamTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/api/ws/WsOrderBookStreamTestSuite.scala
@@ -16,8 +16,6 @@ import com.wavesplatform.dex.settings.{DenormalizedMatchingRule, OrderRestrictio
 import com.wavesplatform.it.WsSuiteBase
 
 import scala.collection.immutable.TreeMap
-import scala.concurrent.duration._
-import scala.concurrent.{Await, Future}
 
 class WsOrderBookStreamTestSuite extends WsSuiteBase {
 
@@ -378,18 +376,6 @@ class WsOrderBookStreamTestSuite extends WsSuiteBase {
       wsc.close()
     }
 
-    "handle many connections simultaneously" in {
-      val wscs = Await.result(
-        Future.traverse((1 to 200).toList)(_ => Future(mkWsConnection(dex1))),
-        25.seconds
-      )
-
-      wscs.foreach { wsc =>
-        wsc.isClosed shouldBe false
-        wsc.close()
-      }
-    }
-
     "close connections when order book is deleted" in {
       val seller                          = mkAccountWithBalance(100.waves -> Waves)
       val IssueResults(issueTx, _, asset) = mkIssueExtended(seller, "cJIoHoxpeH", 1000.asset8)
@@ -416,7 +402,7 @@ class WsOrderBookStreamTestSuite extends WsSuiteBase {
       }
     }
 
-    "close old subscriptions when max subscriptions number limit has reached" in {
+    "close old subscriptions when order book subscriptions limit has been reached" in {
       Seq(
         mkOrderDP(alice, wavesUsdPair, SELL, 1.waves, 1.0),
         mkOrderDP(alice, wavesBtcPair, SELL, 1.waves, 0.00011119),

--- a/dex/src/main/resources/application.conf
+++ b/dex/src/main/resources/application.conf
@@ -501,7 +501,7 @@ waves.dex {
         max-order-book-number = 10
 
         # Max number of subscriptions to addresses changes
-        max-address-number = 1
+        max-address-number = 10
       }
     }
   }

--- a/dex/src/main/resources/application.conf
+++ b/dex/src/main/resources/application.conf
@@ -495,6 +495,14 @@ waves.dex {
       # A public key to validate JWT. The can be obtained from auth services
       jwt-public-key = """-----BEGIN PUBLIC KEY-----
 -----END PUBLIC KEY-----"""
+
+      subscriptions {
+        # Max number of subscriptions to order books changes
+        max-order-book-number = 10
+
+        # Max number of subscriptions to addresses changes
+        max-address-number = 1
+      }
     }
   }
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/api/websockets/actors/WsHandlerActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/websockets/actors/WsHandlerActor.scala
@@ -6,11 +6,12 @@ import akka.actor.typed.{ActorRef, Behavior}
 import akka.{actor => classic}
 import cats.syntax.option._
 import com.wavesplatform.dex.api.websockets._
-import com.wavesplatform.dex.api.websockets.actors.WsHandlerActor.Command.{AssetPairValidated, CancelAddressSubscription}
+import com.wavesplatform.dex.api.websockets.actors.WsHandlerActor.Command.CancelAddressSubscription
 import com.wavesplatform.dex.domain.account.{Address, AddressScheme}
 import com.wavesplatform.dex.domain.asset.AssetPair
 import com.wavesplatform.dex.error.{MatcherError, SubscriptionsLimitReached, WsConnectionMaxLifetimeExceeded, WsConnectionPongTimeout}
 import com.wavesplatform.dex.market.{AggregatedOrderBookActor, MatcherActor}
+import com.wavesplatform.dex.settings.SubscriptionsSettings
 import com.wavesplatform.dex.time.Time
 import com.wavesplatform.dex.{AddressActor, AddressDirectory, AssetPairBuilder, error}
 import shapeless.{Inl, Inr}
@@ -28,16 +29,17 @@ object WsHandlerActor {
     case class ProcessClientMessage(wsMessage: WsClientMessage) extends Command
     case class ForwardClientError(error: MatcherError)          extends Command
     case class CloseConnection(reason: MatcherError)            extends Command
-    case class CancelAddressSubscription(address: Address)      extends Command
 
-    private[WsHandlerActor] case class AssetPairValidated(assetPair: AssetPair) extends Command
-    private[WsHandlerActor] case object SendPing                                extends Command
+    private[WsHandlerActor] case class CancelAddressSubscription(address: Address) extends Command
+    private[WsHandlerActor] case object SendPing                                   extends Command
+  }
+
+  sealed trait Event extends Message
+  object Event {
+    private[WsHandlerActor] case class AssetPairValidated(assetPair: AssetPair) extends Event
   }
 
   case class Completed(completionStatus: Either[Throwable, Unit]) extends Message // Could be an event in the future
-
-  final case class SubscriptionsSettings(maxOrderBookNumber: Int, maxAddressNumber: Int)
-  object SubscriptionsSettings { val default: SubscriptionsSettings = SubscriptionsSettings(10, 1) }
 
   final case class Settings(maxConnectionLifetime: FiniteDuration,
                             pingInterval: FiniteDuration,
@@ -53,6 +55,7 @@ object WsHandlerActor {
             addressRef: classic.ActorRef): Behavior[Message] =
     Behaviors.setup[Message] { context =>
       import context.executionContext
+      import settings.subscriptions._
 
       context.setLoggerName(s"WsHandlerActor[c=${clientRef.path.name}]")
 
@@ -87,7 +90,7 @@ object WsHandlerActor {
                     pongTimeout: Cancellable,
                     nextPing: Cancellable,
                     orderBookSubscriptions: Queue[AssetPair],
-                    addressSubscriptions: Map[Address, Cancellable]): Behavior[Message] = {
+                    addressSubscriptions: Queue[(Address, Cancellable)]): Behavior[Message] = {
         Behaviors
           .receiveMessage[Message] {
 
@@ -124,7 +127,7 @@ object WsHandlerActor {
                   else if (!orderBookSubscriptions.contains(subscribe.key)) {
                     assetPairBuilder.validateAssetPair(subscribe.key).value.onComplete {
                       case Success(Left(e))  => clientRef ! WsError.from(e, time.getTimestamp())
-                      case Success(Right(_)) => context.self ! AssetPairValidated(subscribe.key)
+                      case Success(Right(_)) => context.self ! Event.AssetPairValidated(subscribe.key)
                       case Failure(e) =>
                         context.log.warn(s"An error during validation the asset pair ${subscribe.key}", e)
                         clientRef ! WsError.from(error.WavesNodeConnectionBroken, time.getTimestamp())
@@ -143,19 +146,38 @@ object WsHandlerActor {
                       Behaviors.same
                     case Right(jwtPayload) =>
                       val subscriptionLifetime = (jwtPayload.activeTokenExpirationInSeconds * 1000 - time.correctedTime).millis
+                      val expiration           = scheduleOnce(subscriptionLifetime, CancelAddressSubscription(address))
 
                       addressSubscriptions
-                        .get(subscribe.key)
+                        .find(_._1 == subscribe.key)
                         .fold {
+
                           addressRef ! AddressDirectory.Envelope(subscribe.key, AddressActor.WsCommand.AddWsSubscription(clientRef))
                           context.log.debug(s"WsAddressSubscribe(k=$address, t=$authType) is successful, will expire in $subscriptionLifetime")
-                        } { existedExp =>
-                          existedExp.cancel()
-                          context.log.debug(s"WsAddressSubscribe(k=$address, t=$authType) updated, will expire in $subscriptionLifetime")
-                        }
 
-                      val expiration = scheduleOnce(subscriptionLifetime, CancelAddressSubscription(address))
-                      awaitPong(maybeExpectedPong, pongTimeout, nextPing, orderBookSubscriptions, addressSubscriptions + (address -> expiration))
+                          if (addressSubscriptions.lengthCompare(maxAddressNumber) == 0) {
+                            // safe since maxAddressNumber > 0
+                            val ((evictedSubscription, evictedExpiration), remainingSubscriptions) = addressSubscriptions.dequeue
+                            val newAddressSubscriptions                                            = remainingSubscriptions enqueue address -> expiration
+                            evictedExpiration.cancel()
+                            unsubscribeAddress(evictedSubscription)
+                            clientRef ! WsError.from(SubscriptionsLimitReached(maxAddressNumber, evictedSubscription.toString), time.correctedTime())
+                            awaitPong(maybeExpectedPong, pongTimeout, nextPing, orderBookSubscriptions, newAddressSubscriptions)
+                          } else
+                            awaitPong(maybeExpectedPong,
+                                      pongTimeout,
+                                      nextPing,
+                                      orderBookSubscriptions,
+                                      addressSubscriptions enqueue address -> expiration)
+                        } {
+                          case (_, existedExpiration) =>
+                            existedExpiration.cancel()
+                            context.log.debug(s"WsAddressSubscribe(k=$address, t=$authType) updated, will expire in $subscriptionLifetime")
+                            val newAddressSubscriptions = addressSubscriptions.foldLeft(Queue.empty[(Address, Cancellable)]) {
+                              case (result, (a, e)) => result.enqueue { a -> (if (a == address) expiration else e) }
+                            }
+                            awaitPong(maybeExpectedPong, pongTimeout, nextPing, orderBookSubscriptions, newAddressSubscriptions)
+                        }
                   }
 
                 case unsubscribeRequest: WsUnsubscribe =>
@@ -167,21 +189,22 @@ object WsHandlerActor {
                       }
 
                     case Inr(Inl(address)) =>
-                      addressSubscriptions.get(address).fold[Behavior[Message]](Behaviors.same) { expiration =>
-                        expiration.cancel()
-                        unsubscribeAddress(address)
-                        awaitPong(maybeExpectedPong, pongTimeout, nextPing, orderBookSubscriptions, addressSubscriptions - address)
+                      addressSubscriptions.find(_._1 == address).fold[Behavior[Message]](Behaviors.same) {
+                        case (_, expiration) =>
+                          expiration.cancel()
+                          unsubscribeAddress(address)
+                          val newAddressSubscriptions = addressSubscriptions.filterNot(_._1 == address)
+                          awaitPong(maybeExpectedPong, pongTimeout, nextPing, orderBookSubscriptions, newAddressSubscriptions)
                       }
                     case Inr(Inr(_)) => Behaviors.same
                   }
               }
 
-            case Command.AssetPairValidated(assetPair) =>
-              import settings.subscriptions._
-
+            case Event.AssetPairValidated(assetPair) =>
               matcherRef ! MatcherActor.AggregatedOrderBookEnvelope(assetPair, AggregatedOrderBookActor.Command.AddWsSubscription(clientRef))
 
               if (orderBookSubscriptions.lengthCompare(maxOrderBookNumber) == 0) {
+                // safe since maxOrderBookNumber > 0
                 val (evictedSubscription, remainingSubscriptions) = orderBookSubscriptions.dequeue
                 val newOrderBookSubscriptions                     = remainingSubscriptions enqueue assetPair
                 unsubscribeOrderBook(evictedSubscription)
@@ -192,7 +215,8 @@ object WsHandlerActor {
             case Command.CancelAddressSubscription(address) =>
               clientRef ! WsError.from(error.SubscriptionTokenExpired(address), time.correctedTime())
               unsubscribeAddress(address)
-              awaitPong(maybeExpectedPong, pongTimeout, nextPing, orderBookSubscriptions, addressSubscriptions - address)
+              val newAddressSubscriptions = addressSubscriptions.filterNot(_._1 == address)
+              awaitPong(maybeExpectedPong, pongTimeout, nextPing, orderBookSubscriptions, newAddressSubscriptions)
 
             case command: Command.CloseConnection =>
               context.log.trace("Got CloseConnection: {}", command.reason.message.text)
@@ -220,7 +244,7 @@ object WsHandlerActor {
         pongTimeout = Cancellable.alreadyCancelled,
         nextPing = Cancellable.alreadyCancelled,
         orderBookSubscriptions = Queue.empty,
-        addressSubscriptions = Map.empty
+        addressSubscriptions = Queue.empty
       )
     }
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/error/MatcherError.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/error/MatcherError.scala
@@ -503,6 +503,14 @@ case class SubscriptionTokenExpired(address: Address)
 case class TokenNetworkUnexpected(required: Byte, given: Byte)
     extends MatcherError(token, network, unexpected, e"The required network is ${'required -> required}, but given ${'given -> given}")
 
+case class SubscriptionsLimitReached(limit: Int, id: String)
+    extends MatcherError(
+      webSocket,
+      subscription,
+      limitReached,
+      e"The limit of ${'limit -> limit} subscriptions of this type was reached. The subscription of ${'id -> id} was stopped"
+    )
+
 sealed abstract class Entity(val code: Int)
 object Entity {
   object common  extends Entity(0)
@@ -540,6 +548,7 @@ object Entity {
   object webSocket    extends Entity(104)
   object token        extends Entity(105)
   object payload      extends Entity(106)
+  object subscription extends Entity(107)
 }
 
 sealed abstract class Class(val code: Int)

--- a/dex/src/main/scala/com/wavesplatform/dex/settings/MatcherSettings.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/settings/MatcherSettings.scala
@@ -83,6 +83,9 @@ object MatcherSettings {
   implicit val chosenCase: NameMapper                    = net.ceedubs.ficus.readers.namemappers.implicits.hyphenCase
   implicit val valueReader: ValueReader[MatcherSettings] = (cfg, path) => fromConfig(cfg getConfig path)
 
+  implicit val subscriptionsSettingsReader: ValueReader[SubscriptionsSettings] =
+    com.wavesplatform.dex.settings.SubscriptionsSettings.subscriptionSettingsReader
+
   private def unsafeParseAsset(x: String): Asset = {
     AssetPair.extractAsset(x).getOrElse(throw new IllegalArgumentException(s"Can't parse '$x' as asset"))
   }

--- a/dex/src/main/scala/com/wavesplatform/dex/settings/SubscriptionsSettings.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/settings/SubscriptionsSettings.scala
@@ -1,0 +1,22 @@
+package com.wavesplatform.dex.settings
+
+import cats.syntax.apply._
+import com.wavesplatform.dex.settings.utils.ConfigSettingsValidator
+import com.wavesplatform.dex.settings.utils.ConfigSettingsValidator._
+import net.ceedubs.ficus.Ficus._
+import net.ceedubs.ficus.readers.ValueReader
+
+final case class SubscriptionsSettings(maxOrderBookNumber: Int, maxAddressNumber: Int)
+
+object SubscriptionsSettings {
+
+  val default: SubscriptionsSettings = SubscriptionsSettings(10, 10)
+
+  implicit val subscriptionSettingsReader: ValueReader[SubscriptionsSettings] = { (cfg, path) =>
+    val cfgValidator = ConfigSettingsValidator(cfg)
+    (
+      cfgValidator.validateByPredicate[Int](s"$path.max-order-book-number")(_ > 1, "max order book number should be > 1"),
+      cfgValidator.validateByPredicate[Int](s"$path.max-address-number")(_ > 1, "max address number should be > 1"),
+    ) mapN SubscriptionsSettings.apply getValueOrThrowErrors
+  }
+}

--- a/dex/src/test/scala/com/wavesplatform/dex/settings/BaseSettingsSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/settings/BaseSettingsSpecification.scala
@@ -58,11 +58,20 @@ class BaseSettingsSpecification extends AnyFlatSpec {
        |matching-rules = {}
      """.stripMargin
 
+  val correctSubscriptionsSettingsStr: String =
+    s"""
+       |subscriptions {
+       |  max-order-book-number = 20
+       |  max-address-number = 20
+       |}
+       """.stripMargin
+
   def configWithSettings(orderFeeStr: String = correctOrderFeeStr,
                          deviationsStr: String = correctDeviationsStr,
                          allowedAssetPairsStr: String = correctAllowedAssetPairsStr,
                          orderRestrictionsStr: String = correctOrderRestrictionsStr,
-                         matchingRulesStr: String = correctMatchingRulesStr): Config = {
+                         matchingRulesStr: String = correctMatchingRulesStr,
+                         subscriptionsSettings: String = correctSubscriptionsSettingsStr): Config = {
     val configStr =
       s"""waves {
          |  directory = /waves
@@ -167,6 +176,7 @@ class BaseSettingsSpecification extends AnyFlatSpec {
          |        jwt-public-key = \"\"\"foo
          |bar
          |baz\"\"\"
+         |        $subscriptionsSettings
          |      }
          |    }
          |    address-actor {

--- a/dex/src/test/scala/com/wavesplatform/dex/settings/MatcherSettingsSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/settings/MatcherSettingsSpecification.scala
@@ -5,6 +5,7 @@ import com.typesafe.config.Config
 import com.wavesplatform.dex.AddressActor
 import com.wavesplatform.dex.api.http.OrderBookHttpInfo
 import com.wavesplatform.dex.api.websockets.actors.WsHandlerActor
+import com.wavesplatform.dex.api.websockets.actors.WsHandlerActor.SubscriptionsSettings
 import com.wavesplatform.dex.db.{AccountStorage, OrderDB}
 import com.wavesplatform.dex.domain.asset.Asset.{IssuedAsset, Waves}
 import com.wavesplatform.dex.domain.asset.AssetPair
@@ -98,7 +99,8 @@ class MatcherSettingsSpecification extends BaseSettingsSpecification with Matche
 bar
 baz"""
     settings.webSocketSettings should matchTo(
-      WebSocketSettings(100.milliseconds, WsHandlerActor.Settings(20.hours, 11.seconds, 31.seconds, expectedJwtPublicKey))
+      WebSocketSettings(100.milliseconds,
+                        WsHandlerActor.Settings(20.hours, 11.seconds, 31.seconds, expectedJwtPublicKey, SubscriptionsSettings.default))
     )
     settings.addressActorSettings should matchTo(AddressActor.Settings(100.milliseconds, 18.seconds, 400))
   }

--- a/dex/src/test/scala/com/wavesplatform/dex/settings/MatcherSettingsSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/settings/MatcherSettingsSpecification.scala
@@ -5,7 +5,6 @@ import com.typesafe.config.Config
 import com.wavesplatform.dex.AddressActor
 import com.wavesplatform.dex.api.http.OrderBookHttpInfo
 import com.wavesplatform.dex.api.websockets.actors.WsHandlerActor
-import com.wavesplatform.dex.api.websockets.actors.WsHandlerActor.SubscriptionsSettings
 import com.wavesplatform.dex.db.{AccountStorage, OrderDB}
 import com.wavesplatform.dex.domain.asset.Asset.{IssuedAsset, Waves}
 import com.wavesplatform.dex.domain.asset.AssetPair
@@ -100,7 +99,7 @@ bar
 baz"""
     settings.webSocketSettings should matchTo(
       WebSocketSettings(100.milliseconds,
-                        WsHandlerActor.Settings(20.hours, 11.seconds, 31.seconds, expectedJwtPublicKey, SubscriptionsSettings.default))
+                        WsHandlerActor.Settings(20.hours, 11.seconds, 31.seconds, expectedJwtPublicKey, SubscriptionsSettings(20, 20)))
     )
     settings.addressActorSettings should matchTo(AddressActor.Settings(100.milliseconds, 18.seconds, 400))
   }
@@ -467,5 +466,21 @@ baz"""
       getSettingByConfig(configStr(incorrectRulesOrder(100, 88))) should produce(
         "Invalid setting matching-rules value: Rules should be ordered by offset, but they are: 100, 88")
     }
+  }
+
+  "Subscriptions settings" should "be validated" in {
+
+    val invalidSubscriptionsSettings =
+      s"""
+         | subscriptions {
+         |   max-order-book-number = 0
+         |   max-address-number = 1
+         | }
+         """.stripMargin
+
+    getSettingByConfig(configWithSettings(subscriptionsSettings = invalidSubscriptionsSettings)) should produce(
+      "Invalid setting web-sockets.web-socket-handler.subscriptions.max-order-book-number value: 0 (max order book number should be > 1), " +
+        "Invalid setting web-sockets.web-socket-handler.subscriptions.max-address-number value: 1 (max address number should be > 1)"
+    )
   }
 }


### PR DESCRIPTION
 Main:
  * Order book and address subscriptions are limited
  * Multiple subscriptions for one order book don't have effect
  * SubscriptionsSettings extracted in a separate file, additional validation added
  * Unit and integration test added

 Errors:
  * SubscriptionsLimitReached error introduced
  * subsciption entity introduced

Tests:
  * Test of multiple WS API connections moved to WsConnectionTestSuite

 Miscellaneous:
  * AssetPairValidated in WsHandlerActor is Event now
  * Default address and order book subscriptions limit = 10