### PR TITLE
DEX-766 Checker Improvement

### DIFF
--- a/dex/src/main/scala/com/wavesplatform/dex/api/MatcherApiRoute.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/MatcherApiRoute.scala
@@ -221,6 +221,7 @@ case class MatcherApiRoute(assetPairBuilder: AssetPairBuilder,
           StatusCodes.OK,
           Json.obj(
             "matcherPublicKey" -> matcherPublicKey,
+            "matcherVersion"   -> Version.VersionString,
             "priceAssets"      -> matcherSettings.priceAssets,
             "orderFee"         -> getActualOrderFeeSettings().getJson(matcherAccountFee, rateCache.getJson).value,
             "orderVersions"    -> allowedOrderVersions.toSeq.sorted,

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/Checker.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/Checker.scala
@@ -146,7 +146,7 @@ case class Checker(superConnector: SuperConnector) {
     def awaitSubmittedOrderAtNode: CheckResult[Seq[JsValue]] =
       for {
         txs <- dexRest
-          .repeatRequest(dexRest getTxsByOrderId submittedId)(_.isRight)
+          .repeatRequest(dexRest getTxsByOrderId submittedId)(_.isRight)(nodeRest.repeatRequestOptions)
           .ensure(s"Awaiting of the submitted order at Node failed! Cannot find transactions for order id $submittedId")(_.lengthCompare(1) >= 0)
         _ <- txs.toList.traverse(tx => nodeRest.repeatRequest(nodeRest getTxInfo tx)(_.isRight))
       } yield txs

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/Checker.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/Checker.scala
@@ -46,8 +46,8 @@ case class Checker(superConnector: SuperConnector) {
   private def getAssetPairInfo(f: AssetInfo, s: AssetInfo): AssetPairInfo =
     if (f.asset.compatId < s.asset.compatId) AssetPairInfo(s, f) else AssetPairInfo(f, s)
 
-  private def checkVersion(version: String): CheckResult[Unit] = dexRest.swaggerRequest.flatMap { response =>
-    val parsedVersion = (response \ "info" \ "version").get.as[String]
+  private def checkVersion(version: String): CheckResult[Unit] = dexRest.getMatcherSettings.flatMap { response =>
+    val parsedVersion = (response \ "matcherVersion").get.as[String]
     Either.cond(parsedVersion == version, (), s"""Failed! Expected "$version", but got "$parsedVersion"""")
   }
 

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/AuthServiceRestConnector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/AuthServiceRestConnector.scala
@@ -19,7 +19,7 @@ case class AuthServiceRestConnector(target: String, chainId: Byte) extends RestC
   def loginPageRequest: ErrorOr[Unit] = {
     val uri = uri"$hostPortUri/swagger-ui.html"
     for {
-      errorOrResponse <- Try { basicRequest.get(uri).send().body }.toEither.leftMap(ex => s"Cannot load swagger UI! ${ex.getMessage}")
+      errorOrResponse <- Try { basicRequest.get(uri).send().body }.toEither.leftMap(ex => s"Cannot load swagger UI! ${ex.getWithStackTrace}")
       _               <- errorOrResponse
     } yield ()
   }

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/DexExtensionGrpcConnector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/DexExtensionGrpcConnector.scala
@@ -60,6 +60,5 @@ object DexExtensionGrpcConnector {
       val clientSettings = WavesBlockchainClientSettings(grpcSettings, 100.milliseconds, 100)
       WavesBlockchainClientBuilder.async(clientSettings, monixScheduler, executionContext)
     }.toEither
-      .leftMap(ex => s"Cannot establish gRPC connection to DEX Extension! $ex")
-      .map(client => DexExtensionGrpcConnector(target, client))
+      .bimap(ex => s"Cannot establish gRPC connection to DEX Extension! $ex", client => DexExtensionGrpcConnector(target, client))
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/DexExtensionGrpcConnector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/DexExtensionGrpcConnector.scala
@@ -14,7 +14,6 @@ import com.wavesplatform.dex.grpc.integration.dto.BriefAssetDescription
 import com.wavesplatform.dex.grpc.integration.settings.GrpcClientSettings.ChannelOptionsSettings
 import com.wavesplatform.dex.grpc.integration.settings.{GrpcClientSettings, WavesBlockchainClientSettings}
 import com.wavesplatform.dex.tool.ErrorOr
-import com.wavesplatform.dex.tool.connectors.RestConnector.RepeatRequestOptions
 import monix.execution.Scheduler.Implicits.{global => monixScheduler}
 import org.slf4j.LoggerFactory
 
@@ -24,8 +23,6 @@ import scala.concurrent.{Await, Awaitable, Future}
 import scala.util.Try
 
 case class DexExtensionGrpcConnector private (target: String, grpcAsyncClient: WavesBlockchainClient[Future]) extends Connector {
-
-  override val repeatRequestOptions: RestConnector.RepeatRequestOptions = RepeatRequestOptions(10, 1.second)
 
   import DexExtensionGrpcConnector._
 

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/DexRestConnector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/DexRestConnector.scala
@@ -65,4 +65,6 @@ case class DexRestConnector(target: String) extends RestConnector {
         .copy(querySegments = List(QuerySegment.KeyValue("activeOnly", "true")))
     mkResponse { _.get(uri).headers(timestampAndSignatureHeaders(keyPair, System.currentTimeMillis)) }.map(_.as[Seq[JsValue]])
   }
+
+  def getMatcherSettings: ErrorOr[JsValue] = mkResponse { _.get(uri"$apiUri/settings") }
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/DexRestConnector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/DexRestConnector.scala
@@ -17,7 +17,7 @@ import sttp.model.Uri.QuerySegment
 
 case class DexRestConnector(target: String) extends RestConnector {
 
-  private val apiUri = s"$target/matcher"
+  private val apiUri = s"$targetUri/matcher"
 
   private def mkCancelRequest(orderId: Order.Id, owner: KeyPair): CancelOrderRequest = {
     val cancelRequest = CancelOrderRequest(owner, orderId.some, None, Array.emptyByteArray)

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/DexWsConnector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/DexWsConnector.scala
@@ -9,7 +9,7 @@ import com.wavesplatform.dex.api.websockets.connection.WsConnectionOps._
 import com.wavesplatform.dex.domain.asset.AssetPair
 import com.wavesplatform.dex.tool._
 import com.wavesplatform.dex.tool.connectors.AuthServiceRestConnector.AuthCredentials
-import com.wavesplatform.dex.tool.connectors.RestConnector.RepeatRequestOptions
+import com.wavesplatform.dex.tool.connectors.Connector.RepeatRequestOptions
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -20,7 +20,7 @@ case class DexWsConnector private (target: String, wsc: WsConnection)(implicit s
 
   import DexWsConnector._
 
-  override val repeatRequestOptions: RestConnector.RepeatRequestOptions = RepeatRequestOptions(30, 100.millis)
+  override implicit val repeatRequestOptions: RepeatRequestOptions = RepeatRequestOptions(30, 100.millis)
 
   private def repeat[A](f: => A)(test: A => Boolean): ErrorOr[A] = repeatRequest { lift(f) } { _.exists(test) }
 

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/DexWsConnector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/DexWsConnector.scala
@@ -68,7 +68,6 @@ object DexWsConnector {
     implicit val materializer: Materializer = Materializer.matFromSystem(system)
 
     Try { new WsConnection(target, true) }.toEither
-      .leftMap(ex => s"Web Socket connection cannot be established! $ex")
-      .map(wsc => DexWsConnector(target, wsc))
+      .bimap(ex => s"Web Socket connection cannot be established! $ex", wsc => DexWsConnector(target, wsc))
   }
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/NodeRestConnector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/NodeRestConnector.scala
@@ -15,7 +15,7 @@ import scala.concurrent.duration._
 
 case class NodeRestConnector(target: String, chainId: Byte, timeBetweenBlocks: FiniteDuration) extends RestConnector {
 
-  override implicit val repeatRequestOptions: RepeatRequestOptions = RepeatRequestOptions(10, timeBetweenBlocks)
+  override implicit val repeatRequestOptions: RepeatRequestOptions = RepeatRequestOptions((timeBetweenBlocks * 1.5).toSeconds.toInt, 1.second)
 
   private val mapper: WavesJsonMapper = new WavesJsonMapper(chainId); mapper.registerModule(new PlayJsonModule(JsonParserSettings()))
 

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/NodeRestConnector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/NodeRestConnector.scala
@@ -19,14 +19,14 @@ case class NodeRestConnector(target: String, chainId: Byte) extends RestConnecto
   private val mapper: WavesJsonMapper = new WavesJsonMapper(chainId); mapper.registerModule(new PlayJsonModule(JsonParserSettings()))
 
   def broadcastTx(tx: Transaction): ErrorOrJsonResponse = mkResponse {
-    _.post(uri"$target/transactions/broadcast").body(mapper writeValueAsString tx).contentType(MediaType.ApplicationJson)
+    _.post(uri"$targetUri/transactions/broadcast").body(mapper writeValueAsString tx).contentType(MediaType.ApplicationJson)
   }
 
-  def getTxInfo(txId: String): ErrorOrJsonResponse    = mkResponse { _.get(uri"$target/transactions/info/$txId") }
+  def getTxInfo(txId: String): ErrorOrJsonResponse    = mkResponse { _.get(uri"$targetUri/transactions/info/$txId") }
   def getTxInfo(tx: JsValue): ErrorOrJsonResponse     = getTxInfo { (tx \ "id").as[String] }
   def getTxInfo(tx: Transaction): ErrorOrJsonResponse = getTxInfo(tx.getId.toString)
 
-  def getCurrentHeight: ErrorOr[Long] = mkResponse { _.get(uri"$target/blocks/height") }.map(json => (json \ "height").as[Long])
+  def getCurrentHeight: ErrorOr[Long] = mkResponse { _.get(uri"$targetUri/blocks/height") }.map(json => (json \ "height").as[Long])
 
   @tailrec
   final def waitForHeightArise(): ErrorOr[Long] = getCurrentHeight match {

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/NodeRestConnector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/NodeRestConnector.scala
@@ -1,7 +1,8 @@
 package com.wavesplatform.dex.tool.connectors
 
 import com.wavesplatform.dex.tool.ErrorOr
-import com.wavesplatform.dex.tool.connectors.RestConnector.{ErrorOrJsonResponse, RepeatRequestOptions}
+import com.wavesplatform.dex.tool.connectors.Connector.RepeatRequestOptions
+import com.wavesplatform.dex.tool.connectors.RestConnector.ErrorOrJsonResponse
 import com.wavesplatform.wavesj.Transaction
 import com.wavesplatform.wavesj.json.WavesJsonMapper
 import play.api.libs.json.jackson.PlayJsonModule
@@ -12,9 +13,9 @@ import sttp.model.MediaType
 import scala.annotation.tailrec
 import scala.concurrent.duration._
 
-case class NodeRestConnector(target: String, chainId: Byte) extends RestConnector {
+case class NodeRestConnector(target: String, chainId: Byte, timeBetweenBlocks: FiniteDuration) extends RestConnector {
 
-  override val repeatRequestOptions: RestConnector.RepeatRequestOptions = RepeatRequestOptions(30, 1.second)
+  override implicit val repeatRequestOptions: RepeatRequestOptions = RepeatRequestOptions(10, timeBetweenBlocks)
 
   private val mapper: WavesJsonMapper = new WavesJsonMapper(chainId); mapper.registerModule(new PlayJsonModule(JsonParserSettings()))
 

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/RestConnector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/RestConnector.scala
@@ -7,7 +7,6 @@ import play.api.libs.json.{JsValue, Json}
 import sttp.client._
 import sttp.model.Uri
 
-import scala.concurrent.duration._
 import scala.util.Try
 
 trait RestConnector extends Connector {
@@ -35,12 +34,4 @@ object RestConnector {
   type ErrorOrJsonResponse = ErrorOr[JsValue]
   type RequestFunction     = RequestT[Empty, Either[String, String], Nothing] => Request[Either[String, String], Nothing]
 
-  final case class RepeatRequestOptions(attemptsLeft: Int, delay: FiniteDuration) {
-    def decreaseAttempts: RepeatRequestOptions = copy(attemptsLeft = attemptsLeft - 1)
-    override def toString: String              = s"max attempts = $attemptsLeft, interval = $delay"
-  }
-
-  object RepeatRequestOptions {
-    val default: RepeatRequestOptions = RepeatRequestOptions(10, 1.second)
-  }
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/SuperConnector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/SuperConnector.scala
@@ -35,16 +35,17 @@ object SuperConnector {
 
   private[tool] final case class Env(chainId: Byte, matcherSettings: MatcherSettings, matcherKeyPair: KeyPair)
 
-  private val processLeftIndent = 90
+  private val processLeftIndent = 110
 
   def create(dexConfigPath: String,
              nodeRestApi: String,
              authServiceRestApi: Option[String],
              timeBetweenBlocks: FiniteDuration): ErrorOr[SuperConnector] = {
 
-    def prependScheme(uri: String, webSocket: Boolean = false): String = {
-      val (plain, secure) = if (webSocket) "ws://" -> "wss://" else "http://" -> "https://"
-      if (uri.startsWith(secure) || uri.startsWith(plain)) uri else plain + uri
+    def prependScheme(uri: String): String = {
+      val uriWithoutSlash = if (uri.last == '/') uri.init else uri
+      val (plain, secure) = "http://" -> "https://"
+      if (uri.startsWith(secure) || uri.startsWith(plain)) uriWithoutSlash else plain + uriWithoutSlash
     }
 
     def logProcessing[A](processing: String)(f: => ErrorOr[A]): ErrorOr[A] = wrapByLogs(f)(s"  $processing... ", "Done\n", processLeftIndent.some)
@@ -86,7 +87,7 @@ object SuperConnector {
         DexExtensionGrpcConnector.create(extensionGrpcApiUri)
       }
 
-      dexWsApiUri = prependScheme(dexRestIpAndPort, webSocket = true) + "/ws/v0"
+      dexWsApiUri = s"${if (nodeRestApiUri startsWith "http://") "ws://" else "wss://"}$dexRestIpAndPort/ws/v0"
 
       (dexWsConnector, wsInitial) <- logProcessing("Setting up connection with DEX WS API")(
         for {
@@ -95,11 +96,11 @@ object SuperConnector {
         } yield wsConnector -> wsInitial
       )
 
-      mayBeAuthServiceRestApiUri = authServiceRestApi map { prependScheme(_) }
+      mayBeAuthServiceRestApiUri = authServiceRestApi map prependScheme
       mayBeAuthServiceConnector  = mayBeAuthServiceRestApiUri map { AuthServiceRestConnector(_, chainId) }
 
       _ <- logProcessing("Setting up connection with Auth Service REST API") {
-        mayBeAuthServiceConnector.fold(success) { _.loginPageRequest }
+        mayBeAuthServiceConnector.fold(success)(_.loginPageRequest)
       }
 
       env = Env(chainId, matcherSettings, matcherKeyPair)

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/SuperConnector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/SuperConnector.scala
@@ -13,6 +13,7 @@ import com.wavesplatform.dex.tool._
 import com.wavesplatform.dex.tool.connectors.SuperConnector.Env
 import net.ceedubs.ficus.Ficus._
 
+import scala.concurrent.duration.FiniteDuration
 import scala.util.Try
 
 case class SuperConnector private (env: Env,
@@ -36,7 +37,10 @@ object SuperConnector {
 
   private val processLeftIndent = 90
 
-  def create(dexConfigPath: String, nodeRestApi: String, authServiceRestApi: Option[String]): ErrorOr[SuperConnector] = {
+  def create(dexConfigPath: String,
+             nodeRestApi: String,
+             authServiceRestApi: Option[String],
+             timeBetweenBlocks: FiniteDuration): ErrorOr[SuperConnector] = {
 
     def prependScheme(uri: String, webSocket: Boolean = false): String = {
       val (plain, secure) = if (webSocket) "ws://" -> "wss://" else "http://" -> "https://"
@@ -70,7 +74,7 @@ object SuperConnector {
 
       chainId           = AddressScheme.current.chainId
       nodeRestApiUri    = prependScheme(nodeRestApi)
-      nodeRestConnector = NodeRestConnector(nodeRestApiUri, chainId)
+      nodeRestConnector = NodeRestConnector(nodeRestApiUri, chainId, timeBetweenBlocks)
 
       _ <- logProcessing(s"Setting up connection with Node REST API (${nodeRestConnector.repeatRequestOptions})") {
         nodeRestConnector.waitForSwaggerJson

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/SuperConnector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/SuperConnector.scala
@@ -50,7 +50,7 @@ object SuperConnector {
         val matcherSettings: MatcherSettings = loadConfig { parseFile(new File(dexConfigPath)) }.as[MatcherSettings]("waves.dex")
         AddressScheme.current = new AddressScheme { override val chainId: Byte = matcherSettings.addressSchemeCharacter.toByte }
         matcherSettings
-      }.toEither.leftMap(ex => s"Cannot load matcher settings by path $confPath: $ex")
+      }.toEither.leftMap(ex => s"Cannot load matcher settings by path $confPath: ${ex.getWithStackTrace}")
 
     def loadMatcherKeyPair(accountStorage: AccountStorage.Settings): ErrorOr[KeyPair] =
       AccountStorage.load(accountStorage).bimap(ex => s"Cannot load Matcher account! $ex", _.keyPair)

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/package.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/package.scala
@@ -1,5 +1,7 @@
 package com.wavesplatform.dex
 
+import java.io.{PrintWriter, StringWriter}
+
 import cats.syntax.either._
 
 package object tool {
@@ -22,4 +24,13 @@ package object tool {
       result <- f
       _      <- log(end)
     } yield result
+
+  implicit class ThrowableOps(private val t: Throwable) extends AnyVal {
+
+    def getWithStackTrace: String = {
+      val sw = new StringWriter
+      t.printStackTrace(new PrintWriter(sw))
+      s"$t, ${sw.toString}"
+    }
+  }
 }


### PR DESCRIPTION
 * Stack traces in error messages
 * Matcher version in REST API endpoint
 * Checker retrieves version from REST API method
 * Time between blocks parameter introduced
 * RepeatRequestOptions moved to Connector. Now its passed as implicit parameter into repeatRequest method
 * Correct scheme for WS API
