### PR TITLE
DEX-751 WS API check

### DIFF
--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/websockets/HasWebSockets.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/websockets/HasWebSockets.scala
@@ -6,6 +6,7 @@ import java.util.concurrent.ConcurrentHashMap
 import akka.actor.ActorSystem
 import akka.stream.Materializer
 import com.wavesplatform.dex.api.websockets._
+import com.wavesplatform.dex.api.websockets.connection.{WsConnection, WsConnectionOps}
 import com.wavesplatform.dex.domain.account.KeyPair
 import com.wavesplatform.dex.domain.asset.{Asset, AssetPair}
 import com.wavesplatform.dex.error.ErrorFormatterContext
@@ -26,7 +27,7 @@ trait HasWebSockets extends BeforeAndAfterAll with HasJwt with WsConnectionOps w
   implicit protected val materializer: Materializer = Materializer.matFromSystem(system)
   implicit protected val efc: ErrorFormatterContext = assetDecimalsMap.apply
 
-  protected def getWsStreamUri(dex: DexContainer): String = s"127.0.0.1:${dex.restApiAddress.getPort}/ws/v0"
+  protected def getWsStreamUri(dex: DexContainer): String = s"ws://127.0.0.1:${dex.restApiAddress.getPort}/ws/v0"
 
   protected val knownWsConnections: ConcurrentHashMap.KeySetView[WsConnection, lang.Boolean] =
     ConcurrentHashMap.newKeySet[WsConnection]()

--- a/dex-it/src/test/scala/com/wavesplatform/it/WsSuiteBase.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/WsSuiteBase.scala
@@ -1,8 +1,9 @@
 package com.wavesplatform.it
 
 import com.softwaremill.diffx.{Derived, Diff}
+import com.wavesplatform.dex.api.websockets.connection.WsConnection
 import com.wavesplatform.dex.api.websockets.{WsError, WsServerMessage}
-import com.wavesplatform.dex.it.api.websockets.{HasWebSockets, WsConnection}
+import com.wavesplatform.dex.it.api.websockets.HasWebSockets
 
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.reflect.ClassTag

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/api/ws/WsAddressStreamTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/api/ws/WsAddressStreamTestSuite.scala
@@ -1,13 +1,13 @@
 package com.wavesplatform.it.sync.api.ws
 
 import com.typesafe.config.{Config, ConfigFactory}
+import com.wavesplatform.dex.api.websockets.connection.WsConnection
 import com.wavesplatform.dex.api.websockets.{WsOrder, _}
 import com.wavesplatform.dex.domain.account.KeyPair
 import com.wavesplatform.dex.domain.asset.Asset
 import com.wavesplatform.dex.domain.asset.Asset.Waves
 import com.wavesplatform.dex.domain.order.OrderType.{BUY, SELL}
 import com.wavesplatform.dex.error.SubscriptionsLimitReached
-import com.wavesplatform.dex.it.api.websockets.WsConnection
 import com.wavesplatform.dex.it.waves.MkWavesEntities.IssueResults
 import com.wavesplatform.dex.model.{LimitOrder, MarketOrder, OrderStatus}
 import com.wavesplatform.it.WsSuiteBase

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/api/ws/WsOrderBookStreamTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/api/ws/WsOrderBookStreamTestSuite.scala
@@ -3,6 +3,7 @@ package com.wavesplatform.it.sync.api.ws
 import cats.syntax.option._
 import com.typesafe.config.{Config, ConfigFactory}
 import com.wavesplatform.dex.api.websockets._
+import com.wavesplatform.dex.api.websockets.connection.WsConnection
 import com.wavesplatform.dex.domain.account.KeyPair
 import com.wavesplatform.dex.domain.asset.Asset.Waves
 import com.wavesplatform.dex.domain.asset.AssetPair
@@ -10,7 +11,6 @@ import com.wavesplatform.dex.domain.order.OrderType
 import com.wavesplatform.dex.domain.order.OrderType.{BUY, SELL}
 import com.wavesplatform.dex.error.SubscriptionsLimitReached
 import com.wavesplatform.dex.it.api.responses.dex.{OrderStatus => ApiOrderStatus}
-import com.wavesplatform.dex.it.api.websockets.WsConnection
 import com.wavesplatform.dex.it.waves.MkWavesEntities.IssueResults
 import com.wavesplatform.dex.settings.{DenormalizedMatchingRule, OrderRestrictionsSettings}
 import com.wavesplatform.it.WsSuiteBase

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/api/ws/WsPingPongTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/api/ws/WsPingPongTestSuite.scala
@@ -2,9 +2,9 @@ package com.wavesplatform.it.sync.api.ws
 
 import akka.http.scaladsl.model.ws.TextMessage
 import com.typesafe.config.{Config, ConfigFactory}
+import com.wavesplatform.dex.api.websockets.connection.WsConnection
 import com.wavesplatform.dex.api.websockets.{WsClientMessage, WsError, WsMessage, WsPingOrPong}
 import com.wavesplatform.dex.error.InvalidJson
-import com.wavesplatform.dex.it.api.websockets.WsConnection
 import com.wavesplatform.it.WsSuiteBase
 
 import scala.concurrent.duration._

--- a/dex/src/main/scala/com/wavesplatform/dex/WavesDexCli.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/WavesDexCli.scala
@@ -115,7 +115,7 @@ object WavesDexCli {
               .action((x, s) => s.copy(dexConfigPath = x)),
             opt[String]("auth-rest-api")
               .abbr("ara")
-              .text("Auth Service REST API uri. Format: scheme://host:port (default scheme will be picked if none was specified)")
+              .text("Auth Service REST API uri. Format: scheme://host:port/path/to/token (default scheme will be picked if none was specified)")
               .valueName("<raw-string>")
               .action((x, s) => s.copy(authServiceRestApi = x.some)),
             opt[String]("account-seed")

--- a/dex/src/main/scala/com/wavesplatform/dex/api/websockets/connection/TestWsHandlerActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/websockets/connection/TestWsHandlerActor.scala
@@ -1,4 +1,4 @@
-package com.wavesplatform.dex.it.api.websockets
+package com.wavesplatform.dex.api.websockets.connection
 
 import akka.actor.{Actor, ActorRef, Props}
 import com.wavesplatform.dex.api.websockets.{WsClientMessage, WsPingOrPong}

--- a/dex/src/main/scala/com/wavesplatform/dex/api/websockets/connection/WsConnection.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/websockets/connection/WsConnection.scala
@@ -1,4 +1,4 @@
-package com.wavesplatform.dex.it.api.websockets
+package com.wavesplatform.dex.api.websockets.connection
 
 import java.util.concurrent.ConcurrentLinkedQueue
 
@@ -19,7 +19,7 @@ import scala.util.{Failure, Success}
 class WsConnection(uri: String, keepAlive: Boolean = true)(implicit system: ActorSystem, materializer: Materializer) extends ScorexLogging {
 
   log.info(s"""Connecting to Matcher WS API:
-            |         URI = ws://$uri
+            |         URI = $uri
             |  Keep alive = $keepAlive""".stripMargin)
 
   private val wsHandlerRef = system.actorOf(TestWsHandlerActor props keepAlive)
@@ -62,13 +62,13 @@ class WsConnection(uri: String, keepAlive: Boolean = true)(implicit system: Acto
   private val flow: Flow[Message, TextMessage.Strict, Future[Done]] = Flow.fromSinkAndSourceCoupled(sink, source).watchTermination() {
     case (_, f) =>
       f.onComplete {
-        case Success(_) => log.info(s"WebSocket connection to ws://$uri successfully closed")
-        case Failure(e) => log.error(s"WebSocket connection to ws://$uri closed with an error", e)
+        case Success(_) => log.info(s"WebSocket connection to $uri successfully closed")
+        case Failure(e) => log.error(s"WebSocket connection to $uri closed with an error", e)
       }(materializer.executionContext)
       f
   }
 
-  private val (response, closed) = Http().singleWebSocketRequest(WebSocketRequest(s"ws://$uri"), flow)
+  private val (response, closed) = Http().singleWebSocketRequest(WebSocketRequest(uri), flow)
 
   def connectionResponse: Future[WebSocketUpgradeResponse] = response
 

--- a/dex/src/main/scala/com/wavesplatform/dex/api/websockets/connection/WsConnection.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/websockets/connection/WsConnection.scala
@@ -5,7 +5,7 @@ import java.util.concurrent.ConcurrentLinkedQueue
 import akka.Done
 import akka.actor.{ActorRef, ActorSystem, Status}
 import akka.http.scaladsl.Http
-import akka.http.scaladsl.model.ws.{Message, TextMessage, WebSocketRequest, WebSocketUpgradeResponse}
+import akka.http.scaladsl.model.ws.{Message, TextMessage, WebSocketRequest}
 import akka.stream.scaladsl.{Flow, Sink, Source}
 import akka.stream.{CompletionStrategy, Materializer, OverflowStrategy}
 import com.wavesplatform.dex.api.websockets._
@@ -68,9 +68,7 @@ class WsConnection(uri: String, keepAlive: Boolean = true)(implicit system: Acto
       f
   }
 
-  private val (response, closed) = Http().singleWebSocketRequest(WebSocketRequest(uri), flow)
-
-  def connectionResponse: Future[WebSocketUpgradeResponse] = response
+  val (connectionResponse, closed) = Http().singleWebSocketRequest(WebSocketRequest(uri), flow)
 
   def messages: List[WsServerMessage] = messagesBuffer.iterator().asScala.toList
   def clearMessages(): Unit           = messagesBuffer.clear()

--- a/dex/src/main/scala/com/wavesplatform/dex/api/websockets/connection/WsConnectionOps.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/websockets/connection/WsConnectionOps.scala
@@ -1,4 +1,4 @@
-package com.wavesplatform.dex.it.api.websockets
+package com.wavesplatform.dex.api.websockets.connection
 
 import com.wavesplatform.dex.api.websockets._
 import com.wavesplatform.dex.domain.asset.Asset
@@ -14,4 +14,7 @@ trait WsConnectionOps {
     def balanceChanges: List[Map[Asset, WsBalances]]             = addressStateChanges.map(_.balances).filter(_.nonEmpty)
     def orderChanges: List[WsOrder]                              = addressStateChanges.flatMap(_.orders)
   }
+
 }
+
+object WsConnectionOps extends WsConnectionOps

--- a/dex/src/main/scala/com/wavesplatform/dex/auth/JwtUtils.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/auth/JwtUtils.scala
@@ -11,6 +11,7 @@ import play.api.libs.json.{JsObject, Json}
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 
 trait JwtUtils {
+
   def mkJwt(authServiceKeyPair: security.KeyPair, payload: JwtPayload): String = mkJwt(authServiceKeyPair, Json.toJsObject(payload))
   def mkJwt(authServiceKeyPair: security.KeyPair, payload: JsObject): String =
     JwtJson.encode(payload, authServiceKeyPair.getPrivate, JwtAlgorithm.RS256)

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/Checker.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/Checker.scala
@@ -181,7 +181,7 @@ case class Checker(superConnector: SuperConnector) {
         credentials <- as.getAuthCredentials(maybeSeed)
         snapshot    <- dexWs.subscribeForAccountUpdates(credentials)
       } yield s"""\n
-           |    Got snapshot for ${credentials.keyPair.publicKey.toAddress} address:
+           |    Got snapshot for ${credentials.keyPair.publicKey.toAddress} address${maybeSeed.fold(" (key pair randomly generated)")(_ => "")}:
            |    ${WsAddressState.wsAddressStateFormat.writes(snapshot).toString}\n
          """.stripMargin
     }

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/AuthServiceRestConnector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/AuthServiceRestConnector.scala
@@ -1,0 +1,55 @@
+package com.wavesplatform.dex.tool.connectors
+
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.ThreadLocalRandom
+
+import cats.syntax.either._
+import com.wavesplatform.dex.auth.JwtUtils
+import com.wavesplatform.dex.domain.account.KeyPair
+import com.wavesplatform.dex.domain.crypto
+import com.wavesplatform.dex.tool._
+import com.wavesplatform.dex.tool.connectors.AuthServiceRestConnector.AuthCredentials
+import sttp.client._
+import sttp.model.Uri.QuerySegment
+
+import scala.util.Try
+
+case class AuthServiceRestConnector(target: String, chainId: Byte) extends RestConnector with JwtUtils {
+
+  def loginPageRequest: ErrorOr[Unit] = {
+    val uri = uri"$hostPortUri/swagger-ui.html"
+    for {
+      errorOrResponse <- Try { basicRequest.get(uri).send().body }.toEither.leftMap(ex => s"Cannot load swagger UI! ${ex.getMessage}")
+      _               <- errorOrResponse
+    } yield ()
+  }
+
+  private def mkAuthTokenRequestParams(keyPair: KeyPair): List[QuerySegment] = {
+    val jwtPayload = mkJwtSignedPayload(keyPair, networkByte = chainId)
+    List(
+      "grant_type" -> "password",
+      "username"   -> jwtPayload.publicKey.base58,
+      "password"   -> s"${jwtPayload.firstTokenExpirationInSeconds}:${jwtPayload.signature}",
+      "scope"      -> jwtPayload.scope.head,
+      "client_id"  -> jwtPayload.clientId
+    ).map { case (k, v) => QuerySegment.KeyValue(k, v) }
+  }
+
+  def getAuthCredentials(maybeSeed: Option[String]): ErrorOr[AuthCredentials] = {
+
+    val keyPair       = KeyPair(crypto secureHash (maybeSeed getOrElse s"minion${ThreadLocalRandom.current.nextInt}" getBytes StandardCharsets.UTF_8))
+    val requestParams = mkAuthTokenRequestParams(keyPair)
+    val uri           = targetUri.copy(querySegments = requestParams)
+
+    mkResponse { _.post(uri) }.map { j =>
+      AuthCredentials(
+        keyPair = keyPair,
+        token = (j \ "access_token").as[String]
+      )
+    }
+  }
+}
+
+object AuthServiceRestConnector {
+  final case class AuthCredentials(keyPair: KeyPair, token: String)
+}

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/Connector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/Connector.scala
@@ -1,5 +1,32 @@
 package com.wavesplatform.dex.tool.connectors
 
+import cats.syntax.either._
+import cats.syntax.option._
+import com.wavesplatform.dex.tool.ErrorOr
+import com.wavesplatform.dex.tool.connectors.RestConnector.RepeatRequestOptions
+
+import scala.annotation.tailrec
+
 trait Connector extends AutoCloseable {
-  val target: String
+
+  protected val target: String
+  protected val repeatRequestOptions: RepeatRequestOptions
+
+  final def repeatRequest[A](sendRequest: => ErrorOr[A])(test: ErrorOr[A] => Boolean): ErrorOr[A] = {
+
+    @tailrec
+    def go(ro: RepeatRequestOptions, lastResponse: Option[ErrorOr[A]]): ErrorOr[A] = {
+      if (ro.attemptsLeft == 0) s"All attempts are out! ${lastResponse.fold("")(lr => s"Last response: ${lr.fold(identity, _.toString)}")}".asLeft
+      else {
+        val response = sendRequest
+        if (test(response)) response
+        else {
+          Thread.sleep(ro.delay.toMillis)
+          go(ro.decreaseAttempts, response.some)
+        }
+      }
+    }
+
+    go(repeatRequestOptions, None)
+  }
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/Connector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/Connector.scala
@@ -10,7 +10,8 @@ import scala.annotation.tailrec
 trait Connector extends AutoCloseable {
 
   protected val target: String
-  protected val repeatRequestOptions: RepeatRequestOptions
+
+  val repeatRequestOptions: RepeatRequestOptions = RepeatRequestOptions.default
 
   final def repeatRequest[A](sendRequest: => ErrorOr[A])(test: ErrorOr[A] => Boolean): ErrorOr[A] = {
 

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/DexExtensionGrpcConnector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/DexExtensionGrpcConnector.scala
@@ -14,6 +14,7 @@ import com.wavesplatform.dex.grpc.integration.dto.BriefAssetDescription
 import com.wavesplatform.dex.grpc.integration.settings.GrpcClientSettings.ChannelOptionsSettings
 import com.wavesplatform.dex.grpc.integration.settings.{GrpcClientSettings, WavesBlockchainClientSettings}
 import com.wavesplatform.dex.tool.ErrorOr
+import com.wavesplatform.dex.tool.connectors.RestConnector.RepeatRequestOptions
 import monix.execution.Scheduler.Implicits.{global => monixScheduler}
 import org.slf4j.LoggerFactory
 
@@ -23,6 +24,8 @@ import scala.concurrent.{Await, Awaitable, Future}
 import scala.util.Try
 
 case class DexExtensionGrpcConnector private (target: String, grpcAsyncClient: WavesBlockchainClient[Future]) extends Connector {
+
+  override val repeatRequestOptions: RestConnector.RepeatRequestOptions = RepeatRequestOptions(10, 1.second)
 
   import DexExtensionGrpcConnector._
 

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/DexExtensionGrpcConnector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/DexExtensionGrpcConnector.scala
@@ -44,7 +44,7 @@ case class DexExtensionGrpcConnector private (target: String, grpcAsyncClient: W
 
   def matcherBalanceSync(address: Address): DetailedBalance = sync { matcherBalanceAsync(address) }
 
-  override def close(): Unit = grpcAsyncClient.close()
+  override def close(): Unit = Await.result(grpcAsyncClient.close(), 3.seconds)
 }
 
 object DexExtensionGrpcConnector {

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/DexRestConnector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/DexRestConnector.scala
@@ -9,17 +9,13 @@ import com.wavesplatform.dex.domain.bytes.codec.Base58
 import com.wavesplatform.dex.domain.crypto
 import com.wavesplatform.dex.domain.order.Order
 import com.wavesplatform.dex.tool.ErrorOr
-import com.wavesplatform.dex.tool.connectors.RestConnector.{ErrorOrJsonResponse, RepeatRequestOptions}
+import com.wavesplatform.dex.tool.connectors.RestConnector.ErrorOrJsonResponse
 import play.api.libs.json.{JsValue, Json}
 import sttp.client._
 import sttp.model.MediaType
 import sttp.model.Uri.QuerySegment
 
-import scala.concurrent.duration._
-
 case class DexRestConnector(target: String) extends RestConnector {
-
-  override val repeatRequestOptions: RestConnector.RepeatRequestOptions = RepeatRequestOptions(10, 1.second)
 
   private val apiUri = s"$target/matcher"
 

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/DexWsConnector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/DexWsConnector.scala
@@ -3,20 +3,44 @@ package com.wavesplatform.dex.tool.connectors
 import akka.actor.ActorSystem
 import akka.stream.Materializer
 import cats.syntax.either._
-import com.wavesplatform.dex.api.websockets.WsInitial
 import com.wavesplatform.dex.api.websockets.connection.WsConnection
 import com.wavesplatform.dex.api.websockets.connection.WsConnectionOps._
+import com.wavesplatform.dex.api.websockets.{WsInitial, WsOrderBook, WsOrderBookSubscribe, WsServerMessage}
+import com.wavesplatform.dex.domain.asset.AssetPair
+import com.wavesplatform.dex.tool._
 import com.wavesplatform.dex.tool.connectors.RestConnector.RepeatRequestOptions
-import com.wavesplatform.dex.tool.{ErrorOr, _}
 
 import scala.concurrent.duration._
+import scala.reflect.ClassTag
 import scala.util.Try
 
 case class DexWsConnector private (target: String, wsc: WsConnection) extends Connector {
 
-  override val repeatRequestOptions: RestConnector.RepeatRequestOptions = RepeatRequestOptions(10, 100.millis)
+  import DexWsConnector._
 
-  def receiveInitialMessage: ErrorOr[WsInitial] = repeatRequest { lift(wsc.collectMessages[WsInitial]) } { _.exists(_.nonEmpty) }.map(_.head)
+  override val repeatRequestOptions: RestConnector.RepeatRequestOptions = RepeatRequestOptions(30, 100.millis)
+
+  private def repeat[A](f: => A)(test: A => Boolean): ErrorOr[A] = repeatRequest { lift(f) } { _.exists(test) }
+
+  def receiveAtLeastN[T <: WsServerMessage: ClassTag](count: Int): ErrorOr[List[T]] =
+    for {
+      result <- repeat(wsc.collectMessages[T])(_.length >= count)
+      _      <- lift { Thread.sleep(awaitingAdditionalMessagesPeriodMs) }
+    } yield result
+
+  def receiveInitialMessage: ErrorOr[WsInitial] =
+    for {
+      wsInitial <- receiveAtLeastN[WsInitial](1).map(_.head)
+      _         <- clearMessages()
+    } yield wsInitial
+
+  def subscribeForOrderBookUpdates(assetPair: AssetPair): ErrorOr[WsOrderBook] =
+    for {
+      _        <- lift { wsc.send(WsOrderBookSubscribe(assetPair, defaultDepth)) }
+      snapshot <- receiveAtLeastN[WsOrderBook](1).bimap(ex => s"Cannot get order book snapshot! $ex", _.head)
+    } yield snapshot
+
+  def clearMessages(): ErrorOr[Unit] = lift { wsc.clearMessages() }
 
   override def close(): Unit = wsc.close()
 }
@@ -25,6 +49,9 @@ object DexWsConnector {
 
   implicit private val system: ActorSystem        = ActorSystem()
   implicit private val materializer: Materializer = Materializer.matFromSystem(system)
+
+  private val defaultDepth                       = 10
+  private val awaitingAdditionalMessagesPeriodMs = 200
 
   def create(target: String): ErrorOr[DexWsConnector] =
     Try { new WsConnection(target, true) }.toEither

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/DexWsConnector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/DexWsConnector.scala
@@ -1,0 +1,33 @@
+package com.wavesplatform.dex.tool.connectors
+
+import akka.actor.ActorSystem
+import akka.stream.Materializer
+import cats.syntax.either._
+import com.wavesplatform.dex.api.websockets.WsInitial
+import com.wavesplatform.dex.api.websockets.connection.WsConnection
+import com.wavesplatform.dex.api.websockets.connection.WsConnectionOps._
+import com.wavesplatform.dex.tool.connectors.RestConnector.RepeatRequestOptions
+import com.wavesplatform.dex.tool.{ErrorOr, _}
+
+import scala.concurrent.duration._
+import scala.util.Try
+
+case class DexWsConnector private (target: String, wsc: WsConnection) extends Connector {
+
+  override val repeatRequestOptions: RestConnector.RepeatRequestOptions = RepeatRequestOptions(10, 100.millis)
+
+  def receiveInitialMessage: ErrorOr[WsInitial] = repeatRequest { lift(wsc.collectMessages[WsInitial]) } { _.exists(_.nonEmpty) }.map(_.head)
+
+  override def close(): Unit = wsc.close()
+}
+
+object DexWsConnector {
+
+  implicit private val system: ActorSystem        = ActorSystem()
+  implicit private val materializer: Materializer = Materializer.matFromSystem(system)
+
+  def create(target: String): ErrorOr[DexWsConnector] =
+    Try { new WsConnection(target, true) }.toEither
+      .leftMap(ex => s"Web Socket connection cannot be established! $ex")
+      .map(wsc => DexWsConnector(target, wsc))
+}

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/RestConnector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/RestConnector.scala
@@ -5,6 +5,7 @@ import com.wavesplatform.dex.tool.ErrorOr
 import com.wavesplatform.dex.tool.connectors.RestConnector.{ErrorOrJsonResponse, RequestFunction}
 import play.api.libs.json.{JsValue, Json}
 import sttp.client._
+import sttp.model.Uri
 
 import scala.concurrent.duration._
 import scala.util.Try
@@ -12,6 +13,9 @@ import scala.util.Try
 trait RestConnector extends Connector {
 
   implicit protected val backend: SttpBackend[Identity, Nothing, NothingT] = HttpURLConnectionBackend()
+
+  protected val targetUri        = uri"$target"
+  protected val hostPortUri: Uri = uri"${targetUri.scheme}://${targetUri.host}:${targetUri.port.get}"
 
   protected def mkResponse(request: RequestFunction): ErrorOrJsonResponse =
     for {
@@ -34,5 +38,9 @@ object RestConnector {
   final case class RepeatRequestOptions(attemptsLeft: Int, delay: FiniteDuration) {
     def decreaseAttempts: RepeatRequestOptions = copy(attemptsLeft = attemptsLeft - 1)
     override def toString: String              = s"max attempts = $attemptsLeft, interval = $delay"
+  }
+
+  object RepeatRequestOptions {
+    val default: RepeatRequestOptions = RepeatRequestOptions(10, 1.second)
   }
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/SuperConnector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/SuperConnector.scala
@@ -19,10 +19,10 @@ case class SuperConnector private (env: Env,
                                    dexRest: DexRestConnector,
                                    nodeRest: NodeRestConnector,
                                    dexExtensionGrpc: DexExtensionGrpcConnector,
-                                   dexWsConnector: DexWsConnector)
+                                   dexWs: DexWsConnector)
     extends AutoCloseable {
 
-  def close(): Unit = Seq(nodeRest, dexRest, dexExtensionGrpc, dexWsConnector).foreach { _.close() }
+  def close(): Unit = Seq(nodeRest, dexRest, dexExtensionGrpc, dexWs).foreach { _.close() }
 }
 
 // noinspection ScalaStyle

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/SuperConnector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/SuperConnector.scala
@@ -19,10 +19,14 @@ case class SuperConnector private (env: Env,
                                    dexRest: DexRestConnector,
                                    nodeRest: NodeRestConnector,
                                    dexExtensionGrpc: DexExtensionGrpcConnector,
-                                   dexWs: DexWsConnector)
+                                   dexWs: DexWsConnector,
+                                   authServiceRest: Option[AuthServiceRestConnector])
     extends AutoCloseable {
 
-  def close(): Unit = Seq(nodeRest, dexRest, dexExtensionGrpc, dexWs).foreach { _.close() }
+  def close(): Unit = {
+    Seq(dexRest, nodeRest, dexExtensionGrpc, dexWs).foreach { _.close() }
+    authServiceRest.foreach { _.close() }
+  }
 }
 
 // noinspection ScalaStyle
@@ -32,7 +36,12 @@ object SuperConnector {
 
   private val processLeftIndent = 90
 
-  def create(dexConfigPath: String, nodeRestApi: String): ErrorOr[SuperConnector] = {
+  def create(dexConfigPath: String, nodeRestApi: String, authServiceRestApi: Option[String]): ErrorOr[SuperConnector] = {
+
+    def prependScheme(uri: String, webSocket: Boolean = false): String = {
+      val (plain, secure) = if (webSocket) "ws://" -> "wss://" else "http://" -> "https://"
+      if (uri.startsWith(secure) || uri.startsWith(plain)) uri else plain + uri
+    }
 
     def logProcessing[A](processing: String)(f: => ErrorOr[A]): ErrorOr[A] = wrapByLogs(f)(s"  $processing... ", "Done\n", processLeftIndent.some)
 
@@ -52,7 +61,7 @@ object SuperConnector {
       matcherKeyPair  <- logProcessing("Loading Matcher key pair") { loadMatcherKeyPair(matcherSettings.accountStorage) }
 
       dexRestIpAndPort = s"${matcherSettings.restApi.address}:${matcherSettings.restApi.port}"
-      dexRestApiUri    = s"http://$dexRestIpAndPort"
+      dexRestApiUri    = prependScheme(dexRestIpAndPort)
       dexRestConnector = DexRestConnector(dexRestApiUri)
 
       _ <- logProcessing(s"Setting up connection with DEX REST API (${dexRestConnector.repeatRequestOptions})") {
@@ -60,7 +69,7 @@ object SuperConnector {
       }
 
       chainId           = AddressScheme.current.chainId
-      nodeRestApiUri    = if (nodeRestApi.startsWith("https://") || nodeRestApi.startsWith("http://")) nodeRestApi else s"http://$nodeRestApi"
+      nodeRestApiUri    = prependScheme(nodeRestApi)
       nodeRestConnector = NodeRestConnector(nodeRestApiUri, chainId)
 
       _ <- logProcessing(s"Setting up connection with Node REST API (${nodeRestConnector.repeatRequestOptions})") {
@@ -73,7 +82,7 @@ object SuperConnector {
         DexExtensionGrpcConnector.create(extensionGrpcApiUri)
       }
 
-      dexWsApiUri = s"ws://$dexRestIpAndPort/ws/v0"
+      dexWsApiUri = prependScheme(dexRestIpAndPort, webSocket = true) + "/ws/v0"
 
       (dexWsConnector, wsInitial) <- logProcessing("Setting up connection with DEX WS API")(
         for {
@@ -82,21 +91,36 @@ object SuperConnector {
         } yield wsConnector -> wsInitial
       )
 
-      env            = Env(chainId, matcherSettings, matcherKeyPair)
-      superConnector = SuperConnector(env, dexRestConnector, nodeRestConnector, dexExtensionGrpcConnector, dexWsConnector)
+      mayBeAuthServiceRestApiUri = authServiceRestApi map { prependScheme(_) }
+      mayBeAuthServiceConnector  = mayBeAuthServiceRestApiUri map { AuthServiceRestConnector(_, chainId) }
+
+      _ <- logProcessing("Setting up connection with Auth Service REST API") {
+        mayBeAuthServiceConnector.fold(success) { _.loginPageRequest }
+      }
+
+      env = Env(chainId, matcherSettings, matcherKeyPair)
+      superConnector = SuperConnector(
+        env,
+        dexRestConnector,
+        nodeRestConnector,
+        dexExtensionGrpcConnector,
+        dexWsConnector,
+        mayBeAuthServiceConnector
+      )
 
       _ <- log(
         s"""
            |Super Connector created!
            |
            |DEX configurations:
-           |  Chain ID               : $chainId
+           |  Chain ID               : $chainId (${chainId.toChar})
            |  Matcher public key     : ${matcherKeyPair.publicKey.toString}
            |  Matcher address        : ${matcherKeyPair.publicKey.toAddress}
            |  DEX REST API           : $dexRestApiUri
            |  Node REST API          : $nodeRestApiUri
            |  DEX extension gRPC API : $extensionGrpcApiUri
            |  DEX WS API             : $dexWsApiUri, connection ID = ${wsInitial.connectionId}
+           |  Auth Service REST API  : ${mayBeAuthServiceRestApiUri.getOrElse("Target wasn't provided, account updates check will not be performed!")}
        """.stripMargin
       )
     } yield superConnector

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/package.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/package.scala
@@ -8,6 +8,8 @@ package object tool {
 
   def lift[A](a: A): ErrorOr[A] = a.asRight
 
+  val success: ErrorOr[Unit] = lift { () }
+
   def log(log: String, indent: Option[Int] = None): ErrorOr[Unit] = lift {
     indent.fold { print(log) } { i =>
       print(log + " " * (i - log.length))


### PR DESCRIPTION
Main:
  * DexWsConnector and AuthServiceRestConnector introduced
  * During initialization SuperConnector establishes connection to:
    - DEX WS API and awaits WsInitial message
    - Auth Service REST API and tries to load swagger UI page
  * Check of the order book WS stream added
  * Check of the account updates WS stream added. If Auth Service REST API uri was not specified, Checker skips account updates check
  * Checker can test account updates for the specified seed

Miscellaneous:
  * WsConnection, WsConnectionOps, TestWsHandlerActor moved to dex module
  * Full WS uri passed to WsConnection (prefix is set from outside)
  * repeatRequest and repeatRequestOptions moved from RestConnector to Connector