### PR TITLE
DEX-737 Checker

### DIFF
--- a/dex/src/main/scala/com/wavesplatform/dex/WavesDexCli.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/WavesDexCli.scala
@@ -217,6 +217,7 @@ object WavesDexCli {
 
               val superConnector = SuperConnector.create(args.dexConfigPath, args.dexRestApi, args.nodeRestApi)
               Checker(superConnector).checkState(args.version)
+              superConnector.close()
           }
           println("Done")
       }

--- a/dex/src/main/scala/com/wavesplatform/dex/WavesDexCli.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/WavesDexCli.scala
@@ -13,6 +13,7 @@ import com.wavesplatform.dex.domain.bytes.ByteStr
 import com.wavesplatform.dex.domain.bytes.codec.Base58
 import com.wavesplatform.dex.tool.Checker
 import com.wavesplatform.dex.tool.connectors.SuperConnector
+import com.wavesplatform.dex.util.MatcherStateCheckingFailedError
 import scopt.{OParser, RenderingMode}
 
 import scala.util.{Failure, Success, Try}
@@ -219,7 +220,7 @@ object WavesDexCli {
                 } yield checkResult
               ) match {
                 case Right(diagnosticNotes) => println(s"$diagnosticNotes\nCongratulations! All checks passed!")
-                case Left(error)            => println(error)
+                case Left(error)            => println(error); util.forceStopApplication(MatcherStateCheckingFailedError)
               }
           }
           println("Done")

--- a/dex/src/main/scala/com/wavesplatform/dex/WavesDexCli.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/WavesDexCli.scala
@@ -12,6 +12,7 @@ import com.wavesplatform.dex.domain.account.{AddressScheme, KeyPair}
 import com.wavesplatform.dex.domain.bytes.ByteStr
 import com.wavesplatform.dex.domain.bytes.codec.Base58
 import com.wavesplatform.dex.tool.Checker
+import com.wavesplatform.dex.tool.connectors.SuperConnector
 import scopt.{OParser, RenderingMode}
 
 import scala.util.{Failure, Success, Try}
@@ -203,7 +204,19 @@ object WavesDexCli {
                          |waves.dex.rest-api.api-key-hash = "$hashedApiKey"
                          |""".stripMargin)
 
-            case Command.CheckServer => Checker(args.dexRestApi, args.nodeRestApi, args.version, args.dexConfigPath).checkState()
+            case Command.CheckServer =>
+              println(
+                s"""
+                   |Passed arguments:
+                   |  DEX REST API         : ${args.dexRestApi}
+                   |  WavesNode REST API   : ${args.nodeRestApi}
+                   |  Expected DEX version : ${args.version}
+                   |  DEX config path      : ${args.dexConfigPath}
+                   """.stripMargin
+              )
+
+              val superConnector = SuperConnector.create(args.dexConfigPath, args.dexRestApi, args.nodeRestApi)
+              Checker(superConnector).checkState(args.version)
           }
           println("Done")
       }

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/Checker.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/Checker.scala
@@ -32,12 +32,7 @@ case class Checker(superConnector: SuperConnector) {
   type CheckResult[A]       = ErrorOr[A]
   type CheckLoggedResult[A] = CheckResult[(A, String)]
 
-  private def logCheck[A](name: String)(f: => CheckResult[A]): CheckResult[A] =
-    for {
-      _      <- log(s"  $name... ", checkLeftIndent.some)
-      result <- f
-      _      <- log("Passed\n")
-    } yield result
+  private def logCheck[A](name: String)(f: => CheckResult[A]): CheckResult[A] = wrapByLogs(f)(s"  $name... ", "Passed\n", checkLeftIndent.some)
 
   private def denormalize(value: Long, decimals: Int = testAssetDecimals.toInt): Double =
     Denormalization.denormalizeAmountAndFee(value, decimals).toDouble
@@ -173,7 +168,7 @@ case class Checker(superConnector: SuperConnector) {
 
   def checkState(version: String): ErrorOr[String] =
     for {
-      _                                  <- log("\nChecking\n")
+      _                                  <- log("\nChecking:\n")
       _                                  <- logCheck("1. DEX version") { checkVersion(version) }
       (balance, balanceNotes)            <- logCheck("2. Matcher balance") { checkBalance }
       (wuJIoInfo, firstAssetNotes)       <- logCheck("3. First test asset") { checkTestAsset(balance, firstTestAssetName) }

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/Checker.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/Checker.scala
@@ -1,64 +1,24 @@
 package com.wavesplatform.dex.tool
 
-import java.io.File
-
-import cats.instances.future._
-import cats.instances.list._
 import cats.syntax.either._
-import cats.syntax.traverse._
-import ch.qos.logback.classic.{Level, Logger}
-import com.typesafe.config.Config
-import com.typesafe.config.ConfigFactory._
-import com.wavesplatform.dex.db.AccountStorage
-import com.wavesplatform.dex.domain.account.{AddressScheme, KeyPair}
-import com.wavesplatform.dex.domain.asset.Asset
-import com.wavesplatform.dex.domain.asset.Asset.{IssuedAsset, Waves}
 import com.wavesplatform.dex.domain.model.{Denormalization, Normalization}
-import com.wavesplatform.dex.domain.utils.EitherExt2
-import com.wavesplatform.dex.grpc.integration.WavesBlockchainClientBuilder
-import com.wavesplatform.dex.grpc.integration.clients.WavesBlockchainClient
-import com.wavesplatform.dex.grpc.integration.dto.BriefAssetDescription
-import com.wavesplatform.dex.grpc.integration.settings.GrpcClientSettings._
-import com.wavesplatform.dex.grpc.integration.settings.{GrpcClientSettings, WavesBlockchainClientSettings}
-import com.wavesplatform.dex.settings.MatcherSettings.valueReader
-import com.wavesplatform.dex.settings.{MatcherSettings, loadConfig}
-import com.wavesplatform.wavesj.json.WavesJsonMapper
+import com.wavesplatform.dex.tool.connectors.{RestConnector, SuperConnector}
+import com.wavesplatform.wavesj.transactions.IssueTransactionV2
 import com.wavesplatform.wavesj.{PrivateKeyAccount, Transactions}
-import monix.execution.Scheduler.Implicits.{global => monixScheduler}
-import net.ceedubs.ficus.Ficus._
-import org.slf4j.LoggerFactory
-import play.api.libs.json.jackson.PlayJsonModule
-import play.api.libs.json.{Json, JsonParserSettings}
-import sttp.client._
-import sttp.model.MediaType
+import play.api.libs.json.Json
 
-import scala.annotation.tailrec
-import scala.concurrent.ExecutionContext.Implicits.{global => executionContext}
 import scala.concurrent.duration._
-import scala.concurrent.{Await, Future}
 
 // noinspection ScalaStyle
-case class Checker(dexRestApi: String, nodeRestApi: String, version: String, dexConfigPath: String) {
+case class Checker(superConnector: SuperConnector) {
 
   import Checker._
-
-  LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME).asInstanceOf[Logger].setLevel(Level.OFF)
-
-  println(
-    s"""
-       |Passed arguments:
-       |  DEX REST API         : $dexRestApi
-       |  WavesNode REST API   : $nodeRestApi
-       |  Expected DEX version : $version
-       |  DEX config path      : $dexConfigPath
-       """.stripMargin
-  )
-
-  private implicit val backend: SttpBackend[Identity, Nothing, NothingT] = HttpURLConnectionBackend()
+  import superConnector._
 
   type CheckResult[A] = Either[String, A]
 
-  private def denormalize(value: Long): Double = Denormalization.denormalizeAmountAndFee(value, 8).toDouble
+  private def denormalize(value: Long, decimals: Int = testAssetDecimals.toInt): Double =
+    Denormalization.denormalizeAmountAndFee(value, decimals).toDouble
 
   private def check[A](name: String, doneOnSameLine: Boolean = true)(f: => CheckResult[A]): CheckResult[A] = {
     if (doneOnSameLine) print(name) else println(name)
@@ -68,99 +28,25 @@ case class Checker(dexRestApi: String, nodeRestApi: String, version: String, dex
     res
   }
 
-  print(s"Processing DEX config... ")
-
-  private val config: Config              = parseFile(new File(dexConfigPath))
-  private val settings: MatcherSettings   = loadConfig(config).as[MatcherSettings]("waves.dex")
-  private val matcherKeyPair: KeyPair     = AccountStorage.load(settings.accountStorage).map(_.keyPair).explicitGet()
-  private val extensionGrpcApiUri: String = settings.wavesBlockchainClient.grpc.target
-
-  private val dexRestApiUri: String  = s"http://${if (dexRestApi.nonEmpty) dexRestApi else s"${settings.restApi.address}:${settings.restApi.port}"}"
-  private val nodeRestApiUri: String = s"http://${if (dexRestApi.nonEmpty) nodeRestApi else s"${extensionGrpcApiUri.dropRight(4) + 6869}"}"
-
-  AddressScheme.current = new AddressScheme { override val chainId: Byte = settings.addressSchemeCharacter.toByte }
-
-  private val chainId: Byte = AddressScheme.current.chainId
-
-  private val matcherAccount: PrivateKeyAccount = PrivateKeyAccount.fromPrivateKey(matcherKeyPair.privateKey.base58, chainId)
-  private val mapper: WavesJsonMapper           = new WavesJsonMapper(chainId); mapper.registerModule(new PlayJsonModule(JsonParserSettings()))
-
-  println("Done")
-
-  private val grpcAsyncClient: WavesBlockchainClient[Future] = {
-    print("Establishing gRPC connection to DEX extension... ")
-    val grpcSettings   = GrpcClientSettings(extensionGrpcApiUri, 5, 5, true, 2.seconds, 5.seconds, 1.minute, ChannelOptionsSettings(5.seconds))
-    val clientSettings = WavesBlockchainClientSettings(grpcSettings, 100.milliseconds, 100)
-    val client         = WavesBlockchainClientBuilder.async(clientSettings, monixScheduler, executionContext)
-    println(s"Done")
-    client
-  }
-
-  println(
-    s"""
-       |DEX configurations:
-       | Chain ID               : $chainId
-       | Matcher public key     : ${matcherKeyPair.publicKey.toString}
-       | Matcher address        : ${matcherKeyPair.publicKey.toAddress}
-       | DEX REST API           : $dexRestApiUri
-       | Node REST API          : $nodeRestApiUri
-       | DEX extension gRPC API : $extensionGrpcApiUri
-       """.stripMargin
-  )
-
-  private def checkVersion(checkName: String): CheckResult[String] = check(s" $checkName ") {
-    basicRequest.get(uri"$dexRestApiUri/api-docs/swagger.json").send().body.flatMap { body =>
+  private def checkVersion(checkName: String, version: String): CheckResult[String] = check(s" $checkName ") {
+    dexRest.swaggerRequest.body.flatMap { body =>
       val parsedVersion = (Json.parse(body) \ "info" \ "version").get.as[String].trim
       Either.cond(parsedVersion == version, "Passed", s"""Failed! Expected "$version", but got "$parsedVersion"""")
     }
   }
 
   private def issueTestAsset(name: String, description: String, quantity: Long): CheckResult[String] = {
-
-    val tx           = Transactions.makeIssueTx(matcherAccount, chainId, name, description, quantity, testAssetDecimals, false, null, 1.waves)
-    val serializedTx = mapper writeValueAsString tx
-
-    def broadcastRequest = basicRequest.post(uri"$nodeRestApiUri/transactions/broadcast").body(serializedTx).contentType(MediaType.ApplicationJson)
-    def txInfoRequest    = basicRequest.get(uri"$nodeRestApiUri/transactions/info/${tx.getId.toString}")
-
-    @tailrec
-    def repeatRequest(attemptsLeft: Int, delay: FiniteDuration)(sendRequest: => Either[String, String],
-                                                                test: Either[String, String] => Boolean): Either[String, String] = {
-      if (attemptsLeft == 0) "All attempts are out!".asLeft
-      else {
-        val response = sendRequest
-        if (test(response)) response
-        else {
-          Thread.sleep(delay.toMillis)
-          repeatRequest(attemptsLeft - 1, delay)(sendRequest, test)
-        }
-      }
-    }
-
+    val matcher: PrivateKeyAccount = PrivateKeyAccount.fromPrivateKey(env.matcherKeyPair.privateKey.base58, env.chainId)
+    val tx: IssueTransactionV2     = Transactions.makeIssueTx(matcher, env.chainId, name, description, quantity, testAssetDecimals, false, null, 1.waves)
     for {
-      _ <- { print(s"Issuing ${denormalize(quantity)} $name... "); broadcastRequest.send().body.leftMap(ex => s"Cannot broadcast transaction! $ex") }
-      _ <- { print(s"Awaiting tx in blockchain... "); repeatRequest(10, 1.second)(txInfoRequest.send().body, _.isRight) }
+      _ <- { print(s"Issuing ${denormalize(quantity)} $name... "); nodeRest.broadcastTx(tx).body.leftMap(ex => s"Cannot broadcast transaction! $ex") }
+      _ <- { print(s"Awaiting tx in blockchain... "); RestConnector.repeatRequest(10, 1.second)(nodeRest.txInfo(tx).body, _.isRight) }
     } yield "Issued!"
   }
 
   private def checkTestAssets(checkName: String): CheckResult[String] = check(s" $checkName ", doneOnSameLine = false) {
-
-    def getDetailedBalance(asset: Asset, balance: Long): Future[(Asset, (BriefAssetDescription, Long))] = asset match {
-      case Waves           => Future.successful(asset -> (BriefAssetDescription.wavesDescription -> balance))
-      case ia: IssuedAsset => grpcAsyncClient.assetDescription(ia).map(maybeDesc => ia -> (maybeDesc.get -> balance))
-    }
-
-    val matcherBalance =
-      Await.result(
-        for {
-          balances                <- grpcAsyncClient.allAssetsSpendableBalance(matcherKeyPair.toAddress)
-          balancesWithDescription <- balances.toList.traverse { case (a, b) => getDetailedBalance(a, b) }
-        } yield balancesWithDescription.toMap,
-        10.seconds
-      )
-
     def findOrIssue(checkName: String, assetName: String, description: String, quantity: Long): CheckResult[String] = check(checkName) {
-      matcherBalance
+      dexGrpc.matcherBalance
         .find(_._2._1.name == assetName)
         .fold { print(s"not found. "); issueTestAsset(assetName, description, quantity) } {
           case (a, (d, b)) => s"found, name = ${d.name}, id = ${a.toString}, balance = ${denormalize(b)}".asRight
@@ -173,12 +59,12 @@ case class Checker(dexRestApi: String, nodeRestApi: String, version: String, dex
     } yield "    Passed"
   }
 
-  def checkState(): Unit = {
+  def checkState(version: String): Unit = {
     println(s"Checking")
 
     val checkResult =
       for {
-        _ <- checkVersion("1. DEX version...")
+        _ <- checkVersion("1. DEX version...", version)
         _ <- checkTestAssets("2. Test assets existence...")
       } yield ()
 
@@ -187,7 +73,7 @@ case class Checker(dexRestApi: String, nodeRestApi: String, version: String, dex
       case Left(_)  => println(s"\nDEX state is INVALID!")
     }
 
-    grpcAsyncClient.close()
+    superConnector.close()
   }
 }
 

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/Checker.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/Checker.scala
@@ -1,20 +1,25 @@
 package com.wavesplatform.dex.tool
 
+import cats.instances.either._
+import cats.instances.list.catsStdInstancesForList
 import cats.syntax.either._
+import cats.syntax.traverse._
 import com.wavesplatform.dex.domain.asset.Asset.{IssuedAsset, Waves}
 import com.wavesplatform.dex.domain.asset.{Asset, AssetPair}
 import com.wavesplatform.dex.domain.bytes.ByteStr
 import com.wavesplatform.dex.domain.model.{Denormalization, Normalization}
 import com.wavesplatform.dex.domain.order.OrderType.{BUY, SELL}
-import com.wavesplatform.dex.domain.order.{Order, OrderV3}
+import com.wavesplatform.dex.domain.order.{Order, OrderType, OrderV3}
 import com.wavesplatform.dex.model.OrderStatus
 import com.wavesplatform.dex.tool.connectors.DexExtensionGrpcConnector.DetailedBalance
 import com.wavesplatform.dex.tool.connectors.RestConnector._
 import com.wavesplatform.dex.tool.connectors.SuperConnector
+import com.wavesplatform.wavesj.PrivateKeyAccount
+import com.wavesplatform.wavesj.Transactions._
 import com.wavesplatform.wavesj.transactions.IssueTransactionV2
-import com.wavesplatform.wavesj.{PrivateKeyAccount, Transactions}
-import play.api.libs.json.Json
+import play.api.libs.json.JsValue
 
+import scala.Ordered._
 import scala.concurrent.duration._
 import scala.util.Random
 
@@ -30,40 +35,44 @@ case class Checker(superConnector: SuperConnector) {
   private def denormalize(value: Long, decimals: Int = testAssetDecimals.toInt): Double =
     Denormalization.denormalizeAmountAndFee(value, decimals).toDouble
 
-  private def check[A](name: String, doneOnSameLine: Boolean = true)(f: => CheckResult[A]): CheckResult[A] = {
-    if (doneOnSameLine) print(s" $name... ") else println(name)
-    val res = f
-    val msg = res.fold(identity, { case s: String => s; case _ => "Passed" })
-    println(msg)
-    res
+  private def denormalizeWavesBalance(value: Long): Double = denormalize(value, 8)
+
+  private def printOrder(amountAssetName: String, priceAssetName: String)(order: Order): String =
+    s"${order.orderType} ${denormalize(order.amount)} $amountAssetName @ ${denormalize(order.price)} $priceAssetName, id = ${order.id()}"
+
+  private def getAmountAndPriceAssetsInfo(f: AssetInfo, s: AssetInfo): (AssetInfo, AssetInfo) =
+    if (f.asset.compatId < s.asset.compatId) s -> f else f -> s
+
+  private def check[A](name: String)(f: => CheckResult[A]): CheckResult[A] = {
+    print(s" $name... " + " " * (checkLeftIndent - name.length)); val res = f; println(res fold (identity, _ => "Passed")); res
   }
 
   private def checkVersion(checkName: String)(version: String): CheckResult[Unit] = check(checkName) {
-    dexRest.swaggerRequest.body.flatMap { body =>
-      val parsedVersion = (Json.parse(body) \ "info" \ "version").get.as[String].trim
+    dexRest.swaggerRequest.flatMap { response =>
+      val parsedVersion = (response \ "info" \ "version").get.as[String]
       Either.cond(parsedVersion == version, (), s"""Failed! Expected "$version", but got "$parsedVersion"""")
     }
   }
 
   private def issueAsset(name: String, description: String, quantity: Long): CheckLoggedResult[AssetInfo] = {
     val matcher: PrivateKeyAccount = PrivateKeyAccount.fromPrivateKey(env.matcherKeyPair.privateKey.base58, env.chainId)
-    val tx: IssueTransactionV2     = Transactions.makeIssueTx(matcher, env.chainId, name, description, quantity, testAssetDecimals, false, null, 1.waves)
+    val tx: IssueTransactionV2     = makeIssueTx(matcher, env.chainId, name, description, quantity, testAssetDecimals, false, null, issueTxFee)
     val asset: IssuedAsset         = IssuedAsset(ByteStr(tx.getId.getBytes))
     for {
-      _ <- { nodeRest.broadcastTx(tx).body.leftMap(ex => s"Cannot broadcast transaction! $ex") }
-      _ <- { repeatRequest(10, 1.second)(nodeRest.txInfo(tx).body, _.isRight) }
+      _ <- nodeRest.broadcastTx(tx).leftMap(ex => s"Cannot broadcast transaction! $ex")
+      _ <- nodeRest.repeatRequest(nodeRest getTxInfo tx)(_.isRight)
     } yield AssetInfo(asset, name) -> s"Issued ${denormalize(quantity)} $name"
   }
 
-  private def checkMatcherBalance(checkName: String): CheckLoggedResult[DetailedBalance] = check(checkName) {
+  private def checkBalance(checkName: String): CheckLoggedResult[DetailedBalance] = check(checkName) {
 
-    val balance      = dexExtensionGrpc.matcherBalance
-    val wavesBalance = denormalize(balance.get(Waves).map(_._2).getOrElse(0), 8)
+    val balance      = dexExtensionGrpc.matcherBalanceSync
+    val wavesBalance = denormalizeWavesBalance(balance.get(Waves).map(_._2) getOrElse 0)
 
     Either.cond(
-      balance.get(Waves).exists(_._2 > 3.waves),
+      balance.get(Waves).exists(_._2 > minMatcherValidBalance),
       balance -> balance.values.map { case (d, b) => s"${denormalize(b)} ${d.name}" }.mkString(", "),
-      s"Matcher Waves balance ($wavesBalance) less than 3 Waves!"
+      s"Matcher Waves balance ($wavesBalance) less than ${denormalizeWavesBalance(minMatcherValidBalance)}) Waves!"
     )
   }
 
@@ -71,59 +80,86 @@ case class Checker(superConnector: SuperConnector) {
     check(checkName) {
       matcherBalance
         .find(_._2._1.name == assetName)
-        .fold { issueAsset(assetName, testAssetDescription, mnogo.mbIJIo) } {
+        .fold { issueAsset(assetName, testAssetDescription, mnogo.coin) } {
           case (a, (d, b)) => (AssetInfo(a, d.name) -> s"Balance = ${denormalize(b)} ${d.name} (${a.toString})").asRight
         }
     }
 
-  private def isOrderStatus(response: Either[String, String], orderStatusName: String): Boolean =
-    response.map(j => (Json.parse(j) \ "status").get.as[String]).exists(_ == orderStatusName)
+  private def mkMatcherOrder(assetPair: AssetPair, orderType: OrderType): Order = {
+    val timestamp = System.currentTimeMillis
+    OrderV3(env.matcherKeyPair,
+            env.matcherKeyPair.publicKey,
+            assetPair,
+            orderType,
+            testAmount,
+            testPrice,
+            timestamp,
+            timestamp + 24.hours.toMillis,
+            matcherOrderFee,
+            Waves)
+  }
 
   private def checkPlacement(checkName: String)(firstAssetInfo: AssetInfo, secondAssetInfo: AssetInfo): CheckLoggedResult[Order] =
     check(checkName) {
 
-      import Ordered._
-
-      val (amountAssetInfo, priceAssetInfo) = {
-        if (firstAssetInfo.asset.compatId < secondAssetInfo.asset.compatId)
-          secondAssetInfo   -> firstAssetInfo
-        else firstAssetInfo -> secondAssetInfo
-      }
-
-      val assetPair = AssetPair(amountAssetInfo.asset, priceAssetInfo.asset)
-      val orderType = if (Random.nextBoolean) BUY else SELL
-      val amount    = 1.wuJIo
-      val price     = 1.mbIJIo
-
-      val timestamp = System.currentTimeMillis
-
-      val order =
-        OrderV3(
-          env.matcherKeyPair,
-          env.matcherKeyPair.publicKey,
-          assetPair,
-          orderType,
-          amount,
-          price,
-          timestamp,
-          timestamp + 24.hours.toMillis,
-          0.003.waves,
-          Waves
-        )
+      val (amountAssetInfo, priceAssetInfo) = getAmountAndPriceAssetsInfo(firstAssetInfo, secondAssetInfo)
+      val orderType                         = if (Random.nextBoolean) BUY else SELL
+      val order                             = mkMatcherOrder(AssetPair(amountAssetInfo.asset, priceAssetInfo.asset), orderType)
 
       for {
-        _ <- dexRest.placeOrder(order).body
-        _ <- repeatRequest(10, 1.second)(dexRest.getOrderStatus(order).body, isOrderStatus(_, OrderStatus.Accepted.name))
-      } yield {
-        order -> s"Placed $orderType ${denormalize(amount)} ${amountAssetInfo.name} @ ${denormalize(price)} ${priceAssetInfo.name}, order id = ${order.id()}"
-      }
+        _ <- dexRest.placeOrder(order)
+        _ <- dexRest.waitForOrderStatus(order, OrderStatus.Accepted.name)
+      } yield order -> s"Placed order ${printOrder(amountAssetInfo.name, priceAssetInfo.name)(order)}"
     }
 
   private def checkCancellation(checkName: String)(order: Order): CheckLoggedResult[Order] = check(checkName) {
     for {
-      _ <- dexRest.cancelOrder(order, env.matcherKeyPair).body
-      _ <- repeatRequest(10, 1.second)(dexRest.getOrderStatus(order).body, isOrderStatus(_, OrderStatus.Cancelled.name))
+      _ <- dexRest.cancelOrder(order, env.matcherKeyPair)
+      _ <- dexRest.waitForOrderStatus(order, OrderStatus.Cancelled.name)
     } yield order -> s"Order with id ${order.id()} cancelled"
+  }
+
+  private def checkMatching(checkName: String)(firstAssetInfo: AssetInfo, secondAssetInfo: AssetInfo): CheckResult[String] = check(checkName) {
+
+    val (amountAssetInfo, priceAssetInfo) = getAmountAndPriceAssetsInfo(firstAssetInfo, secondAssetInfo)
+    val assetPair                         = AssetPair(amountAssetInfo.asset, priceAssetInfo.asset)
+
+    val counter     = mkMatcherOrder(assetPair, BUY)
+    val submitted   = mkMatcherOrder(assetPair, SELL)
+    val submittedId = submitted.id()
+
+    def checkFillingAtDex(orderStatus: JsValue): ErrorOr[Boolean] = {
+      lazy val expectedFilledStatus = OrderStatus.Filled(submitted.amount, submitted.matcherFee).json.toString
+      (
+        for {
+          filledAmount <- (orderStatus \ "filledAmount").asOpt[Long]
+          filledFee    <- (orderStatus \ "filledFee").asOpt[Long]
+        } yield filledAmount == submitted.amount && filledFee == submitted.matcherFee
+      ).toRight[String](s"Check of submitted order filling failed! Expected $expectedFilledStatus, but got ${orderStatus.toString}")
+    }
+
+    def awaitSubmittedOrderAtNode: ErrorOr[Seq[JsValue]] =
+      for {
+        txs <- dexRest
+          .repeatRequest(dexRest getTxsByOrderId submittedId)(_.isRight)
+          .ensure(s"Failed! Cannot find transactions for order id $submittedId")(_.lengthCompare(1) >= 0)
+        _ <- txs.toList.traverse(tx => nodeRest.repeatRequest(nodeRest getTxInfo tx)(_.isRight))
+      } yield txs
+
+    for {
+      _               <- dexRest.placeOrder(counter)
+      counterStatus   <- dexRest.waitForOrderStatus(counter, OrderStatus.Accepted.name)
+      _               <- dexRest.placeOrder(submitted)
+      submittedStatus <- dexRest.waitForOrderStatus(submitted, OrderStatus.Filled.name)
+      _               <- checkFillingAtDex(submittedStatus)
+      txs             <- awaitSubmittedOrderAtNode
+    } yield {
+      val printOrder: Order => String = this.printOrder(amountAssetInfo.name, priceAssetInfo.name)(_)
+      s"""
+         |    Counter   = ${printOrder(counter)}, status = ${counterStatus.toString}
+         |    Submitted = ${printOrder(submitted)}, status = ${submittedStatus.toString}
+         |    Tx ids    = ${txs.map(tx => (tx \ "id").as[String]).mkString(", ")}""".stripMargin
+    }
   }
 
   def checkState(version: String): Unit = {
@@ -131,20 +167,22 @@ case class Checker(superConnector: SuperConnector) {
 
     val checkResult =
       for {
-        _                                     <- checkVersion("1. DEX version")(version)
-        (matcherBalance, matcherBalanceNotes) <- checkMatcherBalance("2. Matcher balance")
-        (wuJIoInfo, firstAssetNotes)          <- checkTestAsset("3. First test asset")(matcherBalance, firstTestAssetName)
-        (mbIJIoInfo, secondAssetNotes)        <- checkTestAsset("4. Second test asset")(matcherBalance, secondTestAssetName)
-        (order, placementNotes)               <- checkPlacement("5. Order placement")(wuJIoInfo, mbIJIoInfo)
-        (_, cancellationNotes)                <- checkCancellation("6. Order cancellation")(order)
+        _                              <- checkVersion("1. DEX version")(version)
+        (balance, balanceNotes)        <- checkBalance("2. Matcher balance")
+        (wuJIoInfo, firstAssetNotes)   <- checkTestAsset("3. First test asset")(balance, firstTestAssetName)
+        (mbIJIoInfo, secondAssetNotes) <- checkTestAsset("4. Second test asset")(balance, secondTestAssetName)
+        (order, placementNotes)        <- checkPlacement("5. Order placement")(wuJIoInfo, mbIJIoInfo)
+        (_, cancellationNotes)         <- checkCancellation("6. Order cancellation")(order)
+        matchingNotes                  <- checkMatching("7. Matching")(wuJIoInfo, mbIJIoInfo)
       } yield {
         s"""
            |Diagnostic notes:
-           |  Matcher balance : $matcherBalanceNotes 
+           |  Matcher balance : $balanceNotes 
            |  First asset     : $firstAssetNotes
            |  Second asset    : $secondAssetNotes
            |  Placement       : $placementNotes 
            |  Cancellation    : $cancellationNotes
+           |  Matching        : $matchingNotes
        """.stripMargin
       }
 
@@ -162,12 +200,18 @@ object Checker {
   private val firstTestAssetName  = "IIIuJIo"
   private val secondTestAssetName = "MbIJIo"
 
-  private val testAssetDescription = "Asset for the Matcher checking purposes"
-  private val testAssetDecimals    = 8.toByte
+  private val testAssetDescription  = "Asset for the Matcher checking purposes"
+  private val testAssetDecimals     = 8.toByte
+  private val testAmount, testPrice = 1.coin
+  private val mnogo                 = 100000000L
 
-  private val mnogo = 100000000L
+  private val checkLeftIndent = 40
+  private val issueTxFee      = 1.waves
+  private val matcherOrderFee = 0.003.waves
 
-  implicit class DoubleOps(private val value: Double) {
-    val wuJIo, mbIJIo, waves: Long = Normalization.normalizeAmountAndFee(value, 8)
+  private val minMatcherValidBalance = 3.waves
+
+  private[tool] implicit class DoubleOps(private val value: Double) {
+    val coin, waves: Long = Normalization.normalizeAmountAndFee(value, 8)
   }
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/Checker.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/Checker.scala
@@ -1,13 +1,22 @@
 package com.wavesplatform.dex.tool
 
 import cats.syntax.either._
+import com.wavesplatform.dex.domain.asset.Asset.{IssuedAsset, Waves}
+import com.wavesplatform.dex.domain.asset.{Asset, AssetPair}
+import com.wavesplatform.dex.domain.bytes.ByteStr
 import com.wavesplatform.dex.domain.model.{Denormalization, Normalization}
-import com.wavesplatform.dex.tool.connectors.{RestConnector, SuperConnector}
+import com.wavesplatform.dex.domain.order.OrderType.{BUY, SELL}
+import com.wavesplatform.dex.domain.order.{Order, OrderV3}
+import com.wavesplatform.dex.model.OrderStatus
+import com.wavesplatform.dex.tool.connectors.DexExtensionGrpcConnector.DetailedBalance
+import com.wavesplatform.dex.tool.connectors.RestConnector._
+import com.wavesplatform.dex.tool.connectors.SuperConnector
 import com.wavesplatform.wavesj.transactions.IssueTransactionV2
 import com.wavesplatform.wavesj.{PrivateKeyAccount, Transactions}
 import play.api.libs.json.Json
 
 import scala.concurrent.duration._
+import scala.util.Random
 
 // noinspection ScalaStyle
 case class Checker(superConnector: SuperConnector) {
@@ -15,48 +24,106 @@ case class Checker(superConnector: SuperConnector) {
   import Checker._
   import superConnector._
 
-  type CheckResult[A] = Either[String, A]
+  type CheckResult[A]       = Either[String, A]
+  type CheckLoggedResult[A] = CheckResult[(A, String)]
 
   private def denormalize(value: Long, decimals: Int = testAssetDecimals.toInt): Double =
     Denormalization.denormalizeAmountAndFee(value, decimals).toDouble
 
   private def check[A](name: String, doneOnSameLine: Boolean = true)(f: => CheckResult[A]): CheckResult[A] = {
-    if (doneOnSameLine) print(name) else println(name)
+    if (doneOnSameLine) print(s" $name... ") else println(name)
     val res = f
-    val msg = res.fold(identity, { case () => "Done"; case s: String => s })
+    val msg = res.fold(identity, { case s: String => s; case _ => "Passed" })
     println(msg)
     res
   }
 
-  private def checkVersion(checkName: String, version: String): CheckResult[String] = check(s" $checkName ") {
+  private def checkVersion(checkName: String)(version: String): CheckResult[Unit] = check(checkName) {
     dexRest.swaggerRequest.body.flatMap { body =>
       val parsedVersion = (Json.parse(body) \ "info" \ "version").get.as[String].trim
-      Either.cond(parsedVersion == version, "Passed", s"""Failed! Expected "$version", but got "$parsedVersion"""")
+      Either.cond(parsedVersion == version, (), s"""Failed! Expected "$version", but got "$parsedVersion"""")
     }
   }
 
-  private def issueTestAsset(name: String, description: String, quantity: Long): CheckResult[String] = {
+  private def issueAsset(name: String, description: String, quantity: Long): CheckLoggedResult[AssetInfo] = {
     val matcher: PrivateKeyAccount = PrivateKeyAccount.fromPrivateKey(env.matcherKeyPair.privateKey.base58, env.chainId)
     val tx: IssueTransactionV2     = Transactions.makeIssueTx(matcher, env.chainId, name, description, quantity, testAssetDecimals, false, null, 1.waves)
+    val asset: IssuedAsset         = IssuedAsset(ByteStr(tx.getId.getBytes))
     for {
-      _ <- { print(s"Issuing ${denormalize(quantity)} $name... "); nodeRest.broadcastTx(tx).body.leftMap(ex => s"Cannot broadcast transaction! $ex") }
-      _ <- { print(s"Awaiting tx in blockchain... "); RestConnector.repeatRequest(10, 1.second)(nodeRest.txInfo(tx).body, _.isRight) }
-    } yield "Issued!"
+      _ <- { nodeRest.broadcastTx(tx).body.leftMap(ex => s"Cannot broadcast transaction! $ex") }
+      _ <- { repeatRequest(10, 1.second)(nodeRest.txInfo(tx).body, _.isRight) }
+    } yield AssetInfo(asset, name) -> s"Issued ${denormalize(quantity)} $name"
   }
 
-  private def checkTestAssets(checkName: String): CheckResult[String] = check(s" $checkName ", doneOnSameLine = false) {
-    def findOrIssue(checkName: String, assetName: String, description: String, quantity: Long): CheckResult[String] = check(checkName) {
-      dexGrpc.matcherBalance
+  private def checkMatcherBalance(checkName: String): CheckLoggedResult[DetailedBalance] = check(checkName) {
+
+    val balance      = dexExtensionGrpc.matcherBalance
+    val wavesBalance = denormalize(balance.get(Waves).map(_._2).getOrElse(0), 8)
+
+    Either.cond(
+      balance.get(Waves).exists(_._2 > 3.waves),
+      balance -> balance.values.map { case (d, b) => s"${denormalize(b)} ${d.name}" }.mkString(", "),
+      s"Matcher Waves balance ($wavesBalance) less than 3 Waves!"
+    )
+  }
+
+  private def checkTestAsset(checkName: String)(matcherBalance: DetailedBalance, assetName: String): CheckLoggedResult[AssetInfo] =
+    check(checkName) {
+      matcherBalance
         .find(_._2._1.name == assetName)
-        .fold { print(s"not found. "); issueTestAsset(assetName, description, quantity) } {
-          case (a, (d, b)) => s"found, name = ${d.name}, id = ${a.toString}, balance = ${denormalize(b)}".asRight
+        .fold { issueAsset(assetName, testAssetDescription, mnogo.mbIJIo) } {
+          case (a, (d, b)) => (AssetInfo(a, d.name) -> s"Balance = ${denormalize(b)} ${d.name} (${a.toString})").asRight
         }
     }
 
+  private def isOrderStatus(response: Either[String, String], orderStatusName: String): Boolean =
+    response.map(j => (Json.parse(j) \ "status").get.as[String]).exists(_ == orderStatusName)
+
+  private def checkPlacement(checkName: String)(firstAssetInfo: AssetInfo, secondAssetInfo: AssetInfo): CheckLoggedResult[Order] =
+    check(checkName) {
+
+      import Ordered._
+
+      val (amountAssetInfo, priceAssetInfo) = {
+        if (firstAssetInfo.asset.compatId < secondAssetInfo.asset.compatId)
+          secondAssetInfo   -> firstAssetInfo
+        else firstAssetInfo -> secondAssetInfo
+      }
+
+      val assetPair = AssetPair(amountAssetInfo.asset, priceAssetInfo.asset)
+      val orderType = if (Random.nextBoolean) BUY else SELL
+      val amount    = 1.wuJIo
+      val price     = 1.mbIJIo
+
+      val timestamp = System.currentTimeMillis
+
+      val order =
+        OrderV3(
+          env.matcherKeyPair,
+          env.matcherKeyPair.publicKey,
+          assetPair,
+          orderType,
+          amount,
+          price,
+          timestamp,
+          timestamp + 24.hours.toMillis,
+          0.003.waves,
+          Waves
+        )
+
+      for {
+        _ <- dexRest.placeOrder(order).body
+        _ <- repeatRequest(10, 1.second)(dexRest.getOrderStatus(order).body, isOrderStatus(_, OrderStatus.Accepted.name))
+      } yield {
+        order -> s"Placed $orderType ${denormalize(amount)} ${amountAssetInfo.name} @ ${denormalize(price)} ${priceAssetInfo.name}, order id = ${order.id()}"
+      }
+    }
+
+  private def checkCancellation(checkName: String)(order: Order): CheckLoggedResult[Order] = check(checkName) {
     for {
-      _ <- findOrIssue("  - Amount asset ", testAmountAssetName, testAmountAssetDescription, mnogo.wuJIo)
-      _ <- findOrIssue("  - Price asset ", testPriceAssetName, testPriceAssetDescription, mnogo.mbIJIo)
-    } yield "    Passed"
+      _ <- dexRest.cancelOrder(order, env.matcherKeyPair).body
+      _ <- repeatRequest(10, 1.second)(dexRest.getOrderStatus(order).body, isOrderStatus(_, OrderStatus.Cancelled.name))
+    } yield order -> s"Order with id ${order.id()} cancelled"
   }
 
   def checkState(version: String): Unit = {
@@ -64,29 +131,41 @@ case class Checker(superConnector: SuperConnector) {
 
     val checkResult =
       for {
-        _ <- checkVersion("1. DEX version...", version)
-        _ <- checkTestAssets("2. Test assets existence...")
-      } yield ()
+        _                                     <- checkVersion("1. DEX version")(version)
+        (matcherBalance, matcherBalanceNotes) <- checkMatcherBalance("2. Matcher balance")
+        (wuJIoInfo, firstAssetNotes)          <- checkTestAsset("3. First test asset")(matcherBalance, firstTestAssetName)
+        (mbIJIoInfo, secondAssetNotes)        <- checkTestAsset("4. Second test asset")(matcherBalance, secondTestAssetName)
+        (order, placementNotes)               <- checkPlacement("5. Order placement")(wuJIoInfo, mbIJIoInfo)
+        (_, cancellationNotes)                <- checkCancellation("6. Order cancellation")(order)
+      } yield {
+        s"""
+           |Diagnostic notes:
+           |  Matcher balance : $matcherBalanceNotes 
+           |  First asset     : $firstAssetNotes
+           |  Second asset    : $secondAssetNotes
+           |  Placement       : $placementNotes 
+           |  Cancellation    : $cancellationNotes
+       """.stripMargin
+      }
 
     checkResult match {
-      case Right(_) => println("\nCongratulations! DEX state is valid!")
-      case Left(_)  => println(s"\nDEX state is INVALID!")
+      case Right(notes) => println(s"\n$notes\nCongratulations! All checks passed!")
+      case Left(_)      => println(s"\nChecking failed!")
     }
-
-    superConnector.close()
   }
 }
 
 object Checker {
 
-  private val testAmountAssetName = "IIIuJIo"
-  private val testPriceAssetName  = "MbIJIo"
+  private case class AssetInfo(asset: Asset, name: String)
 
-  private val testAmountAssetDescription = "Amount asset for the Matcher checking purposes"
-  private val testPriceAssetDescription  = "Price asset for the Matcher checking purposes"
+  private val firstTestAssetName  = "IIIuJIo"
+  private val secondTestAssetName = "MbIJIo"
 
-  private val mnogo             = 100000000L
-  private val testAssetDecimals = 8.toByte
+  private val testAssetDescription = "Asset for the Matcher checking purposes"
+  private val testAssetDecimals    = 8.toByte
+
+  private val mnogo = 100000000L
 
   implicit class DoubleOps(private val value: Double) {
     val wuJIo, mbIJIo, waves: Long = Normalization.normalizeAmountAndFee(value, 8)

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/Checker.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/Checker.scala
@@ -2,24 +2,43 @@ package com.wavesplatform.dex.tool
 
 import java.io.File
 
+import cats.instances.future._
+import cats.instances.list._
+import cats.syntax.traverse._
+import ch.qos.logback.classic.{Level, Logger}
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory._
 import com.wavesplatform.dex.db.AccountStorage
 import com.wavesplatform.dex.domain.account.AddressScheme
-import com.wavesplatform.dex.domain.bytes.codec.Base58
-import com.wavesplatform.dex.domain.model.Normalization
+import com.wavesplatform.dex.domain.asset.Asset
+import com.wavesplatform.dex.domain.asset.Asset.{IssuedAsset, Waves}
+import com.wavesplatform.dex.domain.model.{Denormalization, Normalization}
 import com.wavesplatform.dex.domain.utils.EitherExt2
+import com.wavesplatform.dex.grpc.integration.WavesBlockchainClientBuilder
+import com.wavesplatform.dex.grpc.integration.clients.WavesBlockchainClient
+import com.wavesplatform.dex.grpc.integration.dto.BriefAssetDescription
+import com.wavesplatform.dex.grpc.integration.settings.GrpcClientSettings._
+import com.wavesplatform.dex.grpc.integration.settings.{GrpcClientSettings, WavesBlockchainClientSettings}
 import com.wavesplatform.dex.settings.MatcherSettings.valueReader
 import com.wavesplatform.dex.settings.{MatcherSettings, loadConfig}
-import com.wavesplatform.dex.tool.Checker.DoubleOps
 import com.wavesplatform.wavesj.transactions.IssueTransactionV2
 import com.wavesplatform.wavesj.{PrivateKeyAccount, Transactions}
+import monix.execution.Scheduler.Implicits.{global => monixScheduler}
 import net.ceedubs.ficus.Ficus._
+import org.slf4j.LoggerFactory
 import play.api.libs.json.Json
 import sttp.client._
 
+import scala.concurrent.ExecutionContext.Implicits.{global => executionContext}
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
+
 // noinspection ScalaStyle
 case class Checker(dexRestApi: String, nodeRestApiUri: String, version: String, dexConfigPath: String) {
+
+  import Checker._
+
+  LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME).asInstanceOf[Logger].setLevel(Level.OFF)
 
   println(
     s"""
@@ -35,22 +54,33 @@ case class Checker(dexRestApi: String, nodeRestApiUri: String, version: String, 
 
   print(s"Processing DEX config... ")
 
-  private val config: Config            = parseFile(new File(dexConfigPath))
-  private val settings: MatcherSettings = loadConfig(config).as[MatcherSettings]("waves.dex")
-  private val matcherKeyPair            = AccountStorage.load(settings.accountStorage).map(_.keyPair).explicitGet()
-  private val dexRestApiUri: String     = s"http://${if (dexRestApi.nonEmpty) dexRestApi else s"${settings.restApi.address}:${settings.restApi.port}"}/"
+  private val config: Config              = parseFile(new File(dexConfigPath))
+  private val settings: MatcherSettings   = loadConfig(config).as[MatcherSettings]("waves.dex")
+  private val matcherKeyPair              = AccountStorage.load(settings.accountStorage).map(_.keyPair).explicitGet()
+  private val dexRestApiUri: String       = s"http://${if (dexRestApi.nonEmpty) dexRestApi else s"${settings.restApi.address}:${settings.restApi.port}"}/"
+  private val extensionGrpcApiUri: String = settings.wavesBlockchainClient.grpc.target
 
   AddressScheme.current = new AddressScheme { override val chainId: Byte = settings.addressSchemeCharacter.toByte }
 
   println("Done")
 
+  private val grpcAsyncClient: WavesBlockchainClient[Future] = {
+    print("Establishing gRPC connection to DEX extension... ")
+    val grpcSettings   = GrpcClientSettings(extensionGrpcApiUri, 5, 5, true, 2.seconds, 5.seconds, 1.minute, ChannelOptionsSettings(5.seconds))
+    val clientSettings = WavesBlockchainClientSettings(grpcSettings, 100.milliseconds, 100)
+    val client         = WavesBlockchainClientBuilder.async(clientSettings, monixScheduler, executionContext)
+    println(s"Done")
+    client
+  }
+
   println(
     s"""
-       |DEX config processing results:
-       | Address scheme     : ${AddressScheme.current.chainId}
-       | Matcher public key : ${matcherKeyPair.publicKey.toString}
-       | Matcher address    : ${matcherKeyPair.publicKey.toAddress}
-       | DEX REST API       : $dexRestApiUri
+       |DEX configurations:
+       | Address scheme         : ${AddressScheme.current.chainId}
+       | Matcher public key     : ${matcherKeyPair.publicKey.toString}
+       | Matcher address        : ${matcherKeyPair.publicKey.toAddress}
+       | DEX REST API           : $dexRestApiUri
+       | DEX extension gRPC API : $extensionGrpcApiUri
        """.stripMargin
   )
 
@@ -64,11 +94,6 @@ case class Checker(dexRestApi: String, nodeRestApiUri: String, version: String, 
     val issueAwlTx  = mkIssueAssetTx("IIIuJIo", "Awl for the Matcher checking purposes", mnogo.wuJIo)
     val issueSoapTx = mkIssueAssetTx("MbIJIo", "Soap for the Matcher checking purposes", mnogo.mbIJIo)
   }
-
-//  private def check(name: String)(f: () => Boolean): Unit = {
-//    print(s"Checking $name... ")
-//    f()
-//  }
 
   private def checkVersion(): Boolean = {
     print(s" 1. DEX version... ")
@@ -88,35 +113,53 @@ case class Checker(dexRestApi: String, nodeRestApiUri: String, version: String, 
     )
   }
 
-  def checkState(): Unit = {
-    println(s"Checking")
-    val isStateCorrect = checkVersion()
-    println(s"\n${if (isStateCorrect) "Congratulations! DEX state is valid!" else "DEX state is INVALID!"}\n")
+  private def checkTestAssets(): Boolean = {
+    println(s" 2. Test assets existence")
+
+    def getDetailedBalance(asset: Asset, balance: Long): Future[(Asset, (BriefAssetDescription, Long))] = {
+      asset match {
+        case Waves           => Future.successful(asset -> (BriefAssetDescription.wavesDescription -> balance))
+        case ia: IssuedAsset => grpcAsyncClient.assetDescription(ia).map(maybeDesc => ia -> (maybeDesc.get -> balance))
+      }
+    }
+
+    val matcherBalance =
+      Await.result(
+        for {
+          balances                <- grpcAsyncClient.allAssetsSpendableBalance(matcherKeyPair.toAddress)
+          balancesWithDescription <- balances.toList.traverse { case (a, b) => getDetailedBalance(a, b) }
+        } yield balancesWithDescription.toMap,
+        10.seconds
+      )
+
+    def checkAssetExistence(name: String): Boolean = {
+      matcherBalance.find(_._2._1.name == name).fold { println("Not found"); false } {
+        case (a, (d, b)) =>
+          val denormalizedBalance = Denormalization.denormalizeAmountAndFee(b, 8)
+          println(s"Found, name = ${d.name}, id = ${a.toString}, balance = $denormalizedBalance")
+          true
+      }
+    }
+
+    print(s"   2.1 Amount asset... "); val amountAssetResult = checkAssetExistence(testAmountAssetName)
+    print(s"   2.2 Price asset... "); val priceAssetResult   = checkAssetExistence(testPriceAssetName)
+
+    amountAssetResult && priceAssetResult
   }
 
-//  def mkIssue(issuer: KeyPair,
-//              name: String,
-//              quantity: Long,
-//              decimals: Int = 8,
-//              fee: Long = issueFee,
-//              script: Option[ByteStr] = None,
-//              reissuable: Boolean = false,
-//              timestamp: Long = System.currentTimeMillis): IssueTransaction = {
-//    Transactions.makeIssueTx(issuer,
-//                             AddressScheme.current.chainId,
-//                             name,
-//                             s"$name asset",
-//                             quantity,
-//                             decimals.toByte,
-//                             reissuable,
-//                             script.map(_.base64).orNull,
-//                             fee,
-//                             timestamp)
-//  }
-
+  def checkState(): Unit = {
+    println(s"Checking")
+    val isStateCorrect = checkVersion() && checkTestAssets()
+    println(s"\n${if (isStateCorrect) "Congratulations! DEX state is valid!" else "DEX state is INVALID!"}\n")
+    grpcAsyncClient.close()
+  }
 }
 
 object Checker {
+
+  private val testAmountAssetName = "IIIuJIo"
+  private val testPriceAssetName  = "MbIJo"
+
   implicit class DoubleOps(private val value: Double) {
     val wuJIo, mbIJIo, waves: Long = Normalization.normalizeAmountAndFee(value, 8)
   }

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/Checker.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/Checker.scala
@@ -1,0 +1,123 @@
+package com.wavesplatform.dex.tool
+
+import java.io.File
+
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory._
+import com.wavesplatform.dex.db.AccountStorage
+import com.wavesplatform.dex.domain.account.AddressScheme
+import com.wavesplatform.dex.domain.bytes.codec.Base58
+import com.wavesplatform.dex.domain.model.Normalization
+import com.wavesplatform.dex.domain.utils.EitherExt2
+import com.wavesplatform.dex.settings.MatcherSettings.valueReader
+import com.wavesplatform.dex.settings.{MatcherSettings, loadConfig}
+import com.wavesplatform.dex.tool.Checker.DoubleOps
+import com.wavesplatform.wavesj.transactions.IssueTransactionV2
+import com.wavesplatform.wavesj.{PrivateKeyAccount, Transactions}
+import net.ceedubs.ficus.Ficus._
+import play.api.libs.json.Json
+import sttp.client._
+
+// noinspection ScalaStyle
+case class Checker(dexRestApi: String, nodeRestApiUri: String, version: String, dexConfigPath: String) {
+
+  println(
+    s"""
+       |Passed arguments:
+       |  DEX REST API         : $dexRestApi
+       |  WavesNode REST API   : $nodeRestApiUri
+       |  Expected DEX version : $version
+       |  DEX config path      : $dexConfigPath
+       """.stripMargin
+  )
+
+  private implicit val backend: SttpBackend[Identity, Nothing, NothingT] = HttpURLConnectionBackend()
+
+  print(s"Processing DEX config... ")
+
+  private val config: Config            = parseFile(new File(dexConfigPath))
+  private val settings: MatcherSettings = loadConfig(config).as[MatcherSettings]("waves.dex")
+  private val matcherKeyPair            = AccountStorage.load(settings.accountStorage).map(_.keyPair).explicitGet()
+  private val dexRestApiUri: String     = s"http://${if (dexRestApi.nonEmpty) dexRestApi else s"${settings.restApi.address}:${settings.restApi.port}"}/"
+
+  AddressScheme.current = new AddressScheme { override val chainId: Byte = settings.addressSchemeCharacter.toByte }
+
+  println("Done")
+
+  println(
+    s"""
+       |DEX config processing results:
+       | Address scheme     : ${AddressScheme.current.chainId}
+       | Matcher public key : ${matcherKeyPair.publicKey.toString}
+       | Matcher address    : ${matcherKeyPair.publicKey.toAddress}
+       | DEX REST API       : $dexRestApiUri
+       """.stripMargin
+  )
+
+  private def mkIssueAssetTx(name: String, description: String, quantity: Long): IssueTransactionV2 = {
+    val matcherAccount = PrivateKeyAccount.fromPrivateKey(matcherKeyPair.privateKey.base58, AddressScheme.current.chainId)
+    Transactions.makeIssueTx(matcherAccount, AddressScheme.current.chainId, name, description, quantity, 8, false, null, 1.waves)
+  }
+
+  private def issueTestAssets(): Unit = {
+    val mnogo       = 3000000
+    val issueAwlTx  = mkIssueAssetTx("IIIuJIo", "Awl for the Matcher checking purposes", mnogo.wuJIo)
+    val issueSoapTx = mkIssueAssetTx("MbIJIo", "Soap for the Matcher checking purposes", mnogo.mbIJIo)
+  }
+
+//  private def check(name: String)(f: () => Boolean): Unit = {
+//    print(s"Checking $name... ")
+//    f()
+//  }
+
+  private def checkVersion(): Boolean = {
+    print(s" 1. DEX version... ")
+
+    val uri      = uri"$dexRestApiUri/api-docs/swagger.json"
+    val request  = basicRequest.get(uri)
+    val response = request.send().body
+
+    response.fold(
+      error => { println(s"Cannot parse $uri! $error"); false },
+      body => {
+        val parsedVersion = (Json.parse(body) \ "info" \ "version").get.as[String].trim
+        val checkResult   = parsedVersion == version
+        println(if (checkResult) "Passed" else s"""Failed! Expected "$version", but got "$parsedVersion"""")
+        checkResult
+      }
+    )
+  }
+
+  def checkState(): Unit = {
+    println(s"Checking")
+    val isStateCorrect = checkVersion()
+    println(s"\n${if (isStateCorrect) "Congratulations! DEX state is valid!" else "DEX state is INVALID!"}\n")
+  }
+
+//  def mkIssue(issuer: KeyPair,
+//              name: String,
+//              quantity: Long,
+//              decimals: Int = 8,
+//              fee: Long = issueFee,
+//              script: Option[ByteStr] = None,
+//              reissuable: Boolean = false,
+//              timestamp: Long = System.currentTimeMillis): IssueTransaction = {
+//    Transactions.makeIssueTx(issuer,
+//                             AddressScheme.current.chainId,
+//                             name,
+//                             s"$name asset",
+//                             quantity,
+//                             decimals.toByte,
+//                             reissuable,
+//                             script.map(_.base64).orNull,
+//                             fee,
+//                             timestamp)
+//  }
+
+}
+
+object Checker {
+  implicit class DoubleOps(private val value: Double) {
+    val wuJIo, mbIJIo, waves: Long = Normalization.normalizeAmountAndFee(value, 8)
+  }
+}

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/Checker.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/Checker.scala
@@ -4,12 +4,13 @@ import java.io.File
 
 import cats.instances.future._
 import cats.instances.list._
+import cats.syntax.either._
 import cats.syntax.traverse._
 import ch.qos.logback.classic.{Level, Logger}
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory._
 import com.wavesplatform.dex.db.AccountStorage
-import com.wavesplatform.dex.domain.account.AddressScheme
+import com.wavesplatform.dex.domain.account.{AddressScheme, KeyPair}
 import com.wavesplatform.dex.domain.asset.Asset
 import com.wavesplatform.dex.domain.asset.Asset.{IssuedAsset, Waves}
 import com.wavesplatform.dex.domain.model.{Denormalization, Normalization}
@@ -21,20 +22,23 @@ import com.wavesplatform.dex.grpc.integration.settings.GrpcClientSettings._
 import com.wavesplatform.dex.grpc.integration.settings.{GrpcClientSettings, WavesBlockchainClientSettings}
 import com.wavesplatform.dex.settings.MatcherSettings.valueReader
 import com.wavesplatform.dex.settings.{MatcherSettings, loadConfig}
-import com.wavesplatform.wavesj.transactions.IssueTransactionV2
+import com.wavesplatform.wavesj.json.WavesJsonMapper
 import com.wavesplatform.wavesj.{PrivateKeyAccount, Transactions}
 import monix.execution.Scheduler.Implicits.{global => monixScheduler}
 import net.ceedubs.ficus.Ficus._
 import org.slf4j.LoggerFactory
-import play.api.libs.json.Json
+import play.api.libs.json.jackson.PlayJsonModule
+import play.api.libs.json.{Json, JsonParserSettings}
 import sttp.client._
+import sttp.model.MediaType
 
+import scala.annotation.tailrec
 import scala.concurrent.ExecutionContext.Implicits.{global => executionContext}
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
 // noinspection ScalaStyle
-case class Checker(dexRestApi: String, nodeRestApiUri: String, version: String, dexConfigPath: String) {
+case class Checker(dexRestApi: String, nodeRestApi: String, version: String, dexConfigPath: String) {
 
   import Checker._
 
@@ -44,7 +48,7 @@ case class Checker(dexRestApi: String, nodeRestApiUri: String, version: String, 
     s"""
        |Passed arguments:
        |  DEX REST API         : $dexRestApi
-       |  WavesNode REST API   : $nodeRestApiUri
+       |  WavesNode REST API   : $nodeRestApi
        |  Expected DEX version : $version
        |  DEX config path      : $dexConfigPath
        """.stripMargin
@@ -52,15 +56,34 @@ case class Checker(dexRestApi: String, nodeRestApiUri: String, version: String, 
 
   private implicit val backend: SttpBackend[Identity, Nothing, NothingT] = HttpURLConnectionBackend()
 
+  type CheckResult[A] = Either[String, A]
+
+  private def denormalize(value: Long): Double = Denormalization.denormalizeAmountAndFee(value, 8).toDouble
+
+  private def check[A](name: String, doneOnSameLine: Boolean = true)(f: => CheckResult[A]): CheckResult[A] = {
+    if (doneOnSameLine) print(name) else println(name)
+    val res = f
+    val msg = res.fold(identity, { case () => "Done"; case s: String => s })
+    println(msg)
+    res
+  }
+
   print(s"Processing DEX config... ")
 
   private val config: Config              = parseFile(new File(dexConfigPath))
   private val settings: MatcherSettings   = loadConfig(config).as[MatcherSettings]("waves.dex")
-  private val matcherKeyPair              = AccountStorage.load(settings.accountStorage).map(_.keyPair).explicitGet()
-  private val dexRestApiUri: String       = s"http://${if (dexRestApi.nonEmpty) dexRestApi else s"${settings.restApi.address}:${settings.restApi.port}"}/"
+  private val matcherKeyPair: KeyPair     = AccountStorage.load(settings.accountStorage).map(_.keyPair).explicitGet()
   private val extensionGrpcApiUri: String = settings.wavesBlockchainClient.grpc.target
 
+  private val dexRestApiUri: String  = s"http://${if (dexRestApi.nonEmpty) dexRestApi else s"${settings.restApi.address}:${settings.restApi.port}"}"
+  private val nodeRestApiUri: String = s"http://${if (dexRestApi.nonEmpty) nodeRestApi else s"${extensionGrpcApiUri.dropRight(4) + 6869}"}"
+
   AddressScheme.current = new AddressScheme { override val chainId: Byte = settings.addressSchemeCharacter.toByte }
+
+  private val chainId: Byte = AddressScheme.current.chainId
+
+  private val matcherAccount: PrivateKeyAccount = PrivateKeyAccount.fromPrivateKey(matcherKeyPair.privateKey.base58, chainId)
+  private val mapper: WavesJsonMapper           = new WavesJsonMapper(chainId); mapper.registerModule(new PlayJsonModule(JsonParserSettings()))
 
   println("Done")
 
@@ -76,51 +99,55 @@ case class Checker(dexRestApi: String, nodeRestApiUri: String, version: String, 
   println(
     s"""
        |DEX configurations:
-       | Address scheme         : ${AddressScheme.current.chainId}
+       | Chain ID               : $chainId
        | Matcher public key     : ${matcherKeyPair.publicKey.toString}
        | Matcher address        : ${matcherKeyPair.publicKey.toAddress}
        | DEX REST API           : $dexRestApiUri
+       | Node REST API          : $nodeRestApiUri
        | DEX extension gRPC API : $extensionGrpcApiUri
        """.stripMargin
   )
 
-  private def mkIssueAssetTx(name: String, description: String, quantity: Long): IssueTransactionV2 = {
-    val matcherAccount = PrivateKeyAccount.fromPrivateKey(matcherKeyPair.privateKey.base58, AddressScheme.current.chainId)
-    Transactions.makeIssueTx(matcherAccount, AddressScheme.current.chainId, name, description, quantity, 8, false, null, 1.waves)
+  private def checkVersion(checkName: String): CheckResult[String] = check(s" $checkName ") {
+    basicRequest.get(uri"$dexRestApiUri/api-docs/swagger.json").send().body.flatMap { body =>
+      val parsedVersion = (Json.parse(body) \ "info" \ "version").get.as[String].trim
+      Either.cond(parsedVersion == version, "Passed", s"""Failed! Expected "$version", but got "$parsedVersion"""")
+    }
   }
 
-  private def issueTestAssets(): Unit = {
-    val mnogo       = 3000000
-    val issueAwlTx  = mkIssueAssetTx("IIIuJIo", "Awl for the Matcher checking purposes", mnogo.wuJIo)
-    val issueSoapTx = mkIssueAssetTx("MbIJIo", "Soap for the Matcher checking purposes", mnogo.mbIJIo)
-  }
+  private def issueTestAsset(name: String, description: String, quantity: Long): CheckResult[String] = {
 
-  private def checkVersion(): Boolean = {
-    print(s" 1. DEX version... ")
+    val tx           = Transactions.makeIssueTx(matcherAccount, chainId, name, description, quantity, testAssetDecimals, false, null, 1.waves)
+    val serializedTx = mapper writeValueAsString tx
 
-    val uri      = uri"$dexRestApiUri/api-docs/swagger.json"
-    val request  = basicRequest.get(uri)
-    val response = request.send().body
+    def broadcastRequest = basicRequest.post(uri"$nodeRestApiUri/transactions/broadcast").body(serializedTx).contentType(MediaType.ApplicationJson)
+    def txInfoRequest    = basicRequest.get(uri"$nodeRestApiUri/transactions/info/${tx.getId.toString}")
 
-    response.fold(
-      error => { println(s"Cannot parse $uri! $error"); false },
-      body => {
-        val parsedVersion = (Json.parse(body) \ "info" \ "version").get.as[String].trim
-        val checkResult   = parsedVersion == version
-        println(if (checkResult) "Passed" else s"""Failed! Expected "$version", but got "$parsedVersion"""")
-        checkResult
+    @tailrec
+    def repeatRequest(attemptsLeft: Int, delay: FiniteDuration)(sendRequest: => Either[String, String],
+                                                                test: Either[String, String] => Boolean): Either[String, String] = {
+      if (attemptsLeft == 0) "All attempts are out!".asLeft
+      else {
+        val response = sendRequest
+        if (test(response)) response
+        else {
+          Thread.sleep(delay.toMillis)
+          repeatRequest(attemptsLeft - 1, delay)(sendRequest, test)
+        }
       }
-    )
+    }
+
+    for {
+      _ <- { print(s"Issuing ${denormalize(quantity)} $name... "); broadcastRequest.send().body.leftMap(ex => s"Cannot broadcast transaction! $ex") }
+      _ <- { print(s"Awaiting tx in blockchain... "); repeatRequest(10, 1.second)(txInfoRequest.send().body, _.isRight) }
+    } yield "Issued!"
   }
 
-  private def checkTestAssets(): Boolean = {
-    println(s" 2. Test assets existence")
+  private def checkTestAssets(checkName: String): CheckResult[String] = check(s" $checkName ", doneOnSameLine = false) {
 
-    def getDetailedBalance(asset: Asset, balance: Long): Future[(Asset, (BriefAssetDescription, Long))] = {
-      asset match {
-        case Waves           => Future.successful(asset -> (BriefAssetDescription.wavesDescription -> balance))
-        case ia: IssuedAsset => grpcAsyncClient.assetDescription(ia).map(maybeDesc => ia -> (maybeDesc.get -> balance))
-      }
+    def getDetailedBalance(asset: Asset, balance: Long): Future[(Asset, (BriefAssetDescription, Long))] = asset match {
+      case Waves           => Future.successful(asset -> (BriefAssetDescription.wavesDescription -> balance))
+      case ia: IssuedAsset => grpcAsyncClient.assetDescription(ia).map(maybeDesc => ia -> (maybeDesc.get -> balance))
     }
 
     val matcherBalance =
@@ -132,25 +159,34 @@ case class Checker(dexRestApi: String, nodeRestApiUri: String, version: String, 
         10.seconds
       )
 
-    def checkAssetExistence(name: String): Boolean = {
-      matcherBalance.find(_._2._1.name == name).fold { println("Not found"); false } {
-        case (a, (d, b)) =>
-          val denormalizedBalance = Denormalization.denormalizeAmountAndFee(b, 8)
-          println(s"Found, name = ${d.name}, id = ${a.toString}, balance = $denormalizedBalance")
-          true
-      }
+    def findOrIssue(checkName: String, assetName: String, description: String, quantity: Long): CheckResult[String] = check(checkName) {
+      matcherBalance
+        .find(_._2._1.name == assetName)
+        .fold { print(s"not found. "); issueTestAsset(assetName, description, quantity) } {
+          case (a, (d, b)) => s"found, name = ${d.name}, id = ${a.toString}, balance = ${denormalize(b)}".asRight
+        }
     }
 
-    print(s"   2.1 Amount asset... "); val amountAssetResult = checkAssetExistence(testAmountAssetName)
-    print(s"   2.2 Price asset... "); val priceAssetResult   = checkAssetExistence(testPriceAssetName)
-
-    amountAssetResult && priceAssetResult
+    for {
+      _ <- findOrIssue("  - Amount asset ", testAmountAssetName, testAmountAssetDescription, mnogo.wuJIo)
+      _ <- findOrIssue("  - Price asset ", testPriceAssetName, testPriceAssetDescription, mnogo.mbIJIo)
+    } yield "    Passed"
   }
 
   def checkState(): Unit = {
     println(s"Checking")
-    val isStateCorrect = checkVersion() && checkTestAssets()
-    println(s"\n${if (isStateCorrect) "Congratulations! DEX state is valid!" else "DEX state is INVALID!"}\n")
+
+    val checkResult =
+      for {
+        _ <- checkVersion("1. DEX version...")
+        _ <- checkTestAssets("2. Test assets existence...")
+      } yield ()
+
+    checkResult match {
+      case Right(_) => println("\nCongratulations! DEX state is valid!")
+      case Left(_)  => println(s"\nDEX state is INVALID!")
+    }
+
     grpcAsyncClient.close()
   }
 }
@@ -158,7 +194,13 @@ case class Checker(dexRestApi: String, nodeRestApiUri: String, version: String, 
 object Checker {
 
   private val testAmountAssetName = "IIIuJIo"
-  private val testPriceAssetName  = "MbIJo"
+  private val testPriceAssetName  = "MbIJIo"
+
+  private val testAmountAssetDescription = "Amount asset for the Matcher checking purposes"
+  private val testPriceAssetDescription  = "Price asset for the Matcher checking purposes"
+
+  private val mnogo             = 100000000L
+  private val testAssetDecimals = 8.toByte
 
   implicit class DoubleOps(private val value: Double) {
     val wuJIo, mbIJIo, waves: Long = Normalization.normalizeAmountAndFee(value, 8)

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/Connector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/Connector.scala
@@ -1,6 +1,5 @@
 package com.wavesplatform.dex.tool.connectors
 
-trait Connector {
+trait Connector extends AutoCloseable {
   val target: String
-  def close(): Unit
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/Connector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/Connector.scala
@@ -1,0 +1,6 @@
+package com.wavesplatform.dex.tool.connectors
+
+trait Connector {
+  val target: String
+  def close(): Unit
+}

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/DexExtensionGrpcConnector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/DexExtensionGrpcConnector.scala
@@ -2,9 +2,10 @@ package com.wavesplatform.dex.tool.connectors
 
 import cats.instances.future._
 import cats.instances.list._
+import cats.syntax.either._
 import cats.syntax.traverse._
 import ch.qos.logback.classic.{Level, Logger}
-import com.wavesplatform.dex.domain.account.KeyPair
+import com.wavesplatform.dex.domain.account.Address
 import com.wavesplatform.dex.domain.asset.Asset
 import com.wavesplatform.dex.domain.asset.Asset.{IssuedAsset, Waves}
 import com.wavesplatform.dex.grpc.integration.WavesBlockchainClientBuilder
@@ -12,25 +13,18 @@ import com.wavesplatform.dex.grpc.integration.clients.WavesBlockchainClient
 import com.wavesplatform.dex.grpc.integration.dto.BriefAssetDescription
 import com.wavesplatform.dex.grpc.integration.settings.GrpcClientSettings.ChannelOptionsSettings
 import com.wavesplatform.dex.grpc.integration.settings.{GrpcClientSettings, WavesBlockchainClientSettings}
-import com.wavesplatform.dex.tool.connectors.SuperConnector.wrapByLogs
+import com.wavesplatform.dex.tool.ErrorOr
 import monix.execution.Scheduler.Implicits.{global => monixScheduler}
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.ExecutionContext.Implicits.{global => executionContext}
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Awaitable, Future}
+import scala.util.Try
 
-private[tool] case class DexExtensionGrpcConnector(target: String, matcherKeyPair: KeyPair) extends Connector {
+case class DexExtensionGrpcConnector private (target: String, grpcAsyncClient: WavesBlockchainClient[Future]) extends Connector {
 
   import DexExtensionGrpcConnector._
-
-  LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME).asInstanceOf[Logger].setLevel(Level.OFF)
-
-  private val grpcAsyncClient: WavesBlockchainClient[Future] = wrapByLogs("Establishing gRPC connection to DEX extension... ") {
-    val grpcSettings   = GrpcClientSettings(target, 5, 5, true, 2.seconds, 5.seconds, 1.minute, ChannelOptionsSettings(5.seconds))
-    val clientSettings = WavesBlockchainClientSettings(grpcSettings, 100.milliseconds, 100)
-    WavesBlockchainClientBuilder.async(clientSettings, monixScheduler, executionContext)
-  }
 
   private def sync[A](f: Awaitable[A]): A = Await.result(f, requestTimeout)
 
@@ -39,13 +33,13 @@ private[tool] case class DexExtensionGrpcConnector(target: String, matcherKeyPai
     case ia: IssuedAsset => grpcAsyncClient.assetDescription(ia).map(maybeDesc => ia -> (maybeDesc.get -> balance))
   }
 
-  def matcherBalanceAsync: Future[DetailedBalance] =
+  def matcherBalanceAsync(address: Address): Future[DetailedBalance] =
     for {
-      balances                <- grpcAsyncClient.allAssetsSpendableBalance(matcherKeyPair.toAddress)
+      balances                <- grpcAsyncClient.allAssetsSpendableBalance(address)
       balancesWithDescription <- balances.toList.traverse { case (a, b) => getDetailedBalance(a, b) }
     } yield balancesWithDescription.toMap
 
-  def matcherBalanceSync: DetailedBalance = sync(matcherBalanceAsync)
+  def matcherBalanceSync(address: Address): DetailedBalance = sync { matcherBalanceAsync(address) }
 
   override def close(): Unit = grpcAsyncClient.close()
 }
@@ -55,4 +49,14 @@ object DexExtensionGrpcConnector {
   val requestTimeout: FiniteDuration = 10.seconds
 
   type DetailedBalance = Map[Asset, (BriefAssetDescription, Long)]
+
+  def create(target: String): ErrorOr[DexExtensionGrpcConnector] =
+    Try {
+      LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME).asInstanceOf[Logger].setLevel(Level.OFF)
+      val grpcSettings   = GrpcClientSettings(target, 5, 5, true, 2.seconds, 5.seconds, 1.minute, ChannelOptionsSettings(5.seconds))
+      val clientSettings = WavesBlockchainClientSettings(grpcSettings, 100.milliseconds, 100)
+      WavesBlockchainClientBuilder.async(clientSettings, monixScheduler, executionContext)
+    }.toEither
+      .leftMap(ex => s"Cannot establish gRPC connection to DEX Extension! $ex")
+      .map(client => DexExtensionGrpcConnector(target, client))
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/DexGrpcConnector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/DexGrpcConnector.scala
@@ -1,0 +1,47 @@
+package com.wavesplatform.dex.tool.connectors
+
+import cats.instances.future._
+import cats.instances.list._
+import cats.syntax.traverse._
+import ch.qos.logback.classic.{Level, Logger}
+import com.wavesplatform.dex.domain.account.KeyPair
+import com.wavesplatform.dex.domain.asset.Asset
+import com.wavesplatform.dex.domain.asset.Asset.{IssuedAsset, Waves}
+import com.wavesplatform.dex.grpc.integration.WavesBlockchainClientBuilder
+import com.wavesplatform.dex.grpc.integration.clients.WavesBlockchainClient
+import com.wavesplatform.dex.grpc.integration.dto.BriefAssetDescription
+import com.wavesplatform.dex.grpc.integration.settings.GrpcClientSettings.ChannelOptionsSettings
+import com.wavesplatform.dex.grpc.integration.settings.{GrpcClientSettings, WavesBlockchainClientSettings}
+import com.wavesplatform.dex.tool.connectors.SuperConnector.wrapByLogs
+import monix.execution.Scheduler.Implicits.{global => monixScheduler}
+import org.slf4j.LoggerFactory
+
+import scala.concurrent.ExecutionContext.Implicits.{global => executionContext}
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
+
+private[tool] case class DexGrpcConnector(target: String, matcherKeyPair: KeyPair) extends Connector {
+
+  LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME).asInstanceOf[Logger].setLevel(Level.OFF)
+
+  private val grpcAsyncClient: WavesBlockchainClient[Future] = wrapByLogs("Establishing gRPC connection to DEX extension... ") {
+    val grpcSettings   = GrpcClientSettings(target, 5, 5, true, 2.seconds, 5.seconds, 1.minute, ChannelOptionsSettings(5.seconds))
+    val clientSettings = WavesBlockchainClientSettings(grpcSettings, 100.milliseconds, 100)
+    WavesBlockchainClientBuilder.async(clientSettings, monixScheduler, executionContext)
+  }
+
+  private def getDetailedBalance(asset: Asset, balance: Long): Future[(Asset, (BriefAssetDescription, Long))] = asset match {
+    case Waves           => Future.successful(asset -> (BriefAssetDescription.wavesDescription -> balance))
+    case ia: IssuedAsset => grpcAsyncClient.assetDescription(ia).map(maybeDesc => ia -> (maybeDesc.get -> balance))
+  }
+
+  def matcherBalance: Map[Asset, (BriefAssetDescription, Long)] = Await.result(
+    for {
+      balances                <- grpcAsyncClient.allAssetsSpendableBalance(matcherKeyPair.toAddress)
+      balancesWithDescription <- balances.toList.traverse { case (a, b) => getDetailedBalance(a, b) }
+    } yield balancesWithDescription.toMap,
+    10.seconds
+  )
+
+  override def close(): Unit = grpcAsyncClient.close()
+}

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/DexRestConnector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/DexRestConnector.scala
@@ -1,0 +1,7 @@
+package com.wavesplatform.dex.tool.connectors
+
+import sttp.client._
+
+private[tool] case class DexRestConnector(target: String) extends RestConnector {
+  def swaggerRequest: Identity[Response[Either[String, String]]] = basicRequest.get(uri"$target/api-docs/swagger.json").send()
+}

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/DexRestConnector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/DexRestConnector.scala
@@ -5,7 +5,8 @@ import com.wavesplatform.dex.domain.account.KeyPair
 import com.wavesplatform.dex.domain.bytes.ByteStr
 import com.wavesplatform.dex.domain.crypto
 import com.wavesplatform.dex.domain.order.Order
-import play.api.libs.json.Json
+import com.wavesplatform.dex.tool.connectors.RestConnector.{ErrorOr, ErrorOrJsonResponse}
+import play.api.libs.json.{JsValue, Json}
 import sttp.client._
 import sttp.model.MediaType
 
@@ -13,29 +14,34 @@ private[tool] case class DexRestConnector(target: String) extends RestConnector 
 
   private val apiUri = s"$target/matcher"
 
-  def swaggerRequest: Identity[Response[Either[String, String]]] = basicRequest.get(uri"$target/api-docs/swagger.json").send()
-
-  def placeOrder(order: Order): Identity[Response[Either[String, String]]] =
-    basicRequest.post(uri"$apiUri/orderbook").body(order.jsonStr).contentType(MediaType.ApplicationJson).send()
-
-  def cancelOrder(order: Order, owner: KeyPair): Identity[Response[Either[String, String]]] = {
-
-    val cancelOrderRequest = mkCancelRequest(order, owner)
-    val body               = Json.stringify(Json.toJson(cancelOrderRequest))
-
-    basicRequest
-      .post(uri"$apiUri/orderbook/${order.assetPair.amountAsset}/${order.assetPair.priceAsset}/cancel")
-      .body(body)
-      .contentType(MediaType.ApplicationJson)
-      .send()
-  }
-
-  def getOrderStatus(order: Order): Identity[Response[Either[String, String]]] =
-    basicRequest.get(uri"$apiUri/orderbook/${order.assetPair.amountAsset}/${order.assetPair.priceAsset}/${order.id()}").send()
-
   private def mkCancelRequest(order: Order, owner: KeyPair): CancelOrderRequest = {
     val cancelRequest = CancelOrderRequest(owner, Some(ByteStr.decodeBase58(order.id().toString).get), None, Array.emptyByteArray)
     val signature     = crypto.sign(owner, cancelRequest.toSign)
     cancelRequest.copy(signature = signature)
   }
+
+  def swaggerRequest: ErrorOrJsonResponse = mkResponse { _.get(uri"$target/api-docs/swagger.json") }
+
+  def placeOrder(order: Order): ErrorOrJsonResponse = mkResponse {
+    _.post(uri"$apiUri/orderbook").body(order.jsonStr).contentType(MediaType.ApplicationJson)
+  }
+
+  def cancelOrder(order: Order, owner: KeyPair): ErrorOrJsonResponse = {
+    val cancelOrderRequest = mkCancelRequest(order, owner)
+    val body               = Json.stringify(Json toJson cancelOrderRequest)
+    mkResponse {
+      _.post(uri"$apiUri/orderbook/${order.assetPair.amountAsset}/${order.assetPair.priceAsset}/cancel")
+        .body(body)
+        .contentType(MediaType.ApplicationJson)
+    }
+  }
+
+  def getOrderStatus(order: Order): ErrorOrJsonResponse = mkResponse {
+    _.get(uri"$apiUri/orderbook/${order.assetPair.amountAsset}/${order.assetPair.priceAsset}/${order.id()}")
+  }
+
+  def getTxsByOrderId(id: Order.Id): ErrorOr[Seq[JsValue]] = mkResponse { _.get(uri"$apiUri/transactions/$id") } map { _.as[Seq[JsValue]] }
+
+  def waitForOrderStatus(order: Order, expectedStatusName: String): ErrorOrJsonResponse =
+    repeatRequest { getOrderStatus(order) } { _.map(json => (json \ "status").get.asOpt[String] contains expectedStatusName).getOrElse(false) }
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/DexRestConnector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/DexRestConnector.scala
@@ -1,7 +1,41 @@
 package com.wavesplatform.dex.tool.connectors
 
+import com.wavesplatform.dex.api.CancelOrderRequest
+import com.wavesplatform.dex.domain.account.KeyPair
+import com.wavesplatform.dex.domain.bytes.ByteStr
+import com.wavesplatform.dex.domain.crypto
+import com.wavesplatform.dex.domain.order.Order
+import play.api.libs.json.Json
 import sttp.client._
+import sttp.model.MediaType
 
 private[tool] case class DexRestConnector(target: String) extends RestConnector {
+
+  private val apiUri = s"$target/matcher"
+
   def swaggerRequest: Identity[Response[Either[String, String]]] = basicRequest.get(uri"$target/api-docs/swagger.json").send()
+
+  def placeOrder(order: Order): Identity[Response[Either[String, String]]] =
+    basicRequest.post(uri"$apiUri/orderbook").body(order.jsonStr).contentType(MediaType.ApplicationJson).send()
+
+  def cancelOrder(order: Order, owner: KeyPair): Identity[Response[Either[String, String]]] = {
+
+    val cancelOrderRequest = mkCancelRequest(order, owner)
+    val body               = Json.stringify(Json.toJson(cancelOrderRequest))
+
+    basicRequest
+      .post(uri"$apiUri/orderbook/${order.assetPair.amountAsset}/${order.assetPair.priceAsset}/cancel")
+      .body(body)
+      .contentType(MediaType.ApplicationJson)
+      .send()
+  }
+
+  def getOrderStatus(order: Order): Identity[Response[Either[String, String]]] =
+    basicRequest.get(uri"$apiUri/orderbook/${order.assetPair.amountAsset}/${order.assetPair.priceAsset}/${order.id()}").send()
+
+  private def mkCancelRequest(order: Order, owner: KeyPair): CancelOrderRequest = {
+    val cancelRequest = CancelOrderRequest(owner, Some(ByteStr.decodeBase58(order.id().toString).get), None, Array.emptyByteArray)
+    val signature     = crypto.sign(owner, cancelRequest.toSign)
+    cancelRequest.copy(signature = signature)
+  }
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/NodeRestConnector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/NodeRestConnector.scala
@@ -1,6 +1,6 @@
 package com.wavesplatform.dex.tool.connectors
 
-import com.wavesplatform.dex.tool.connectors.RestConnector.ErrorOrJsonResponse
+import com.wavesplatform.dex.tool.connectors.RestConnector.{ErrorOrJsonResponse, RepeatRequestOptions}
 import com.wavesplatform.wavesj.Transaction
 import com.wavesplatform.wavesj.json.WavesJsonMapper
 import play.api.libs.json.jackson.PlayJsonModule
@@ -8,7 +8,9 @@ import play.api.libs.json.{JsValue, JsonParserSettings}
 import sttp.client._
 import sttp.model.MediaType
 
-private[tool] case class NodeRestConnector(target: String, chainId: Byte) extends RestConnector {
+import scala.concurrent.duration._
+
+case class NodeRestConnector(target: String, chainId: Byte) extends RestConnector {
 
   private val mapper: WavesJsonMapper = new WavesJsonMapper(chainId); mapper.registerModule(new PlayJsonModule(JsonParserSettings()))
 
@@ -19,4 +21,6 @@ private[tool] case class NodeRestConnector(target: String, chainId: Byte) extend
   def getTxInfo(txId: String): ErrorOrJsonResponse    = mkResponse { _.get(uri"$target/transactions/info/$txId") }
   def getTxInfo(tx: JsValue): ErrorOrJsonResponse     = getTxInfo { (tx \ "id").as[String] }
   def getTxInfo(tx: Transaction): ErrorOrJsonResponse = getTxInfo(tx.getId.toString)
+
+  override val repeatRequestOptions: RestConnector.RepeatRequestOptions = RepeatRequestOptions(30, 1.second)
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/NodeRestConnector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/NodeRestConnector.scala
@@ -1,0 +1,22 @@
+package com.wavesplatform.dex.tool.connectors
+
+import com.wavesplatform.wavesj.Transaction
+import com.wavesplatform.wavesj.json.WavesJsonMapper
+import play.api.libs.json.JsonParserSettings
+import play.api.libs.json.jackson.PlayJsonModule
+import sttp.client._
+import sttp.model.MediaType
+
+private[tool] case class NodeRestConnector(target: String, chainId: Byte) extends RestConnector {
+
+  private val mapper: WavesJsonMapper = new WavesJsonMapper(chainId); mapper.registerModule(new PlayJsonModule(JsonParserSettings()))
+
+  def broadcastTx(tx: Transaction): Identity[Response[Either[String, String]]] = {
+    val serializedTx = mapper writeValueAsString tx
+    basicRequest.post(uri"$target/transactions/broadcast").body(serializedTx).contentType(MediaType.ApplicationJson).send()
+  }
+
+  def txInfo(tx: Transaction): Identity[Response[Either[String, String]]] = {
+    basicRequest.get(uri"$target/transactions/info/${tx.getId.toString}").send()
+  }
+}

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/NodeRestConnector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/NodeRestConnector.scala
@@ -16,7 +16,6 @@ private[tool] case class NodeRestConnector(target: String, chainId: Byte) extend
     basicRequest.post(uri"$target/transactions/broadcast").body(serializedTx).contentType(MediaType.ApplicationJson).send()
   }
 
-  def txInfo(tx: Transaction): Identity[Response[Either[String, String]]] = {
+  def txInfo(tx: Transaction): Identity[Response[Either[String, String]]] =
     basicRequest.get(uri"$target/transactions/info/${tx.getId.toString}").send()
-  }
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/RestConnector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/RestConnector.scala
@@ -1,0 +1,29 @@
+package com.wavesplatform.dex.tool.connectors
+
+import cats.syntax.either._
+import sttp.client.{HttpURLConnectionBackend, Identity, NothingT, SttpBackend}
+
+import scala.annotation.tailrec
+import scala.concurrent.duration.FiniteDuration
+
+trait RestConnector extends Connector {
+  implicit val backend: SttpBackend[Identity, Nothing, NothingT] = HttpURLConnectionBackend()
+  override def close(): Unit                                     = backend.close()
+}
+
+object RestConnector {
+
+  @tailrec
+  def repeatRequest(attemptsLeft: Int, delay: FiniteDuration)(sendRequest: => Either[String, String],
+                                                              test: Either[String, String] => Boolean): Either[String, String] = {
+    if (attemptsLeft == 0) "All attempts are out!".asLeft
+    else {
+      val response = sendRequest
+      if (test(response)) response
+      else {
+        Thread.sleep(delay.toMillis)
+        repeatRequest(attemptsLeft - 1, delay)(sendRequest, test)
+      }
+    }
+  }
+}

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/SuperConnector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/SuperConnector.scala
@@ -12,7 +12,8 @@ import com.wavesplatform.dex.tool.connectors.SuperConnector.Env
 import mouse.any._
 import net.ceedubs.ficus.Ficus._
 
-case class SuperConnector private (env: Env, dexRest: DexRestConnector, nodeRest: NodeRestConnector, dexExtensionGrpc: DexExtensionGrpcConnector) {
+case class SuperConnector private (env: Env, dexRest: DexRestConnector, nodeRest: NodeRestConnector, dexExtensionGrpc: DexExtensionGrpcConnector)
+    extends AutoCloseable {
   def close(): Unit = Seq(nodeRest, dexRest, dexExtensionGrpc).foreach { _.close() }
 }
 

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/SuperConnector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/SuperConnector.scala
@@ -12,8 +12,8 @@ import com.wavesplatform.dex.tool.connectors.SuperConnector.Env
 import mouse.any._
 import net.ceedubs.ficus.Ficus._
 
-case class SuperConnector private (env: Env, dexRest: DexRestConnector, nodeRest: NodeRestConnector, dexGrpc: DexGrpcConnector) {
-  def close(): Unit = Seq(nodeRest, dexRest, dexGrpc).foreach { _.close() }
+case class SuperConnector private (env: Env, dexRest: DexRestConnector, nodeRest: NodeRestConnector, dexExtensionGrpc: DexExtensionGrpcConnector) {
+  def close(): Unit = Seq(nodeRest, dexRest, dexExtensionGrpc).foreach { _.close() }
 }
 
 // noinspection ScalaStyle
@@ -44,17 +44,17 @@ object SuperConnector {
       Env(chainId, matcherSettings, matcherKeyPair),
       DexRestConnector(dexRestApiUri),
       NodeRestConnector(nodeRestApiUri, chainId),
-      DexGrpcConnector(extensionGrpcApiUri, matcherKeyPair)
+      DexExtensionGrpcConnector(extensionGrpcApiUri, matcherKeyPair)
     ) unsafeTap { _ =>
       println(
         s"""
            |DEX configurations:
-           | Chain ID               : $chainId
-           | Matcher public key     : ${matcherKeyPair.publicKey.toString}
-           | Matcher address        : ${matcherKeyPair.publicKey.toAddress}
-           | DEX REST API           : $dexRestApiUri
-           | Node REST API          : $nodeRestApiUri
-           | DEX extension gRPC API : $extensionGrpcApiUri
+           |  Chain ID               : $chainId
+           |  Matcher public key     : ${matcherKeyPair.publicKey.toString}
+           |  Matcher address        : ${matcherKeyPair.publicKey.toAddress}
+           |  DEX REST API           : $dexRestApiUri
+           |  Node REST API          : $nodeRestApiUri
+           |  DEX extension gRPC API : $extensionGrpcApiUri
        """.stripMargin
       )
     }

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/SuperConnector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/SuperConnector.scala
@@ -1,0 +1,62 @@
+package com.wavesplatform.dex.tool.connectors
+
+import java.io.File
+
+import com.typesafe.config.ConfigFactory._
+import com.wavesplatform.dex.db.AccountStorage
+import com.wavesplatform.dex.domain.account.{AddressScheme, KeyPair}
+import com.wavesplatform.dex.domain.utils.EitherExt2
+import com.wavesplatform.dex.settings.MatcherSettings.valueReader
+import com.wavesplatform.dex.settings.{MatcherSettings, loadConfig}
+import com.wavesplatform.dex.tool.connectors.SuperConnector.Env
+import mouse.any._
+import net.ceedubs.ficus.Ficus._
+
+case class SuperConnector private (env: Env, dexRest: DexRestConnector, nodeRest: NodeRestConnector, dexGrpc: DexGrpcConnector) {
+  def close(): Unit = Seq(nodeRest, dexRest, dexGrpc).foreach { _.close() }
+}
+
+// noinspection ScalaStyle
+object SuperConnector {
+
+  private[tool] final case class Env(chainId: Byte, matcherSettings: MatcherSettings, matcherKeyPair: KeyPair)
+
+  def wrapByLogs[T](begin: String, end: String = "Done")(f: => T): T = { print(begin); val result = f; println(end); result }
+
+  def create(dexConfigPath: String, dexRestApi: String, nodeRestApi: String): SuperConnector = {
+
+    val matcherSettings: MatcherSettings = wrapByLogs("Processing DEX config... ") {
+      loadConfig { parseFile(new File(dexConfigPath)) }.as[MatcherSettings]("waves.dex")
+    }
+
+    import matcherSettings._
+
+    AddressScheme.current = new AddressScheme { override val chainId: Byte = matcherSettings.addressSchemeCharacter.toByte }
+
+    val chainId: Byte           = AddressScheme.current.chainId
+    val matcherKeyPair: KeyPair = AccountStorage.load(matcherSettings.accountStorage).map(_.keyPair).explicitGet()
+
+    val extensionGrpcApiUri: String = wavesBlockchainClient.grpc.target
+    val dexRestApiUri: String       = s"http://${if (dexRestApi.nonEmpty) dexRestApi else s"${restApi.address}:${restApi.port}"}"
+    val nodeRestApiUri: String      = s"http://${if (dexRestApi.nonEmpty) nodeRestApi else s"${extensionGrpcApiUri.dropRight(4) + 6869}"}"
+
+    SuperConnector(
+      Env(chainId, matcherSettings, matcherKeyPair),
+      DexRestConnector(dexRestApiUri),
+      NodeRestConnector(nodeRestApiUri, chainId),
+      DexGrpcConnector(extensionGrpcApiUri, matcherKeyPair)
+    ) unsafeTap { _ =>
+      println(
+        s"""
+           |DEX configurations:
+           | Chain ID               : $chainId
+           | Matcher public key     : ${matcherKeyPair.publicKey.toString}
+           | Matcher address        : ${matcherKeyPair.publicKey.toAddress}
+           | DEX REST API           : $dexRestApiUri
+           | Node REST API          : $nodeRestApiUri
+           | DEX extension gRPC API : $extensionGrpcApiUri
+       """.stripMargin
+      )
+    }
+  }
+}

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/SuperConnector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/SuperConnector.scala
@@ -30,12 +30,7 @@ object SuperConnector {
 
   def create(dexConfigPath: String, nodeRestApi: String): ErrorOr[SuperConnector] = {
 
-    def logProcessing[A](processing: String)(f: => ErrorOr[A]): ErrorOr[A] =
-      for {
-        _      <- log(s"  $processing... ", processLeftIndent.some)
-        result <- f
-        _      <- log("Done\n")
-      } yield result
+    def logProcessing[A](processing: String)(f: => ErrorOr[A]): ErrorOr[A] = wrapByLogs(f)(s"  $processing... ", "Done\n", processLeftIndent.some)
 
     def loadMatcherSettings(confPath: String): ErrorOr[MatcherSettings] =
       Try {

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/package.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/package.scala
@@ -13,4 +13,11 @@ package object tool {
       print(log + " " * (i - log.length))
     }
   }
+
+  def wrapByLogs[A](f: => ErrorOr[A])(begin: String, end: String, indent: Option[Int] = None): ErrorOr[A] =
+    for {
+      _      <- log(begin, indent)
+      result <- f
+      _      <- log(end)
+    } yield result
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/package.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/package.scala
@@ -1,0 +1,16 @@
+package com.wavesplatform.dex
+
+import cats.syntax.either._
+
+package object tool {
+
+  type ErrorOr[A] = Either[String, A]
+
+  def lift[A](a: A): ErrorOr[A] = a.asRight
+
+  def log(log: String, indent: Option[Int] = None): ErrorOr[Unit] = lift {
+    indent.fold { print(log) } { i =>
+      print(log + " " * (i - log.length))
+    }
+  }
+}

--- a/dex/src/main/scala/com/wavesplatform/dex/util/ApplicationStopReason.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/util/ApplicationStopReason.scala
@@ -1,7 +1,8 @@
 package com.wavesplatform.dex.util
 
 sealed abstract class ApplicationStopReason(val code: Int)
-case object StartingMatcherError    extends ApplicationStopReason(10)
-case object RecoveryError           extends ApplicationStopReason(12)
-case object EventProcessingError    extends ApplicationStopReason(16)
-case object UnsynchronizedNodeError extends ApplicationStopReason(18)
+case object StartingMatcherError            extends ApplicationStopReason(10)
+case object RecoveryError                   extends ApplicationStopReason(12)
+case object EventProcessingError            extends ApplicationStopReason(16)
+case object UnsynchronizedNodeError         extends ApplicationStopReason(18)
+case object MatcherStateCheckingFailedError extends ApplicationStopReason(20)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -227,7 +227,8 @@ object Dependencies {
       jwtModule("core"),
       jwtModule("play-json"),
       sttpClient,
-      wavesJ
+      wavesJ,
+      betterMonadicFor
     ) ++ testKit ++ quill ++ silencer ++ monocle
 
     lazy val dexIt: Seq[ModuleID] = integrationTestKit

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -43,7 +43,8 @@ object Dependencies {
     val postgresql = "42.2.9"
     val quillJdbc  = "3.5.0"
 
-    val sttp = "1.7.2"
+    val sttp       = "1.7.2"
+    val sttpClient = "2.1.1"
 
     val testContainers          = "0.35.2"
     val testContainersPostgres  = "1.12.5"
@@ -132,6 +133,7 @@ object Dependencies {
   private val jniLevelDb    = "org.ethereum" % "leveldbjni-all" % Version.jniLevelDb
   private val influxDb      = "org.influxdb" % "influxdb-java" % Version.influxDb
   private val commonsNet    = "commons-net" % "commons-net" % Version.commonsNet
+  private val sttpClient    = "com.softwaremill.sttp.client" %% "core" % Version.sttpClient
 
   private val monocle: Seq[ModuleID] = Seq(
     "com.github.julien-truffaut" %% "monocle-core"  % Version.monocle,
@@ -223,7 +225,9 @@ object Dependencies {
       commonsNet,
       swaggerUi,
       jwtModule("core"),
-      jwtModule("play-json")
+      jwtModule("play-json"),
+      sttpClient,
+      wavesJ
     ) ++ testKit ++ quill ++ silencer ++ monocle
 
     lazy val dexIt: Seq[ModuleID] = integrationTestKit


### PR DESCRIPTION
Checker for testing DEX state after update via Waves DEX CLI `check-server` command

Concept:
  * There are two main components:
    1. SuperConnector, is used for connection to REST/gRPC/... APIs of DEX/Node. Can be easily enriched by another connectors. Currently it includes few connectors: `DexRestConnector`, `NodeRestConnector` and `DexExtensionGrpcConnector`;
    2. Checker, contains logic of DEX state testing by means of superConnector methods and own ones
 * Creation of the SuperConnector and checks are written in fail-fast, pretty FP style;
 * All REST methods of connectors are basically the same as in IT module. Main difference is that in this tool we don't parse received Jsons into domain entities and use these Jsons as is;

This tool was tested with the docker containers from IT module