### PR TITLE
DEX-748 Balance changes optimization

### DIFF
--- a/dex/src/main/scala/com/wavesplatform/dex/AddressActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/AddressActor.scala
@@ -138,7 +138,7 @@ class AddressActor(owner: Address,
         addressWsMutableState = addressWsMutableState.putSpendableAssets(msg.allChanges.keySet)
       }
 
-      val toCancel = getOrdersToCancel(msg.decreasingChanges).filterNot(ao => isCancelling(ao.order.id()))
+      val toCancel = getOrdersToCancel(msg.changesForAudit).filterNot(ao => isCancelling(ao.order.id()))
 
       if (toCancel.isEmpty) log.trace(s"Got $msg, nothing to cancel")
       else {
@@ -526,7 +526,7 @@ object AddressActor {
   sealed trait Message
   object Message {
     // values of map allChanges can be used in future for tracking balances in AddressActor
-    case class BalanceChanged(allChanges: Map[Asset, Long], decreasingChanges: Map[Asset, Long]) extends Message
+    case class BalanceChanged(allChanges: Map[Asset, Long], changesForAudit: Map[Asset, Long]) extends Message
   }
 
   sealed trait Query extends Message

--- a/dex/src/main/scala/com/wavesplatform/dex/SpendableBalancesActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/SpendableBalancesActor.scala
@@ -86,23 +86,26 @@ class SpendableBalancesActor(spendableBalances: (Address, Set[Asset]) => Future[
       changes.foreach {
         case (address, stateUpdate) =>
           val knownBalance      = fullState.get(address) orElse incompleteStateChanges.get(address) getOrElse Map.empty
-          val (all, decreasing) = if (knownBalance.isEmpty) (stateUpdate, stateUpdate) else getAllAndDecreasingChanges(stateUpdate, knownBalance)
+          val (clean, forAudit) = if (knownBalance.isEmpty) (stateUpdate, stateUpdate) else getCleanAndForAuditChanges(stateUpdate, knownBalance)
 
-          if (fullState contains address) fullState = fullState.updated(address, knownBalance ++ all)
-          else incompleteStateChanges = incompleteStateChanges.updated(address, knownBalance ++ all)
+          if (fullState contains address) fullState = fullState.updated(address, knownBalance ++ clean)
+          else incompleteStateChanges = incompleteStateChanges.updated(address, knownBalance ++ clean)
 
-          addressDirectory ! AddressDirectory.Envelope(address, AddressActor.Message.BalanceChanged(all, decreasing))
+          addressDirectory ! AddressDirectory.Envelope(address, AddressActor.Message.BalanceChanged(clean, forAudit))
       }
 
     // Subtract is called when there is a web socket connection and thus we have `fullState` for this address
     case SpendableBalancesActor.Command.Subtract(address, balance) => fullState = fullState.updated(address, fullState(address) |-| balance)
   }
 
-  /** Splits balance state update into all clean (unknown so far) and decreasing (compared to known balance) changes */
-  private def getAllAndDecreasingChanges(stateUpdate: AddressState, knownBalance: AddressState): (AddressState, AddressState) =
+  /**
+    * Splits balance state update into clean (unknown so far) changes and
+    * changes for audit (decreasing compared to known balance, they can lead to orders cancelling)
+    */
+  private def getCleanAndForAuditChanges(stateUpdate: AddressState, knownBalance: AddressState): (AddressState, AddressState) =
     stateUpdate.foldLeft { (Map.empty[Asset, Long], Map.empty[Asset, Long]) } {
       case ((ac, dc), balanceChanges @ (asset, update)) =>
-        knownBalance.get(asset).fold { (ac + balanceChanges, dc) } { existedBalance =>
+        knownBalance.get(asset).fold { (ac + balanceChanges, dc + balanceChanges) } { existedBalance =>
           if (update == existedBalance) (ac, dc) else (ac + balanceChanges, if (update < existedBalance) dc + balanceChanges else dc)
         }
     }

--- a/dex/src/test/scala/com/wavesplatform/dex/AddressActorSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/AddressActorSpecification.scala
@@ -229,7 +229,6 @@ class AddressActorSpecification
           eventsProbe.expectMsg(QueueEvent.Placed(lo))
           addressDir ! OrderAdded(lo, System.currentTimeMillis)
         case mo: MarketOrder => eventsProbe.expectMsg(QueueEvent.PlacedMarket(mo))
-
       }
     }
 

--- a/dex/src/test/scala/com/wavesplatform/dex/SpendableBalancesActorSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/SpendableBalancesActorSpecification.scala
@@ -5,6 +5,7 @@ import java.util.concurrent.ConcurrentHashMap
 import akka.actor.{ActorRef, ActorSystem, PoisonPill, Props}
 import akka.pattern.ask
 import akka.testkit.{TestKit, TestProbe}
+import com.softwaremill.diffx.Diff
 import com.wavesplatform.dex.db.EmptyOrderDB
 import com.wavesplatform.dex.domain.account.{Address, KeyPair}
 import com.wavesplatform.dex.domain.asset.Asset
@@ -12,6 +13,7 @@ import com.wavesplatform.dex.domain.asset.Asset.Waves
 import com.wavesplatform.dex.error.ErrorFormatterContext
 import com.wavesplatform.dex.grpc.integration.exceptions.WavesNodeConnectionLostException
 import com.wavesplatform.dex.queue.QueueEventWithMeta
+import com.wavesplatform.dex.test.matchers.DiffMatcherWithImplicits
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
@@ -25,6 +27,8 @@ class SpendableBalancesActorSpecification
     with AnyWordSpecLike
     with Matchers
     with MatcherSpecBase {
+
+  implicit val addressDiff: Diff[Address] = DiffMatcherWithImplicits.getDiff[Address](_ == _)
 
   implicit val efc: ErrorFormatterContext = (_: Asset) => 8
 
@@ -120,6 +124,59 @@ class SpendableBalancesActorSpecification
 
       await { askSpendableBalance(alice, Set(Waves, usd)) } should matchTo { Map(Waves -> 100.waves, usd -> 500.usd) }
       a[WavesNodeConnectionLostException] should be thrownBy await { askSpendableBalance(bob, Set(Waves, usd)) }
+    }
+
+    "correctly creates balance changes events" in {
+
+      val aliceBalance = Map(Waves -> 20.waves, usd -> 5.usd)
+
+      def spendableBalances(address: Address, assets: Set[Asset]): Future[Map[Asset, Long]] = Future.successful {
+        if (address == alice) aliceBalance filterKeys assets else Map.empty
+      }
+
+      def allAssetsSpendableBalances(address: Address): Future[Map[Asset, Long]] = Future.successful {
+        if (address == alice) aliceBalance else Map.empty
+      }
+
+      val sba: ActorRef = system.actorOf(Props(new SpendableBalancesActor(spendableBalances, allAssetsSpendableBalances, testProbe.ref)))
+
+      def updateAndExpectBalanceChanges(update: (Asset, Long)*)(allChanges: Map[Asset, Long], decreasingChanges: Map[Asset, Long]): Unit = {
+        sba ! SpendableBalancesActor.Command.UpdateStates { Map(alice -> update.toMap) }
+        val envelope = testProbe.expectMsgType[AddressDirectory.Envelope]
+        envelope.address should matchTo(alice)
+        envelope.cmd.asInstanceOf[AddressActor.Message.BalanceChanged] should matchTo {
+          AddressActor.Message.BalanceChanged(allChanges, decreasingChanges)
+        }
+      }
+
+      // initial balance = Map(Waves -> 20.waves, usd -> 5.usd)
+      withClue("Snapshot isn't received, increasing balance by Waves twice") {
+        updateAndExpectBalanceChanges(Waves -> 25.waves)(allChanges = Map(Waves -> 25.waves), decreasingChanges = Map(Waves -> 25.waves))
+        updateAndExpectBalanceChanges(Waves -> 26.waves)(allChanges = Map(Waves -> 26.waves), decreasingChanges = Map.empty)
+      }
+
+      withClue("Snapshot isn't received, decreasing balance by Waves") {
+        updateAndExpectBalanceChanges(Waves -> 23.waves)(allChanges = Map(Waves -> 23.waves), decreasingChanges = Map(Waves -> 23.waves))
+      }
+
+      withClue("Snapshot isn't received, increasing by USD") {
+        updateAndExpectBalanceChanges(usd -> 8.usd)(allChanges = Map(usd -> 8.usd), decreasingChanges = Map.empty)
+      }
+
+      withClue("Receiving snapshot") {
+        sba.tell(SpendableBalancesActor.Query.GetSnapshot(alice), testProbe.ref)
+        testProbe.expectMsgType[SpendableBalancesActor.Reply.GetSnapshot].state.getOrElse(Map.empty) should matchTo {
+          Map(Waves -> 23.waves, usd -> 8.usd)
+        }
+      }
+
+      withClue("Snapshot received, increasing balance by Waves") {
+        updateAndExpectBalanceChanges(Waves -> 30.waves)(allChanges = Map(Waves -> 30.waves), decreasingChanges = Map.empty)
+      }
+
+      withClue("Snapshot received, decreasing balance by USD") {
+        updateAndExpectBalanceChanges(usd -> 3.usd)(allChanges = Map(usd -> 3.usd), decreasingChanges = Map(usd -> 3.usd))
+      }
     }
   }
 }

--- a/dex/src/test/scala/com/wavesplatform/dex/SpendableBalancesActorSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/SpendableBalancesActorSpecification.scala
@@ -159,6 +159,10 @@ class SpendableBalancesActorSpecification
         updateAndExpectBalanceChanges(Waves -> 23.waves)(allChanges = Map(Waves -> 23.waves), decreasingChanges = Map(Waves -> 23.waves))
       }
 
+      withClue("Snapshot isn't received, decreasing by USD") {
+        updateAndExpectBalanceChanges(usd -> 3.usd)(allChanges = Map(usd -> 3.usd), decreasingChanges = Map(usd -> 3.usd))
+      }
+
       withClue("Snapshot isn't received, increasing by USD") {
         updateAndExpectBalanceChanges(usd -> 8.usd)(allChanges = Map(usd -> 8.usd), decreasingChanges = Map.empty)
       }


### PR DESCRIPTION
 * AddressActor.Command.CancelNotEnoughCoinsOrders renamed to AddressActor.Message.BalanceChanged
 * BalanceChanged contains all changes and changes for audit (all changes can be used in future)
 * AddressDirectory ignores BalanceChanges message if there isn't any child with specified address
 * AddressActor uses decreasing balance changes to cancel orders and all changes for WS extension
 * SpendableBalancesActor updates map incompleteStateChanges by only clean changes (unknown so far)
 * Unit test added