### PR TITLE
DEX-634 Test kit improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ waves.dex.rest-api.api-key-hash = "7L6GpLHhA5KyJTAVc8WFHwEcyTY8fC8rRbyMCiFnM4i"
 5. IDE can't find Waves Node's classes in `waves-ext`. Download required artifacts manually: `sbt waves-ext/downloadWavesNodeArtifacts` and 
    then reload SBT configuration in IDE.
 
-6. If you want to run integration tests with Kafka, run the command in sbt before: `set `dex-it`/Test/envVars := Map("KAFKA_SERVER" -> "kafka-host:9092")`
+6. If you want to run integration tests with Kafka, run the command in sbt before: ```set `dex-it`/Test/envVars := Map("KAFKA_SERVER" -> "kafka-host:9092")```
 
 ## 10. Production recommendations
 

--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/HasKafka.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/HasKafka.scala
@@ -1,0 +1,35 @@
+package com.wavesplatform.dex.it.api
+
+import java.util.concurrent.ThreadLocalRandom
+
+import com.dimafeng.testcontainers.KafkaContainer
+import com.typesafe.config.{Config, ConfigFactory}
+
+trait HasKafka { self: BaseContainersKit =>
+
+  protected val kafkaContainerName = s"$networkName-kafka"
+
+  protected val kafkaIp = getIp(12)
+
+  protected def dexKafkaConfig(topic: String = ThreadLocalRandom.current.nextInt(0, Int.MaxValue).toString): Config = ConfigFactory.parseString(
+    s"""waves.dex.events-queue {
+       |  type = kafka
+       |  kafka {
+       |    servers = "$kafkaIp:9092"
+       |    topic = "$topic"
+       |  }
+       |}""".stripMargin
+  )
+
+  protected val kafka: KafkaContainer =
+    KafkaContainer().configure { k =>
+      k.withNetwork(network)
+      k.withNetworkAliases(kafkaContainerName)
+      k.withCreateContainerCmdModifier { cmd =>
+        cmd withName kafkaContainerName
+        cmd withIpv4Address getIp(12)
+      }
+    }
+
+  kafka.start()
+}

--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/node/HasWavesNode.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/node/HasWavesNode.scala
@@ -20,8 +20,10 @@ trait HasWavesNode { self: BaseContainersKit =>
 
   protected def createWavesNode(name: String,
                                 runConfig: Config = wavesNodeRunConfig,
-                                suiteInitialConfig: Config = wavesNodeInitialSuiteConfig): WavesNodeContainer =
-    WavesNodeContainer(name, networkName, network, getIp(name), runConfig, suiteInitialConfig, localLogsDir) unsafeTap addKnownContainer
+                                suiteInitialConfig: Config = wavesNodeInitialSuiteConfig,
+                                tag: String = "latest",
+                                netAlias: Option[String] = Some(WavesNodeContainer.wavesNodeNetAlias)): WavesNodeContainer =
+    WavesNodeContainer(name, networkName, network, getIp(name), runConfig, suiteInitialConfig, localLogsDir, tag, netAlias) unsafeTap addKnownContainer
 
   lazy val wavesNode1: WavesNodeContainer = createWavesNode("waves-1")
 }

--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/dex/DexApi.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/dex/DexApi.scala
@@ -1,4 +1,4 @@
-package com.wavesplatform.dex.it.api.dex
+package com.wavesplatform.dex.it.dex
 
 import java.net.{InetSocketAddress, SocketException}
 import java.util.UUID

--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/dex/DexApiOps.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/dex/DexApiOps.scala
@@ -1,4 +1,4 @@
-package com.wavesplatform.dex.it.api.dex
+package com.wavesplatform.dex.it.dex
 
 import cats.Functor
 import cats.syntax.functor._

--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/docker/DexContainer.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/docker/DexContainer.scala
@@ -9,9 +9,9 @@ import cats.instances.try_._
 import com.dimafeng.testcontainers.GenericContainer
 import com.typesafe.config.Config
 import com.wavesplatform.dex.domain.utils.ScorexLogging
-import com.wavesplatform.dex.it.api.dex.DexApi
 import com.wavesplatform.dex.it.cache.CachedData
 import com.wavesplatform.dex.it.collections.Implicits.ListOps
+import com.wavesplatform.dex.it.dex.DexApi
 import com.wavesplatform.dex.it.fp
 import com.wavesplatform.dex.it.resources.getRawContentFromResource
 import com.wavesplatform.dex.it.sttp.LoggingSttpBackend
@@ -50,19 +50,19 @@ object DexContainer extends ScorexLogging {
             internalIp: String,
             runConfig: Config,
             suiteInitialConfig: Config,
-            localLogsDir: Path)(implicit
-                                tryHttpBackend: LoggingSttpBackend[Try, Nothing],
-                                futureHttpBackend: LoggingSttpBackend[Future, Nothing],
-                                ec: ExecutionContext): DexContainer = {
+            localLogsDir: Path,
+            tag: String)(implicit
+                         tryHttpBackend: LoggingSttpBackend[Try, Nothing],
+                         futureHttpBackend: LoggingSttpBackend[Future, Nothing],
+                         ec: ExecutionContext): DexContainer = {
 
     val underlying = GenericContainer(
-      dockerImage = "com.wavesplatform/dex-it:latest",
+      dockerImage = s"com.wavesplatform/dex-it:$tag",
       exposedPorts = Seq(restApiPort),
       env = getEnv(name),
       waitStrategy = ignoreWaitStrategy
     ).configure { c =>
       c.withNetwork(network)
-      c.withNetworkAliases("d3x")
       c.withFileSystemBind(localLogsDir.toString, containerLogsPath, BindMode.READ_WRITE)
       c.withCreateContainerCmdModifier {
         _.withName(s"$networkName-$name") // network.getName returns random id

--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/docker/DexContainer.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/docker/DexContainer.scala
@@ -89,9 +89,10 @@ object DexContainer extends ScorexLogging {
   }
 
   private def getEnv(containerName: String): Map[String, String] = Map(
-    "BRIEF_LOG_PATH"       -> s"$containerLogsPath/container-$containerName.log",
-    "DETAILED_LOG_PATH"    -> s"$containerLogsPath/container-$containerName.detailed.log",
-    "WAVES_DEX_CONFIGPATH" -> s"$baseContainerPath/$containerName.conf",
+    "BRIEF_LOG_PATH"              -> s"$containerLogsPath/container-$containerName.log",
+    "DETAILED_LOG_PATH"           -> s"$containerLogsPath/container-$containerName.detailed.log",
+    "WAVES_DEX_CONFIGPATH"        -> s"$baseContainerPath/$containerName.conf",
+    "WAVES_DEX_DETAILED_LOG_PATH" -> s"$containerLogsPath/container-$containerName.detailed.log", // Backward compatibility for v2.0.3
     "WAVES_DEX_OPTS" ->
       List(
         "-J-Xmx1024M",

--- a/dex-it/src/test/java/com/wavesplatform/it/tags/DexMultipleVersions.java
+++ b/dex-it/src/test/java/com/wavesplatform/it/tags/DexMultipleVersions.java
@@ -1,0 +1,14 @@
+package com.wavesplatform.it.tags;
+
+import org.scalatest.TagAnnotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@TagAnnotation
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface DexMultipleVersions {
+}

--- a/dex-it/src/test/scala/com/wavesplatform/it/MatcherSuiteBase.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/MatcherSuiteBase.scala
@@ -10,7 +10,7 @@ import com.wavesplatform.dex.domain.asset.Asset
 import com.wavesplatform.dex.domain.bytes.ByteStr
 import com.wavesplatform.dex.domain.utils.ScorexLogging
 import com.wavesplatform.dex.it.api.BaseContainersKit
-import com.wavesplatform.dex.it.api.dex.HasDex
+import com.wavesplatform.dex.it.dex.HasDex
 import com.wavesplatform.dex.it.api.node.HasWavesNode
 import com.wavesplatform.dex.it.config.{GenesisConfig, PredefinedAccounts, PredefinedAssets}
 import com.wavesplatform.dex.it.matchers.ItMatchers

--- a/dex-it/src/test/scala/com/wavesplatform/it/api/ApiExtensions.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/api/ApiExtensions.scala
@@ -7,7 +7,7 @@ import com.wavesplatform.dex.domain.account.KeyPair
 import com.wavesplatform.dex.domain.asset.Asset.{IssuedAsset, Waves}
 import com.wavesplatform.dex.domain.asset.{Asset, AssetPair}
 import com.wavesplatform.dex.domain.order.Order
-import com.wavesplatform.dex.it.api.dex.DexApi
+import com.wavesplatform.dex.it.dex.DexApi
 import com.wavesplatform.dex.it.api.node.{NodeApi, NodeApiExtensions}
 import com.wavesplatform.dex.it.api.responses.dex.{OrderBookHistoryItem, OrderStatus, OrderStatusResponse}
 import com.wavesplatform.dex.it.docker.DexContainer

--- a/dex-it/src/test/scala/com/wavesplatform/it/api/MatcherCommand.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/api/MatcherCommand.scala
@@ -2,7 +2,7 @@ package com.wavesplatform.it.api
 
 import com.wavesplatform.dex.domain.account.KeyPair
 import com.wavesplatform.dex.domain.order.Order
-import com.wavesplatform.dex.it.api.dex.DexApi
+import com.wavesplatform.dex.it.dex.DexApi
 
 import scala.concurrent.Future
 

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/MultipleMatcherVersionsTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/MultipleMatcherVersionsTestSuite.scala
@@ -36,16 +36,13 @@ class MultipleMatcherVersionsTestSuite extends MatcherSuiteBase with HasKafka {
     wavesNode2.api.waitForHeight(wavesNode1.api.currentHeight)
     broadcastAndAwait(IssueUsdTx)
     dex1.start()
+    dex2.start()
   }
 
-  "test 1" in {
+  "order placed on one DEX is available on another" in {
     val o = mkOrder(alice, wavesUsdPair, BUY, 10.waves, 1.usd)
     placeAndAwaitAtDex(o)
     dex1.api.waitForOrderStatus(o, OrderStatus.Accepted)
-
-    dex1.disconnectFromNetwork()
-
-    dex2.start()
     dex2.api.waitForOrderStatus(o, OrderStatus.Accepted)
   }
 

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/MultipleMatcherVersionsTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/MultipleMatcherVersionsTestSuite.scala
@@ -1,0 +1,52 @@
+package com.wavesplatform.it.sync
+
+import com.typesafe.config.{Config, ConfigFactory}
+import com.wavesplatform.dex.domain.order.OrderType.BUY
+import com.wavesplatform.dex.it.api.HasKafka
+import com.wavesplatform.dex.it.api.responses.dex.OrderStatus
+import com.wavesplatform.dex.it.docker.{DexContainer, WavesNodeContainer}
+import com.wavesplatform.it.MatcherSuiteBase
+import com.wavesplatform.it.tags.DexMultipleVersions
+
+@DexMultipleVersions
+class MultipleMatcherVersionsTestSuite extends MatcherSuiteBase with HasKafka {
+
+  private val dexPrevTag  = Option(System.getenv("DEX_MULTIPLE_VERSIONS_PREVIOUS_TAG")).getOrElse("latest")
+  private val nodePrevTag = Option(System.getenv("NODE_MULTIPLE_VERSIONS_PREVIOUS_TAG")).getOrElse("latest")
+
+  override protected def dexInitialSuiteConfig: Config = ConfigFactory.parseString(s"""waves.dex.price-assets = [ "$UsdId", "WAVES" ]""".stripMargin)
+
+  override protected def kafkaServer: Option[String] = Some(s"$kafkaIp:9092")
+
+  lazy val wavesNode2: WavesNodeContainer = createWavesNode("waves-2", tag = nodePrevTag, netAlias = None)
+
+  private lazy val dexPrevConfig: Config = ConfigFactory.parseString(s"""waves.dex {
+    |  price-assets = [ "$UsdId", "WAVES" ]
+    |  waves-blockchain-client.grpc.target = "${wavesNode2.networkAddress.getHostName}:6887"
+    |}""".stripMargin)
+
+  protected lazy val dex2: DexContainer = createDex("dex-2", suiteInitialConfig = dexPrevConfig, tag = dexPrevTag)
+
+  override protected def beforeAll(): Unit = {
+    kafka.start()
+    wavesNode1.start()
+    wavesNode2.start()
+    wavesNode2.api.connect(wavesNode1.networkAddress)
+    wavesNode2.api.waitForConnectedPeer(wavesNode1.networkAddress)
+    wavesNode2.api.waitForHeight(wavesNode1.api.currentHeight)
+    broadcastAndAwait(IssueUsdTx)
+    dex1.start()
+  }
+
+  "test 1" in {
+    val o = mkOrder(alice, wavesUsdPair, BUY, 10.waves, 1.usd)
+    placeAndAwaitAtDex(o)
+    dex1.api.waitForOrderStatus(o, OrderStatus.Accepted)
+
+    dex1.disconnectFromNetwork()
+
+    dex2.start()
+    dex2.api.waitForOrderStatus(o, OrderStatus.Accepted)
+  }
+
+}

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/MultipleMatchersTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/MultipleMatchersTestSuite.scala
@@ -6,7 +6,7 @@ import com.wavesplatform.dex.domain.account.KeyPair
 import com.wavesplatform.dex.domain.asset.Asset.Waves
 import com.wavesplatform.dex.domain.asset.AssetPair
 import com.wavesplatform.dex.domain.order.{Order, OrderType}
-import com.wavesplatform.dex.it.api.dex.DexApi
+import com.wavesplatform.dex.it.dex.DexApi
 import com.wavesplatform.dex.it.api.responses.dex.OrderStatus
 import com.wavesplatform.dex.it.docker.DexContainer
 import com.wavesplatform.dex.it.fp.CanExtract._

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/networking/DexClientFaultToleranceTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/networking/DexClientFaultToleranceTestSuite.scala
@@ -15,7 +15,7 @@ import org.testcontainers.containers.ToxiproxyContainer.ContainerProxy
 @NetworkTests
 class DexClientFaultToleranceTestSuite extends MatcherSuiteBase with HasToxiProxy {
 
-  private val wavesNodeProxy: ContainerProxy = mkToxiProxy(WavesNodeContainer.netAlias, WavesNodeContainer.dexGrpcExtensionPort)
+  private val wavesNodeProxy: ContainerProxy = mkToxiProxy(WavesNodeContainer.wavesNodeNetAlias, WavesNodeContainer.dexGrpcExtensionPort)
 
   override protected def dexInitialSuiteConfig: Config = {
     ConfigFactory.parseString(s"""waves.dex {

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/networking/NetworkIssuesTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/networking/NetworkIssuesTestSuite.scala
@@ -15,7 +15,7 @@ import org.testcontainers.containers.ToxiproxyContainer.ContainerProxy
 @NetworkTests
 class NetworkIssuesTestSuite extends WsSuiteBase with HasToxiProxy {
 
-  private val wavesNodeProxy: ContainerProxy = mkToxiProxy(WavesNodeContainer.netAlias, WavesNodeContainer.dexGrpcExtensionPort)
+  private val wavesNodeProxy: ContainerProxy = mkToxiProxy(WavesNodeContainer.wavesNodeNetAlias, WavesNodeContainer.dexGrpcExtensionPort)
 
   override protected def dexInitialSuiteConfig: Config =
     ConfigFactory
@@ -120,7 +120,7 @@ class NetworkIssuesTestSuite extends WsSuiteBase with HasToxiProxy {
 
     val conf = ConfigFactory.parseString(s"""waves.dex {
                                  |  price-assets = [ "$UsdId", "WAVES" ]
-                                 |  waves-blockchain-client.grpc.target = "${WavesNodeContainer.netAlias}:${WavesNodeContainer.dexGrpcExtensionPort}"
+                                 |  waves-blockchain-client.grpc.target = "${WavesNodeContainer.wavesNodeNetAlias}:${WavesNodeContainer.dexGrpcExtensionPort}"
                                  |}""".stripMargin)
 
     dex1.restartWithNewSuiteConfig(conf)

--- a/project/ItTestPlugin.scala
+++ b/project/ItTestPlugin.scala
@@ -26,13 +26,14 @@ object ItTestPlugin extends AutoPlugin {
         // Example: SCALATEST_EXCLUDE_TAGS="package1.Tag1 package2.Tag2 package3.Tag3"
         testOptions += {
           val excludeTags = sys.env.get("SCALATEST_EXCLUDE_TAGS").fold(Seq.empty[String])(Seq("-l", _))
+          val includeTags = sys.env.get("SCALATEST_INCLUDE_TAGS").fold(Seq.empty[String])(Seq("-n", _))
           /* http://www.scalatest.org/user_guide/using_the_runner
            * f - select the file reporter with output directory
            * F - show full stack traces
            * W - without color
            * D - show all durations
            */
-          val args = Seq("-fFWD", (logDirectory.value / "summary.log").toString) ++ excludeTags
+          val args = Seq("-fFWD", (logDirectory.value / "summary.log").toString) ++ excludeTags ++ includeTags
           Tests.Argument(TestFrameworks.ScalaTest, args: _*)
         },
         parallelExecution in Test := true,


### PR DESCRIPTION
Build:
* Added SCALATEST_INCLUDE_TAGS to specify "-n" for scalatest;

Test API:
* DexMultipleVersions attribute to mark tests those run againsT multiple different versions of DEX and NODE;
* MultipleMatcherVersionsTestSuite is new test that marked as DexMultipleVersions;
* HasKafka to have a dockerized Kafka setup