### PR TITLE
DEX-755 Order Status Info

### DIFF
--- a/dex/src/main/scala/com/wavesplatform/dex/db/OrderDB.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/db/OrderDB.scala
@@ -6,14 +6,15 @@ import com.wavesplatform.dex.domain.account.Address
 import com.wavesplatform.dex.domain.asset.AssetPair
 import com.wavesplatform.dex.domain.bytes.ByteStr
 import com.wavesplatform.dex.domain.order.Order
+import com.wavesplatform.dex.domain.order.Order.Id
 import com.wavesplatform.dex.domain.utils.ScorexLogging
 import com.wavesplatform.dex.model.OrderInfo.FinalOrderInfo
 import com.wavesplatform.dex.model.{OrderInfo, OrderStatus}
 import org.iq80.leveldb.DB
 
 /**
- * Contains only finalized orders
- */
+  * Contains only finalized orders
+  */
 trait OrderDB {
   def containsInfo(id: Order.Id): Boolean
   def status(id: Order.Id): OrderStatus.Final
@@ -21,6 +22,7 @@ trait OrderDB {
   def saveOrder(o: Order): Unit
   def get(id: Order.Id): Option[Order]
   def getFinalizedOrders(owner: Address, maybePair: Option[AssetPair]): Seq[(Order.Id, OrderInfo[OrderStatus])]
+  def getOrderInfo(id: Order.Id): Option[FinalOrderInfo]
 }
 
 object OrderDB {
@@ -76,6 +78,8 @@ object OrderDB {
           oi     <- db.get(MatcherKeys.orderInfo(id))
         } yield id -> oi).sorted
       }
+
+    override def getOrderInfo(id: Id): Option[FinalOrderInfo] = db.readOnly(_.get(MatcherKeys.orderInfo(id)))
   }
 
   implicit def orderInfoOrdering[S <: OrderStatus]: Ordering[(ByteStr, OrderInfo[S])] = Ordering.by { case (id, oi) => (-oi.timestamp, id) }

--- a/dex/src/test/scala/com/wavesplatform/dex/api/MatcherApiRouteSpec.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/api/MatcherApiRouteSpec.scala
@@ -7,6 +7,7 @@ import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.model.{ContentTypes, HttpEntity, StatusCodes}
 import akka.http.scaladsl.server.Route
 import akka.testkit.{TestActor, TestProbe}
+import cats.syntax.option._
 import com.google.common.primitives.Longs
 import com.typesafe.config.ConfigFactory
 import com.wavesplatform.dex._
@@ -20,6 +21,7 @@ import com.wavesplatform.dex.domain.bytes.codec.Base58
 import com.wavesplatform.dex.domain.crypto
 import com.wavesplatform.dex.effect._
 import com.wavesplatform.dex.grpc.integration.dto.BriefAssetDescription
+import com.wavesplatform.dex.model.{LimitOrder, OrderInfo, OrderStatus}
 import com.wavesplatform.dex.settings.MatcherSettings
 import com.wavesplatform.dex.settings.OrderFeeSettings.DynamicSettings
 import org.scalamock.scalatest.PathMockFactory
@@ -378,6 +380,48 @@ class MatcherApiRouteSpec extends RouteSpec("/matcher") with MatcherSpecBase wit
     )
   }
 
+  routePath("/orders/{address}/{orderId}") - {
+
+    val testOrder = orderToCancel
+    val address   = testOrder.sender.toAddress
+    val orderId   = testOrder.id()
+
+    "X-API-Key is required" in test { route =>
+      Get(routePath(s"/orders/$address/$orderId")) ~> route ~> check {
+        status shouldEqual StatusCodes.Forbidden
+      }
+    }
+
+    "X-User-Public-Key is not required" in test(
+      { route =>
+        Get(routePath(s"/orders/$address/$orderId")).withHeaders(RawHeader("X-API-KEY", apiKey)) ~> route ~> check {
+          status shouldEqual StatusCodes.OK
+        }
+      },
+      apiKey
+    )
+
+    "X-User-Public-Key is specified, but wrong" in test(
+      { route =>
+        Get(routePath(s"/orders/$address/$orderId"))
+          .withHeaders(RawHeader("X-API-KEY", apiKey), RawHeader("X-User-Public-Key", matcherKeyPair.publicKey.base58)) ~> route ~> check {
+          status shouldEqual StatusCodes.Forbidden
+        }
+      },
+      apiKey
+    )
+
+    "sunny day" in test(
+      { route =>
+        Get(routePath(s"/orders/$address/$orderId"))
+          .withHeaders(RawHeader("X-API-KEY", apiKey), RawHeader("X-User-Public-Key", orderToCancel.senderPublicKey.base58)) ~> route ~> check {
+          status shouldEqual StatusCodes.OK
+        }
+      },
+      apiKey
+    )
+  }
+
   routePath("/settings") - {
     "Public key should be returned" in test(
       { route =>
@@ -400,6 +444,9 @@ class MatcherApiRouteSpec extends RouteSpec("/matcher") with MatcherSpecBase wit
           sender ! api.BatchCancelCompleted { command.orderIds.map(id => id -> api.OrderCanceled(id)).toMap }
         case AddressDirectory.Envelope(address, command: AddressActor.Command.CancelOrder) if address == orderToCancel.sender.toAddress =>
           sender ! api.OrderCanceled(command.orderId)
+        case AddressDirectory.Envelope(address, command: AddressActor.Query.GetOrderStatusInfo) if address == orderToCancel.sender.toAddress =>
+          val ao = LimitOrder(orderToCancel)
+          sender ! AddressActor.Reply.OrdersStatusInfo(OrderInfo.v4(ao, OrderStatus.Accepted).some)
         case _ =>
       }
 

--- a/dex/src/test/scala/com/wavesplatform/dex/db/EmptyOrderDB.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/db/EmptyOrderDB.scala
@@ -3,6 +3,8 @@ package com.wavesplatform.dex.db
 import com.wavesplatform.dex.domain.account.Address
 import com.wavesplatform.dex.domain.asset.AssetPair
 import com.wavesplatform.dex.domain.order.Order
+import com.wavesplatform.dex.domain.order.Order.Id
+import com.wavesplatform.dex.model.OrderInfo.FinalOrderInfo
 import com.wavesplatform.dex.model.{OrderInfo, OrderStatus}
 
 object EmptyOrderDB extends OrderDB {
@@ -14,4 +16,6 @@ object EmptyOrderDB extends OrderDB {
   override def saveOrder(o: Order): Unit                                                            = {}
   override def getFinalizedOrders(owner: Address, maybePair: Option[AssetPair]): Seq[(Order.Id, OrderInfo[OrderStatus])] =
     Seq.empty
+
+  override def getOrderInfo(id: Id): Option[FinalOrderInfo] = None
 }

--- a/dex/src/test/scala/com/wavesplatform/dex/db/TestOrderDB.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/db/TestOrderDB.scala
@@ -3,6 +3,8 @@ package com.wavesplatform.dex.db
 import com.wavesplatform.dex.domain.account.Address
 import com.wavesplatform.dex.domain.asset.AssetPair
 import com.wavesplatform.dex.domain.order.Order
+import com.wavesplatform.dex.domain.order.Order.Id
+import com.wavesplatform.dex.model.OrderInfo.FinalOrderInfo
 import com.wavesplatform.dex.model.{OrderInfo, OrderStatus}
 
 class TestOrderDB(maxFinalizedOrders: Int) extends OrderDB {
@@ -32,4 +34,6 @@ class TestOrderDB(maxFinalizedOrders: Int) extends OrderDB {
       info <- orderInfo.get(id)
     } yield id -> info)
       .sortBy { case (_, oi) => -oi.timestamp }
+
+  override def getOrderInfo(id: Id): Option[FinalOrderInfo] = orderInfo.get(id)
 }


### PR DESCRIPTION
  * MatcherApiRoute new methods:
    1. getOrderStatusInfoByIdWithApiKey. It obtains order status info without users's signature;
    2. getOrderStatusInfoByIdWithSignature
  * AddressActor.Query.GetOrderStatusInfo introduced
  * OrderDB getOrderInfo method introduced
  * Unit and integration test added