### PR TITLE
DEX-637 Backward compatibility tests for database

### DIFF
--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/MultipleVersions.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/MultipleVersions.scala
@@ -5,11 +5,9 @@ import com.wavesplatform.dex.it.api.node.HasWavesNode
 import com.wavesplatform.dex.it.dex.HasDex
 import com.wavesplatform.dex.it.docker.{DexContainer, WavesNodeContainer}
 
-trait MultipleVersions extends HasKafka with HasDex with HasWavesNode { self: BaseContainersKit =>
+trait MultipleVersions extends HasDex with HasWavesNode { self: BaseContainersKit =>
   private val dex2Tag  = Option(System.getenv("DEX_MULTIPLE_VERSIONS_PREVIOUS_TAG")).getOrElse("latest")
   private val node2Tag = Option(System.getenv("NODE_MULTIPLE_VERSIONS_PREVIOUS_TAG")).getOrElse("latest")
-
-  override protected def kafkaServer: Option[String] = Some(s"$kafkaIp:9092")
 
   protected lazy val wavesNode2: WavesNodeContainer = createWavesNode("waves-2", tag = node2Tag, netAlias = None)
 

--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/docker/BaseContainer.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/docker/BaseContainer.scala
@@ -76,7 +76,7 @@ abstract class BaseContainer(protected val baseContainerPath: String, private va
 
   def printDebugMessage(text: String): Unit = {
     try {
-      if (dockerClient.inspectContainerCmd(underlying.containerId).exec().getState.getRunning) {
+      if (Option(underlying.containerId).exists(dockerClient.inspectContainerCmd(_).exec().getState.getRunning)) {
 
         val escaped = text.replace('\'', '\"')
 

--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/docker/DexContainer.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/docker/DexContainer.scala
@@ -111,4 +111,10 @@ object DexContainer extends ScorexLogging {
         }
         .mkString(" ", " ", " ")
   )
+
+  /**
+    * @param resolve A relate to the base directory path of application
+    * @note Works only with /
+    */
+  def containerPath(resolve: String): String = s"$baseContainerPath/$resolve"
 }

--- a/dex-it/src/test/java/com/wavesplatform/it/tags/DexItKafkaRequired.java
+++ b/dex-it/src/test/java/com/wavesplatform/it/tags/DexItKafkaRequired.java
@@ -9,6 +9,6 @@ import java.lang.annotation.Target;
 
 @TagAnnotation
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD, ElementType.TYPE})
+@Target({ElementType.TYPE})
 public @interface DexItKafkaRequired {
 }

--- a/dex-it/src/test/java/com/wavesplatform/it/tags/DexMultipleVersions.java
+++ b/dex-it/src/test/java/com/wavesplatform/it/tags/DexMultipleVersions.java
@@ -9,6 +9,6 @@ import java.lang.annotation.Target;
 
 @TagAnnotation
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD, ElementType.TYPE})
+@Target({ElementType.TYPE})
 public @interface DexMultipleVersions {
 }

--- a/dex-it/src/test/java/com/wavesplatform/it/tags/NetworkTests.java
+++ b/dex-it/src/test/java/com/wavesplatform/it/tags/NetworkTests.java
@@ -9,6 +9,6 @@ import java.lang.annotation.Target;
 
 @TagAnnotation
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD, ElementType.TYPE})
+@Target({ElementType.TYPE})
 public @interface NetworkTests {
 }

--- a/dex-it/src/test/scala/com/wavesplatform/it/it.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/it.scala
@@ -36,7 +36,8 @@ package object it {
   def orderGen(matcher: PublicKey,
                trader: KeyPair,
                assetPairs: Seq[AssetPair],
-               types: Seq[OrderType] = Seq(OrderType.BUY, OrderType.SELL)): Gen[Order] =
+               types: Seq[OrderType] = Seq(OrderType.BUY, OrderType.SELL)): Gen[Order] = {
+    val ts = System.currentTimeMillis()
     for {
       assetPair      <- Gen.oneOf(assetPairs)
       tpe            <- Gen.oneOf(types)
@@ -45,7 +46,6 @@ package object it {
       orderVersion   <- Gen.choose[Byte](1, 3)
       expirationDiff <- Gen.choose(600000, 6000000)
     } yield {
-      val ts = System.currentTimeMillis()
       if (tpe == OrderType.BUY)
         Order.buy(
           trader,
@@ -53,7 +53,7 @@ package object it {
           assetPair,
           amount,
           price * Order.PriceConstant,
-          System.currentTimeMillis(),
+          ts,
           ts + expirationDiff,
           matcherFee,
           orderVersion
@@ -65,12 +65,13 @@ package object it {
           assetPair,
           amount,
           price * Order.PriceConstant,
-          System.currentTimeMillis(),
+          ts,
           ts + expirationDiff,
           matcherFee,
           orderVersion
         )
     }
+  }
 
   def choose[T](xs: IndexedSeq[T]): T = xs(Random.nextInt(xs.size))
 }

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/compat/BackwardCompatSuiteBase.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/compat/BackwardCompatSuiteBase.scala
@@ -13,7 +13,7 @@ import com.wavesplatform.it.api.MatcherState
 /**
   * Doesn't start DEX in beforeAll
   */
-trait BackwardCompatTestSuite extends MatcherSuiteBase with MultipleVersions {
+trait BackwardCompatSuiteBase extends MatcherSuiteBase with MultipleVersions {
 
   override protected def dexInitialSuiteConfig: Config = ConfigFactory.parseString(s"""waves.dex.price-assets = [ "$UsdId", "WAVES" ]""".stripMargin)
 

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/compat/BackwardCompatTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/compat/BackwardCompatTestSuite.scala
@@ -9,7 +9,12 @@ import com.wavesplatform.dex.it.api.responses.dex.OrderStatus
 import com.wavesplatform.dex.it.dex.DexApi
 import com.wavesplatform.it.MatcherSuiteBase
 import com.wavesplatform.it.api.MatcherState
+import com.wavesplatform.it.tags.DexMultipleVersions
 
+/**
+  * Doesn't start DEX in beforeAll
+  */
+@DexMultipleVersions
 trait BackwardCompatTestSuite extends MatcherSuiteBase with MultipleVersions {
 
   override protected def dexInitialSuiteConfig: Config = ConfigFactory.parseString(s"""waves.dex.price-assets = [ "$UsdId", "WAVES" ]""".stripMargin)
@@ -18,7 +23,6 @@ trait BackwardCompatTestSuite extends MatcherSuiteBase with MultipleVersions {
   protected val accounts = List(alice, bob)
 
   override protected def beforeAll(): Unit = {
-    kafka.start()
     wavesNode1.start()
     wavesNode2.start()
     wavesNode2.api.connect(wavesNode1.networkAddress)
@@ -34,13 +38,6 @@ trait BackwardCompatTestSuite extends MatcherSuiteBase with MultipleVersions {
       mkTransfer(alice, bob, IssueUsdTx.getQuantity / 2, usd),
       mkTransfer(alice, bob, IssueEthTx.getQuantity / 2, eth)
     )
-    dex1.start()
-    dex2.start()
-  }
-
-  override protected def afterAll(): Unit = {
-    super.afterAll()
-    kafka.stop()
   }
 
   protected def waitOnBoth(order: Order, status: OrderStatus): Unit = {

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/compat/BackwardCompatTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/compat/BackwardCompatTestSuite.scala
@@ -9,12 +9,10 @@ import com.wavesplatform.dex.it.api.responses.dex.OrderStatus
 import com.wavesplatform.dex.it.dex.DexApi
 import com.wavesplatform.it.MatcherSuiteBase
 import com.wavesplatform.it.api.MatcherState
-import com.wavesplatform.it.tags.DexMultipleVersions
 
 /**
   * Doesn't start DEX in beforeAll
   */
-@DexMultipleVersions
 trait BackwardCompatTestSuite extends MatcherSuiteBase with MultipleVersions {
 
   override protected def dexInitialSuiteConfig: Config = ConfigFactory.parseString(s"""waves.dex.price-assets = [ "$UsdId", "WAVES" ]""".stripMargin)

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/compat/BackwardCompatTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/compat/BackwardCompatTestSuite.scala
@@ -1,0 +1,64 @@
+package com.wavesplatform.it.sync.compat
+
+import cats.Id
+import com.typesafe.config.{Config, ConfigFactory}
+import com.wavesplatform.dex.domain.asset.Asset.Waves
+import com.wavesplatform.dex.domain.order.Order
+import com.wavesplatform.dex.it.api.MultipleVersions
+import com.wavesplatform.dex.it.api.responses.dex.OrderStatus
+import com.wavesplatform.dex.it.dex.DexApi
+import com.wavesplatform.it.MatcherSuiteBase
+import com.wavesplatform.it.api.MatcherState
+
+trait BackwardCompatTestSuite extends MatcherSuiteBase with MultipleVersions {
+
+  override protected def dexInitialSuiteConfig: Config = ConfigFactory.parseString(s"""waves.dex.price-assets = [ "$UsdId", "WAVES" ]""".stripMargin)
+
+  protected val carol    = mkKeyPair("carol")
+  protected val accounts = List(alice, bob)
+
+  override protected def beforeAll(): Unit = {
+    kafka.start()
+    wavesNode1.start()
+    wavesNode2.start()
+    wavesNode2.api.connect(wavesNode1.networkAddress)
+    wavesNode2.api.waitForConnectedPeer(wavesNode1.networkAddress)
+    broadcastAndAwait(
+      IssueUsdTx,
+      IssueEthTx,
+      mkTransfer(alice, carol, 1.003.waves, Waves)
+    )
+    wavesNode1.api.waitForHeightArise()
+    wavesNode2.api.waitForHeight(wavesNode1.api.currentHeight)
+    broadcastAndAwait(
+      mkTransfer(alice, bob, IssueUsdTx.getQuantity / 2, usd),
+      mkTransfer(alice, bob, IssueEthTx.getQuantity / 2, eth)
+    )
+    dex1.start()
+    dex2.start()
+  }
+
+  override protected def afterAll(): Unit = {
+    super.afterAll()
+    kafka.stop()
+  }
+
+  protected def waitOnBoth(order: Order, status: OrderStatus): Unit = {
+    dex1.api.waitForOrderStatus(order, status)
+    dex2.api.waitForOrderStatus(order, status)
+  }
+
+  protected def cancelAll(): Unit = {
+    accounts.foreach(dex2.api.cancelAll(_))
+    accounts.foreach(dex2.api.waitForOrderHistory(_, activeOnly = Some(true))(_.isEmpty))
+  }
+
+  protected def state(dexApi: DexApi[Id], orders: IndexedSeq[Order]): MatcherState = clean(matcherState(List(wavesUsdPair), orders, accounts, dexApi))
+
+  private def clean(state: MatcherState): MatcherState = state.copy(
+    offset = 0L, // doesn't matter in this test
+    // we can't guarantee that SaveSnapshot message will come at same place in a orderbook's queue on both matchers
+    snapshots = state.snapshots.map { case (k, _) => k -> 0L }
+  )
+
+}

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/compat/DatabaseBackwardCompatTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/compat/DatabaseBackwardCompatTestSuite.scala
@@ -11,7 +11,7 @@ import org.testcontainers.containers.BindMode
 import scala.concurrent.duration.DurationInt
 
 @DexMultipleVersions
-class DatabaseBackwardCompatTestSuite extends BackwardCompatTestSuite {
+class DatabaseBackwardCompatTestSuite extends BackwardCompatSuiteBase {
   "Database backward compatibility test" in {
     val assetPairs = List(ethWavesPair, wavesUsdPair)
     val twoAccountsOrdersGen = Gen.oneOf(

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/compat/DatabaseBackwardCompatTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/compat/DatabaseBackwardCompatTestSuite.scala
@@ -4,11 +4,13 @@ import com.wavesplatform.dex.domain.order.Order
 import com.wavesplatform.dex.it.api.responses.dex.OrderStatus
 import com.wavesplatform.dex.it.docker.DexContainer
 import com.wavesplatform.it.orderGen
+import com.wavesplatform.it.tags.DexMultipleVersions
 import org.scalacheck.Gen
 import org.testcontainers.containers.BindMode
 
 import scala.concurrent.duration.DurationInt
 
+@DexMultipleVersions
 class DatabaseBackwardCompatTestSuite extends BackwardCompatTestSuite {
   "Database backward compatibility test" in {
     val assetPairs = List(ethWavesPair, wavesUsdPair)

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/compat/DatabaseBackwardCompatTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/compat/DatabaseBackwardCompatTestSuite.scala
@@ -1,0 +1,49 @@
+package com.wavesplatform.it.sync.compat
+
+import com.wavesplatform.dex.domain.order.Order
+import com.wavesplatform.dex.it.api.responses.dex.OrderStatus
+import com.wavesplatform.dex.it.docker.DexContainer
+import com.wavesplatform.it.orderGen
+import org.scalacheck.Gen
+import org.testcontainers.containers.BindMode
+
+import scala.concurrent.duration.DurationInt
+
+class DatabaseBackwardCompatTestSuite extends BackwardCompatTestSuite {
+  "Database backward compatibility test" in {
+    val assetPairs = List(ethWavesPair, wavesUsdPair)
+    val twoAccountsOrdersGen = Gen.oneOf(
+      orderGen(matcher, alice, assetPairs),
+      orderGen(matcher, bob, assetPairs)
+    )
+
+    val orders = Gen.containerOfN[Vector, Order](200, twoAccountsOrdersGen).sample.get
+    orders.foreach(dex2.api.place)
+
+    dex2.api.waitForOrder(orders.last)(_.status != OrderStatus.NotFound)
+    dex2.stopWithoutRemove()
+
+    dex1.start()
+    orders.groupBy(_.assetPair).valuesIterator.foreach { orders =>
+      dex1.api.waitForOrder(orders.last)(_.status != OrderStatus.NotFound)
+    }
+    Thread.sleep(3.seconds.toMillis) // An additional time to wait the concurrent processing
+
+    val state1 = state(dex1.api, orders)
+    val state2 = state(dex2.api, orders)
+    state1 should matchTo(state2)
+  }
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+
+    val containerDataDir = DexContainer.containerPath("data")
+    List(dex1, dex2).foreach {
+      _.underlying.configure {
+        _.withFileSystemBind(localLogsDir.resolve("db").toString, containerDataDir, BindMode.READ_WRITE)
+      }
+    }
+
+    dex2.start()
+  }
+}

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/compat/OrderBookBackwardCompatTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/compat/OrderBookBackwardCompatTestSuite.scala
@@ -6,8 +6,10 @@ import com.wavesplatform.dex.domain.order.{Order, OrderType}
 import com.wavesplatform.dex.it.api.HasKafka
 import com.wavesplatform.dex.it.api.responses.dex.OrderStatus
 import com.wavesplatform.it.orderGen
+import com.wavesplatform.it.tags.DexMultipleVersions
 import org.scalacheck.Gen
 
+@DexMultipleVersions
 class OrderBookBackwardCompatTestSuite extends BackwardCompatTestSuite with HasKafka {
   "Backward compatibility by order book of v2.0.x" - {
     "OrderBook logic" - {

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/compat/OrderBookBackwardCompatTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/compat/OrderBookBackwardCompatTestSuite.scala
@@ -10,7 +10,7 @@ import com.wavesplatform.it.tags.DexMultipleVersions
 import org.scalacheck.Gen
 
 @DexMultipleVersions
-class OrderBookBackwardCompatTestSuite extends BackwardCompatTestSuite with HasKafka {
+class OrderBookBackwardCompatTestSuite extends BackwardCompatSuiteBase with HasKafka {
   "Backward compatibility by order book of v2.0.x" - {
     "OrderBook logic" - {
       "if (!submitted.order.isValid(eventTs))" ignore {} // Hard to reproduce

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/compat/OrderBookBackwardCompatTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/compat/OrderBookBackwardCompatTestSuite.scala
@@ -3,14 +3,12 @@ package com.wavesplatform.it.sync.compat
 import com.wavesplatform.dex.domain.account.KeyPair
 import com.wavesplatform.dex.domain.order.OrderType.{BUY, SELL}
 import com.wavesplatform.dex.domain.order.{Order, OrderType}
+import com.wavesplatform.dex.it.api.HasKafka
 import com.wavesplatform.dex.it.api.responses.dex.OrderStatus
 import com.wavesplatform.it.orderGen
-import com.wavesplatform.it.tags.DexMultipleVersions
 import org.scalacheck.Gen
 
-@DexMultipleVersions
-class OrderBookBackwardCompatTestSuite extends BackwardCompatTestSuite {
-
+class OrderBookBackwardCompatTestSuite extends BackwardCompatTestSuite with HasKafka {
   "Backward compatibility by order book of v2.0.x" - {
     "OrderBook logic" - {
       "if (!submitted.order.isValid(eventTs))" ignore {} // Hard to reproduce
@@ -167,4 +165,17 @@ class OrderBookBackwardCompatTestSuite extends BackwardCompatTestSuite {
   private def mkOrder(account: KeyPair, orderSide: OrderType, amount: Long, price: Long): Order =
     mkOrder(account, wavesUsdPair, orderSide, amount, price)
 
+  override protected def kafkaServer: Option[String] = Some(s"$kafkaIp:9092")
+
+  override protected def beforeAll(): Unit = {
+    kafka.start()
+    super.beforeAll()
+    dex1.start()
+    dex2.start()
+  }
+
+  override protected def afterAll(): Unit = {
+    super.afterAll()
+    kafka.stop()
+  }
 }

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/compat/OrderBookBackwardCompatTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/compat/OrderBookBackwardCompatTestSuite.scala
@@ -1,26 +1,15 @@
-package com.wavesplatform.it.sync
+package com.wavesplatform.it.sync.compat
 
-import cats.Id
-import com.typesafe.config.{Config, ConfigFactory}
 import com.wavesplatform.dex.domain.account.KeyPair
-import com.wavesplatform.dex.domain.asset.Asset.Waves
 import com.wavesplatform.dex.domain.order.OrderType.{BUY, SELL}
 import com.wavesplatform.dex.domain.order.{Order, OrderType}
-import com.wavesplatform.dex.it.api.MultipleVersions
 import com.wavesplatform.dex.it.api.responses.dex.OrderStatus
-import com.wavesplatform.dex.it.dex.DexApi
-import com.wavesplatform.it.api.MatcherState
+import com.wavesplatform.it.orderGen
 import com.wavesplatform.it.tags.DexMultipleVersions
-import com.wavesplatform.it.{MatcherSuiteBase, orderGen}
 import org.scalacheck.Gen
 
 @DexMultipleVersions
-class MultipleDifferentMatchersTestSuite extends MatcherSuiteBase with MultipleVersions {
-
-  override protected def dexInitialSuiteConfig: Config = ConfigFactory.parseString(s"""waves.dex.price-assets = [ "$UsdId", "WAVES" ]""".stripMargin)
-
-  private val carol    = mkKeyPair("carol")
-  private val accounts = List(alice, bob)
+class OrderBookBackwardCompatTestSuite extends BackwardCompatTestSuite {
 
   "Backward compatibility by order book of v2.0.x" - {
     "OrderBook logic" - {
@@ -166,32 +155,6 @@ class MultipleDifferentMatchersTestSuite extends MatcherSuiteBase with MultipleV
     }
   }
 
-  override protected def beforeAll(): Unit = {
-    kafka.start()
-    wavesNode1.start()
-    wavesNode2.start()
-    wavesNode2.api.connect(wavesNode1.networkAddress)
-    wavesNode2.api.waitForConnectedPeer(wavesNode1.networkAddress)
-    broadcastAndAwait(
-      IssueUsdTx,
-      IssueEthTx,
-      mkTransfer(alice, carol, 1.003.waves, Waves)
-    )
-    wavesNode1.api.waitForHeightArise()
-    wavesNode2.api.waitForHeight(wavesNode1.api.currentHeight)
-    broadcastAndAwait(
-      mkTransfer(alice, bob, IssueUsdTx.getQuantity / 2, usd),
-      mkTransfer(alice, bob, IssueEthTx.getQuantity / 2, eth)
-    )
-    dex1.start()
-    dex2.start()
-  }
-
-  override protected def afterAll(): Unit = {
-    super.afterAll()
-    kafka.stop()
-  }
-
   private def test(f: => IndexedSeq[Order]): Unit = {
     cancelAll()
     val orders = f
@@ -201,25 +164,7 @@ class MultipleDifferentMatchersTestSuite extends MatcherSuiteBase with MultipleV
     cancelAll()
   }
 
-  private def waitOnBoth(order: Order, status: OrderStatus): Unit = {
-    dex1.api.waitForOrderStatus(order, status)
-    dex2.api.waitForOrderStatus(order, status)
-  }
-
-  private def cancelAll(): Unit = {
-    accounts.foreach(dex2.api.cancelAll(_))
-    accounts.foreach(dex2.api.waitForOrderHistory(_, activeOnly = Some(true))(_.isEmpty))
-  }
-
   private def mkOrder(account: KeyPair, orderSide: OrderType, amount: Long, price: Long): Order =
     mkOrder(account, wavesUsdPair, orderSide, amount, price)
-
-  private def state(dexApi: DexApi[Id], orders: IndexedSeq[Order]): MatcherState = clean(matcherState(List(wavesUsdPair), orders, accounts, dexApi))
-
-  private def clean(state: MatcherState): MatcherState = state.copy(
-    offset = 0L, // doesn't matter in this test
-    // we can't guarantee that SaveSnapshot message will come at same place in a orderbook's queue on both matchers
-    snapshots = state.snapshots.map { case (k, _) => k -> 0L }
-  )
 
 }


### PR DESCRIPTION
Integration tests:
* Added DatabaseBackwardCompatTestSuite;
* The common part for backward compat tests of MultipleDifferentMatchersTestSuite is separated to BackwardCompatSuiteBase;
* MultipleDifferentMatchersTestSuite is renamed to OrderBookBackwardCompatTestSuite;

Test API:
* Annotations: removed Target=ElementType.METHOD;
* BaseContainer: fixed a bug with printing debug messages when a container wasn't started;