### PR TITLE
DEX-731 WS connection ID

### DIFF
--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/websockets/WsConnectionOps.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/websockets/WsConnectionOps.scala
@@ -6,15 +6,12 @@ import com.wavesplatform.dex.domain.asset.Asset
 import scala.reflect.ClassTag
 
 trait WsConnectionOps {
+
   final implicit class Ops(self: WsConnection) {
-    def collectMessages[T <: WsServerMessage: ClassTag]: List[T] = self.messages.collect {
-      case x: T => x
-    }
-
-    def pings: List[WsPingOrPong] = collectMessages[WsPingOrPong]
-
-    def addressStateChanges: List[WsAddressState]    = collectMessages[WsAddressState]
-    def balanceChanges: List[Map[Asset, WsBalances]] = addressStateChanges.map(_.balances).filter(_.nonEmpty)
-    def orderChanges: List[WsOrder]                  = addressStateChanges.flatMap(_.orders)
+    def collectMessages[T <: WsServerMessage: ClassTag]: List[T] = self.messages.collect { case x: T => x }
+    def pings: List[WsPingOrPong]                                = collectMessages[WsPingOrPong]
+    def addressStateChanges: List[WsAddressState]                = collectMessages[WsAddressState]
+    def balanceChanges: List[Map[Asset, WsBalances]]             = addressStateChanges.map(_.balances).filter(_.nonEmpty)
+    def orderChanges: List[WsOrder]                              = addressStateChanges.flatMap(_.orders)
   }
 }

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/api/ws/WsPingPongTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/api/ws/WsPingPongTestSuite.scala
@@ -34,10 +34,10 @@ class WsPingPongTestSuite extends WsSuiteBase {
       val wsac = mkWsAddressConnection(alice, dex1)
       wsac.isClosed shouldBe false
 
-      Thread.sleep(maxConnectionLifetime - 0.1.second)
+      Thread.sleep(maxConnectionLifetime - 0.2.second)
       wsac.isClosed shouldBe false
 
-      Thread.sleep(0.1.second)
+      Thread.sleep(0.2.second)
       eventually {
         wsac.pings.size should be >= 5
         wsac.isClosed shouldBe true
@@ -115,14 +115,14 @@ class WsPingPongTestSuite extends WsSuiteBase {
       wsac1.send(wsac2.pings.head) // send correct pong but from another connection
       wsac2.send(wsac1.pings.head) // send correct pong but from another connection
 
-      Thread.sleep(pongTimeout - 0.2.second)
+      Thread.sleep(pongTimeout - 0.3.second)
 
       Seq(wsac1, wsac2).foreach { conn =>
         conn.pings should have size 3
         conn.isClosed shouldBe false
       }
 
-      Thread.sleep(0.1.second)
+      Thread.sleep(0.3.second)
       eventually {
         Seq(wsac1, wsac2).foreach { conn =>
           conn.pings.size should (be >= 3 and be <= 4)

--- a/dex/src/main/scala/com/wavesplatform/dex/api/websockets/WsAddressState.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/websockets/WsAddressState.scala
@@ -19,7 +19,7 @@ object WsAddressState {
 
   implicit val balancesMapFormat: Format[Map[Asset, WsBalances]] = Format(
     { // TODO use reads for Map[Asset, T]!
-      case JsObject(ab) => JsSuccess(ab.toMap.map { case (a, b) => AssetPair.extractAsset(a).get -> WsBalances.format.reads(b).get })
+      case JsObject(ab) => JsSuccess(ab.toMap.map { case (a, b) => AssetPair.extractAsset(a).get -> WsBalances.wsBalancesFormat.reads(b).get })
       case _            => JsError("Cannot parse asset balances map!")
     }, { balances =>
       Json.obj(
@@ -30,7 +30,7 @@ object WsAddressState {
     }
   )
 
-  implicit val format: Format[WsAddressState] = (
+  implicit val wsAddressStateFormat: Format[WsAddressState] = (
     (__ \ "T").format[String] and
       (__ \ "_").format[Long] and
       (__ \ "U").format[Long] and

--- a/dex/src/main/scala/com/wavesplatform/dex/api/websockets/WsAddressSubscribe.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/websockets/WsAddressSubscribe.scala
@@ -73,7 +73,7 @@ object WsAddressSubscribe {
   }
 
   object JwtPayload {
-    val toSignPrefix = Array[Byte](-1, -1, -1, 1)
+    val toSignPrefix: Array[Byte] = Array[Byte](-1, -1, -1, 1)
 
     implicit val jwtPayloadFormat: OFormat[JwtPayload] = (
       (__ \ "sig").format[ByteStr] and

--- a/dex/src/main/scala/com/wavesplatform/dex/api/websockets/WsBalances.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/websockets/WsBalances.scala
@@ -14,5 +14,5 @@ object WsBalances {
     Writes.Tuple2W[Double, Double](doubleAsStringFormat, doubleAsStringFormat).contramap(wsb => wsb.tradable -> wsb.reserved)
   }
 
-  implicit val format: Format[WsBalances] = Format(reads, writes)
+  implicit val wsBalancesFormat: Format[WsBalances] = Format(reads, writes)
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/api/websockets/WsInitial.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/websockets/WsInitial.scala
@@ -1,0 +1,25 @@
+package com.wavesplatform.dex.api.websockets
+
+import cats.syntax.option._
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{Format, _}
+
+case class WsInitial(connectionId: String, timestamp: Long) extends WsServerMessage {
+  override def tpe: String = WsInitial.tpe
+}
+
+object WsInitial {
+
+  val tpe = "i"
+
+  def wsUnapply(arg: WsInitial): Option[(String, Long, String)] = (arg.tpe, arg.timestamp, arg.connectionId).some
+
+  implicit val wsInitialFormat: Format[WsInitial] = (
+    (__ \ "T").format[String] and
+      (__ \ "_").format[Long] and
+      (__ \ "i").format[String]
+  )(
+    (_, timestamp, connectionId) => WsInitial(connectionId, timestamp),
+    unlift(WsInitial.wsUnapply)
+  )
+}

--- a/dex/src/main/scala/com/wavesplatform/dex/api/websockets/WsOrder.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/websockets/WsOrder.scala
@@ -87,7 +87,7 @@ object WsOrder {
     }
   )
 
-  implicit val format: Format[WsOrder] =
+  implicit val wsOrderFormat: Format[WsOrder] =
     (
       (__ \ "i").format[Order.Id] and                               // id
         (__ \ "t").formatNullable[Long] and                         // timestamp

--- a/dex/src/main/scala/com/wavesplatform/dex/api/websockets/WsOrderBookSettings.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/websockets/WsOrderBookSettings.scala
@@ -30,7 +30,7 @@ object WsOrderBookSettings {
     }
   )
 
-  implicit val format: Format[WsOrderBookSettings] = (
+  implicit val wsOrderBookSettingsFormat: Format[WsOrderBookSettings] = (
     (__ \ "r").formatNullable[OrderRestrictionsSettings] and
       (__ \ "m" \ "t").formatNullable[Double]
   )(

--- a/dex/src/main/scala/com/wavesplatform/dex/api/websockets/WsServerMessage.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/websockets/WsServerMessage.scala
@@ -2,12 +2,15 @@ package com.wavesplatform.dex.api.websockets
 
 import play.api.libs.json._
 
-trait WsServerMessage extends WsMessage
+trait WsServerMessage extends WsMessage {
+  val timestamp: Long
+}
 
 object WsServerMessage {
   // Will be never propagated to a client
   case object Complete extends WsServerMessage {
-    override val tpe: String = "unused"
+    override val tpe: String     = "unused"
+    override val timestamp: Long = 0L
   }
 
   // TODO play-json discriminator
@@ -17,6 +20,7 @@ object WsServerMessage {
       case WsAddressState.tpe => json.validate[WsAddressState]
       case WsOrderBook.tpe    => json.validate[WsOrderBook]
       case WsError.tpe        => json.validate[WsError]
+      case WsInitial.tpe      => json.validate[WsInitial]
       case x                  => JsError(JsPath \ "T", s"An unknown type: $x")
     }
   }
@@ -26,6 +30,7 @@ object WsServerMessage {
     case x: WsAddressState => Json.toJson(x)
     case x: WsOrderBook    => Json.toJson(x)
     case x: WsError        => Json.toJson(x)
+    case x: WsInitial      => Json.toJson(x)
     case x                 => throw new NotImplementedError(x.getClass.getName)
   }
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/market/AggregatedOrderBookActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/market/AggregatedOrderBookActor.scala
@@ -38,7 +38,10 @@ object AggregatedOrderBookActor {
     private[AggregatedOrderBookActor] case object SendWsUpdates                                                           extends Command
   }
 
-  case object OrderBookRemoved extends Message // Could be an event in the future
+  sealed trait Event extends Message
+  object Event {
+    case object OrderBookRemoved extends Event
+  }
 
   case class Settings(wsMessagesInterval: FiniteDuration)
 
@@ -120,7 +123,7 @@ object AggregatedOrderBookActor {
               if (updated.ws.hasSubscriptions) scheduleNextSendWsUpdates()
               default(updated)
 
-            case OrderBookRemoved =>
+            case Event.OrderBookRemoved =>
               context.log.warn("Order book was deleted, closing all WebSocket connections...")
               val reason = error.OrderBookStopped(assetPair)
               state.ws.wsConnections.foreach {

--- a/dex/src/main/scala/com/wavesplatform/dex/market/OrderBookActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/market/OrderBookActor.scala
@@ -127,7 +127,7 @@ class OrderBookActor(settings: Settings,
               process(request.timestamp, orderBook.cancelAll(request.timestamp))
               // We don't delete the snapshot, because it could be required after restart
               // snapshotStore ! OrderBookSnapshotStoreActor.Message.Delete(assetPair)
-              aggregatedRef ! AggregatedOrderBookActor.OrderBookRemoved
+              aggregatedRef ! AggregatedOrderBookActor.Event.OrderBookRemoved
               context.stop(self)
           }
       }


### PR DESCRIPTION
 Main:
  * WsInitial server message introduced. It contains connection id and is sent to the client right after connection creation
  * WsError is created with time.getTimestamp() in any places
  * Unit and integration tests are fixed

 Tests:
  * mkWsConnection automatically checks WsInitial receiving

 Minor improvements:
  * Completed message in WsHandlerActor and OrderBookDeleted message in AggregatedOrderBookActor became Event
  * WsServerMessage got abstract timestamp field
  * Formats of some ws messages and entities got more explicit names (useful for debugging)