### PR TITLE
DEX-785 Active orders removing during Kafka issues

### DIFF
--- a/dex/src/main/scala/com/wavesplatform/dex/AddressWsMutableState.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/AddressWsMutableState.scala
@@ -82,8 +82,8 @@ case class AddressWsMutableState(address: Address,
 
 object AddressWsMutableState {
 
-  def empty(address: Address) = AddressWsMutableState(address, Map.empty, Set.empty, Set.empty, Set.empty, Map.empty)
-  val numberMaxSafeInteger    = 9007199254740991L
+  def empty(address: Address): AddressWsMutableState = AddressWsMutableState(address, Map.empty, Set.empty, Set.empty, Set.empty, Map.empty)
+  val numberMaxSafeInteger                           = 9007199254740991L
 
   def getNextUpdateId(currentUpdateId: Long): Long = if (currentUpdateId == numberMaxSafeInteger) 1 else currentUpdateId + 1
 }


### PR DESCRIPTION
 * Fixed bug when two error messages are produced for sender of duplicated orders
 * Order is removed from active ones during handling of StoreFailed event only if there was pending command for this order