### PR TITLE
DEX-789 Better error handling due Kafka issues

### DIFF
--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/test/InformativeTestStart.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/test/InformativeTestStart.scala
@@ -12,11 +12,7 @@ trait InformativeTestStart extends Suite { self: BaseContainersKit =>
 
   override protected def runTest(testName: String, args: Args): Status = {
 
-    def print(text: String): Unit = {
-      val formatted = s"---------- [${LocalDateTime.now(ZoneId.of("UTC"))}] $text ----------"
-      log.debug(formatted)
-      knownContainers.get().foreach { _.printDebugMessage(formatted) }
-    }
+    def print(text: String): Unit = writeGlobalLog(s"---------- [${LocalDateTime.now(ZoneId.of("UTC"))}] $text ----------")
 
     print(s"Test '$testName' started")
 
@@ -26,5 +22,10 @@ trait InformativeTestStart extends Suite { self: BaseContainersKit =>
         case Failure(e) => print(s"Test '$testName' failed with exception '${e.getClass.getSimpleName}'")
       }
     }
+  }
+
+  protected def writeGlobalLog(x: String): Unit = {
+    log.debug(x)
+    knownContainers.get().foreach { _.printDebugMessage(x) }
   }
 }

--- a/dex-it/src/test/java/com/wavesplatform/it/tags/DexItExternalKafkaRequired.java
+++ b/dex-it/src/test/java/com/wavesplatform/it/tags/DexItExternalKafkaRequired.java
@@ -10,5 +10,5 @@ import java.lang.annotation.Target;
 @TagAnnotation
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE})
-public @interface DexItKafkaRequired {
+public @interface DexItExternalKafkaRequired {
 }

--- a/dex-it/src/test/resources/dex-servers/dex-base.conf
+++ b/dex-it/src/test/resources/dex-servers/dex-base.conf
@@ -30,6 +30,13 @@ waves.dex {
 
   events-queue {
     local.polling-interval = 100ms
+
+    kafka.producer.client {
+      request.timeout.ms = 15000
+      delivery.timeout.ms = 20000
+    }
+
+    circuit-breaker.call-timeout = 15000
   }
 
   start-events-processing-timeout = 3m # Limit the starting time of container

--- a/dex-it/src/test/scala/com/wavesplatform/it/api/ApiExtensions.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/api/ApiExtensions.scala
@@ -45,7 +45,7 @@ trait ApiExtensions extends NodeApiExtensions { this: MatcherSuiteBase =>
     waitForOrderAtNode(order.id(), dexApi, wavesNodeApi)
 
   protected def waitForOrderAtNode(orderId: Order.Id, dexApi: DexApi[Id], wavesNodeApi: NodeApi[Id]): Seq[ExchangeTransaction] =
-    dex1.api.waitForTransactionsByOrder(orderId, 1).unsafeTap {
+    dexApi.waitForTransactionsByOrder(orderId, 1).unsafeTap {
       _.foreach(tx => wavesNodeApi.waitForTransaction(tx.getId))
     }
 

--- a/dex-it/src/test/scala/com/wavesplatform/it/it.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/it.scala
@@ -22,16 +22,16 @@ package object it {
     Await.result(Future.sequence(xs.map(executeCommand(_, ignoreErrors))), timeout).sum
   }
 
-  private def executeCommand(x: MatcherCommand, ignoreErrors: Boolean): Future[Int] = x match {
-    case MatcherCommand.Place(api, order) => api.tryPlace(order).map(_.fold(_ => 0, _ => 1))
-    case MatcherCommand.Cancel(api, owner, order) =>
-      try api.tryCancel(owner, order).map(_.fold(_ => 0, _ => 1))
-      catch {
-        case NonFatal(e) =>
-          if (ignoreErrors) Future.successful(0)
-          else Future.failed(e)
-      }
-  }
+  private def executeCommand(x: MatcherCommand, ignoreErrors: Boolean): Future[Int] =
+    try x match {
+      case MatcherCommand.Place(api, order) => api.tryPlace(order).map(_.fold(_ => 0, _ => 1))
+      case MatcherCommand.Cancel(api, owner, order) =>
+        api.tryCancel(owner, order).map(_.fold(_ => 0, _ => 1))
+    } catch {
+      case NonFatal(e) =>
+        if (ignoreErrors) Future.successful(0)
+        else Future.failed(e)
+    }
 
   def orderGen(matcher: PublicKey,
                trader: KeyPair,

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/KafkaIssuesTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/KafkaIssuesTestSuite.scala
@@ -1,6 +1,6 @@
 package com.wavesplatform.it.sync
 
-import com.github.dockerjava.api.model.ContainerNetwork
+import com.github.dockerjava.api.model.{ContainerNetwork, NetworkSettings}
 import com.typesafe.config.{Config, ConfigFactory}
 import com.wavesplatform.dex.api.websockets.{WsBalances, WsOrder}
 import com.wavesplatform.dex.domain.asset.Asset
@@ -8,15 +8,24 @@ import com.wavesplatform.dex.domain.asset.Asset.Waves
 import com.wavesplatform.dex.domain.model.Denormalization._
 import com.wavesplatform.dex.domain.order.OrderType.SELL
 import com.wavesplatform.dex.it.api.HasKafka
+import com.wavesplatform.dex.it.api.responses.dex.{OrderStatus => ApiOrderStatus}
 import com.wavesplatform.dex.it.api.websockets.HasWebSockets
 import com.wavesplatform.dex.model.{LimitOrder, OrderStatus}
 import com.wavesplatform.it.WsSuiteBase
+import com.wavesplatform.it.tags.DexItKafkaRequired
 
 import scala.collection.JavaConverters._
 
+@DexItKafkaRequired
 class KafkaIssuesTestSuite extends WsSuiteBase with HasWebSockets with HasKafka {
 
-  override protected val dexInitialSuiteConfig: Config = ConfigFactory.parseString(s"""waves.dex.price-assets = [ "$UsdId", "WAVES" ]""")
+  override protected val dexInitialSuiteConfig: Config = ConfigFactory.parseString(s"""waves.dex { 
+  price-assets = [ "$UsdId", "WAVES" ]
+  events-queue.kafka.producer.client {
+    request.timeout.ms = 1000
+    delivery.timeout.ms = 1100
+  }
+}""")
 
   override protected lazy val dexRunConfig = dexKafkaConfig().withFallback(jwtPublicKeyConfig)
 
@@ -28,25 +37,7 @@ class KafkaIssuesTestSuite extends WsSuiteBase with HasWebSockets with HasKafka 
     dex1.start()
   }
 
-  private def disconnectKafkaFromNetwork(): Unit = {
-    kafka.dockerClient
-      .disconnectFromNetworkCmd()
-      .withContainerId(kafka.containerId)
-      .withNetworkId(kafka.network.getId)
-      .exec()
-  }
-
-  private def connectKafkaToNetwork(): Unit = {
-    kafka.dockerClient
-      .connectToNetworkCmd()
-      .withContainerId(kafka.containerId)
-      .withNetworkId(kafka.network.getId)
-      .withContainerNetwork(
-        new ContainerNetwork()
-          .withIpamConfig(new ContainerNetwork.Ipam().withIpv4Address(kafkaIp))
-          .withAliases(kafka.networkAliases.asJava))
-      .exec()
-  }
+  private val networkId = kafka.network.getId
 
   "Matcher should free reserved balances if order wasn't placed into the queue" in {
 
@@ -57,9 +48,7 @@ class KafkaIssuesTestSuite extends WsSuiteBase with HasWebSockets with HasKafka 
 
     assertChanges(wsac, squash = false) { Map(Waves -> WsBalances(initialWavesBalance, 0), usd -> WsBalances(initialUsdBalance, 0)) }()
 
-    val sellOrder    = mkOrderDP(alice, wavesUsdPair, SELL, 10.waves, 3.0)
-    val bigSellOrder = mkOrderDP(alice, wavesUsdPair, SELL, 30.waves, 3.0)
-
+    val sellOrder = mkOrderDP(alice, wavesUsdPair, SELL, 10.waves, 3.0)
     placeAndAwaitAtDex(sellOrder)
 
     dex1.api.currentOffset shouldBe 0
@@ -72,6 +61,8 @@ class KafkaIssuesTestSuite extends WsSuiteBase with HasWebSockets with HasKafka 
     disconnectKafkaFromNetwork()
 
     dex1.api.tryCancel(alice, sellOrder) shouldBe 'left
+
+    val bigSellOrder = mkOrderDP(alice, wavesUsdPair, SELL, 30.waves, 3.0)
     dex1.api.tryPlace(bigSellOrder) shouldBe 'left
 
     dex1.api.reservedBalance(alice) should matchTo(Map[Asset, Long](Waves -> 10.003.waves))
@@ -88,6 +79,8 @@ class KafkaIssuesTestSuite extends WsSuiteBase with HasWebSockets with HasKafka 
     connectKafkaToNetwork()
 
     dex1.api.tryCancel(alice, sellOrder) shouldBe 'right
+    dex1.api.waitForOrderStatus(sellOrder, ApiOrderStatus.Cancelled)
+
     dex1.api.orderHistory(alice, Some(true)) should have size 0
     dex1.api.reservedBalance(alice) shouldBe empty
 
@@ -96,6 +89,8 @@ class KafkaIssuesTestSuite extends WsSuiteBase with HasWebSockets with HasKafka 
     }
 
     dex1.api.tryPlace(bigSellOrder) shouldBe 'right
+    dex1.api.waitForOrderStatus(bigSellOrder, ApiOrderStatus.Accepted)
+
     dex1.api.orderHistory(alice, Some(true)) should have size 1
     dex1.api.reservedBalance(alice) should matchTo(Map[Asset, Long](Waves -> 30.003.waves))
 
@@ -106,4 +101,40 @@ class KafkaIssuesTestSuite extends WsSuiteBase with HasWebSockets with HasKafka 
     dex1.api.cancelAll(alice)
     wsac.close()
   }
+
+  private def disconnectKafkaFromNetwork(): Unit = {
+    writeGlobalLog("--- Disconnecting Kafka from the network ---")
+    kafka.dockerClient
+      .disconnectFromNetworkCmd()
+      .withContainerId(kafka.containerId)
+      .withNetworkId(networkId)
+      .exec()
+
+    waitForNetworkSettings(_.getNetworks.containsKey(networkId))
+  }
+
+  private def connectKafkaToNetwork(): Unit = {
+    writeGlobalLog("--- Connecting Kafka to the network ---")
+    kafka.dockerClient
+      .connectToNetworkCmd()
+      .withContainerId(kafka.containerId)
+      .withNetworkId(networkId)
+      .withContainerNetwork(
+        new ContainerNetwork()
+          .withIpamConfig(new ContainerNetwork.Ipam().withIpv4Address(kafkaIp))
+          .withAliases(kafka.networkAliases.asJava))
+      .exec()
+
+    waitForNetworkSettings(!_.getNetworks.containsKey(networkId))
+  }
+
+  private def waitForNetworkSettings(pred: NetworkSettings => Boolean): Unit =
+    Iterator
+      .continually {
+        Thread.sleep(1000)
+        kafka.dockerClient.inspectContainerCmd(kafka.containerId).exec().getNetworkSettings
+      }
+      .zipWithIndex
+      .find { case (ns, attempt) => pred(ns) || attempt == 10 }
+      .fold(log.warn(s"Can't wait on ${kafka.containerId}"))(_ => ())
 }

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/KafkaIssuesTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/KafkaIssuesTestSuite.scala
@@ -70,7 +70,7 @@ class KafkaIssuesTestSuite extends WsSuiteBase with HasWebSockets with HasKafka 
       dex1.api.currentOffset shouldBe offsetBefore
     }
 
-    // dex1.api.tryPlace(mkOrderDP(alice, wavesUsdPair, SELL, 1.waves, 3.0)) shouldBe 'right
+     dex1.api.tryPlace(mkOrderDP(alice, wavesUsdPair, SELL, 1.waves, 3.0)) shouldBe 'right
 
     dex1.api.cancelAll(alice)
   }

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/MultipleMatchersTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/MultipleMatchersTestSuite.scala
@@ -13,7 +13,7 @@ import com.wavesplatform.dex.it.fp.CanExtract._
 import com.wavesplatform.it._
 import com.wavesplatform.it.api.{MatcherCommand, MatcherState}
 import com.wavesplatform.it.config.DexTestConfig.createAssetPair
-import com.wavesplatform.it.tags.DexItKafkaRequired
+import com.wavesplatform.it.tags.DexItExternalKafkaRequired
 import org.scalacheck.Gen
 
 import scala.concurrent.duration.DurationInt
@@ -21,7 +21,7 @@ import scala.concurrent.{Await, Future}
 import scala.util.Random
 import scala.util.control.NonFatal
 
-@DexItKafkaRequired
+@DexItExternalKafkaRequired
 class MultipleMatchersTestSuite extends MatcherSuiteBase {
 
   override protected def dexInitialSuiteConfig: Config =

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/MultipleMatchersTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/MultipleMatchersTestSuite.scala
@@ -79,6 +79,7 @@ class MultipleMatchersTestSuite extends MatcherSuiteBase {
 
     successfulCommandsNumber = executeCommands(places ++ cancels)
     successfulCommandsNumber += executeCommands(List(MatcherCommand.Place(dex1.asyncApi, lastOrder)))
+    log.info(s"Successful commands: $successfulCommandsNumber")
   }
 
   "Wait until all requests are processed" in {

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/api/ws/WsPingPongTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/api/ws/WsPingPongTestSuite.scala
@@ -15,7 +15,7 @@ class WsPingPongTestSuite extends WsSuiteBase {
   private val maxConnectionLifetime = 6.seconds
   private val pingInterval          = 1.second
   private val pongTimeout           = pingInterval * 3
-  private val delta                 = 0.5.seconds
+  private val delta                 = 1.second
 
   private implicit def duration2Long(d: FiniteDuration): Long = d.toMillis
 

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/compat/OrderBookBackwardCompatTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/compat/OrderBookBackwardCompatTestSuite.scala
@@ -6,10 +6,11 @@ import com.wavesplatform.dex.domain.order.{Order, OrderType}
 import com.wavesplatform.dex.it.api.HasKafka
 import com.wavesplatform.dex.it.api.responses.dex.OrderStatus
 import com.wavesplatform.it.orderGen
-import com.wavesplatform.it.tags.DexMultipleVersions
+import com.wavesplatform.it.tags.{DexItKafkaRequired, DexMultipleVersions}
 import org.scalacheck.Gen
 
 @DexMultipleVersions
+@DexItKafkaRequired
 class OrderBookBackwardCompatTestSuite extends BackwardCompatSuiteBase with HasKafka {
   "Backward compatibility by order book of v2.0.x" - {
     "OrderBook logic" - {

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/compat/OrderBookBackwardCompatTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/compat/OrderBookBackwardCompatTestSuite.scala
@@ -6,11 +6,11 @@ import com.wavesplatform.dex.domain.order.{Order, OrderType}
 import com.wavesplatform.dex.it.api.HasKafka
 import com.wavesplatform.dex.it.api.responses.dex.OrderStatus
 import com.wavesplatform.it.orderGen
-import com.wavesplatform.it.tags.{DexItKafkaRequired, DexMultipleVersions}
+import com.wavesplatform.it.tags.{DexItExternalKafkaRequired, DexMultipleVersions}
 import org.scalacheck.Gen
 
 @DexMultipleVersions
-@DexItKafkaRequired
+@DexItExternalKafkaRequired
 class OrderBookBackwardCompatTestSuite extends BackwardCompatSuiteBase with HasKafka {
   "Backward compatibility by order book of v2.0.x" - {
     "OrderBook logic" - {

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/networking/MultipleMatchersOrderCancelTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/networking/MultipleMatchersOrderCancelTestSuite.scala
@@ -17,7 +17,7 @@ class MultipleMatchersOrderCancelTestSuite extends MatcherSuiteBase {
 
   override protected def beforeAll(): Unit = {
     wavesNode1.start()
-    broadcastAndAwait(IssueUsdTx)
+    broadcastAndAwait(IssueUsdTx, IssueEthTx)
     dex1.start()
     dex2.start()
   }
@@ -34,9 +34,11 @@ class MultipleMatchersOrderCancelTestSuite extends MatcherSuiteBase {
 
     val acc1 = mkAccountWithBalance(15.015.waves -> Waves)
     val acc2 = mkAccountWithBalance(0.015.waves  -> Waves, 15.usd -> usd)
+    val acc3 = mkAccountWithBalance(1.waves      -> Waves, 10.eth -> eth) // Account for fake orders
 
+    val ts = System.currentTimeMillis()
     val sellOrders = (1 to 5).map { amt =>
-      mkOrderDP(acc1, wavesUsdPair, OrderType.SELL, amt.waves, amt)
+      mkOrderDP(acc1, wavesUsdPair, OrderType.SELL, amt.waves, amt, ts = ts + amt) // To cancel latest first
     }
 
     sellOrders.foreach { placeAndAwaitAtDex(_) }
@@ -47,6 +49,11 @@ class MultipleMatchersOrderCancelTestSuite extends MatcherSuiteBase {
 
     dex1.api.saveSnapshots
     dex1.restartWithNewSuiteConfig(ConfigFactory.parseString(s"waves.dex.events-queue.type = local").withFallback(dexInitialSuiteConfig))
+    // HACK: Because we switched the queue, we need to place 5 orders to move offset of queue
+    (1 to 5).foreach { i =>
+      val order = mkOrderDP(acc3, ethWavesPair, OrderType.SELL, 1.eth, 1)
+      dex1.api.place(order)
+    }
 
     (1 to 3).foreach { amt =>
       val order = mkOrderDP(acc2, wavesUsdPair, OrderType.BUY, amt.waves, amt)
@@ -54,8 +61,13 @@ class MultipleMatchersOrderCancelTestSuite extends MatcherSuiteBase {
       dex2.api.waitForOrderStatus(order, OrderStatus.Filled)
     }
 
-    // problem solution should prevent sell orders from cancelling!
-    dex1.api.waitForOrderStatus(sellOrders(4), OrderStatus.Cancelled)
-    dex1.api.waitForOrderStatus(sellOrders(3), OrderStatus.Cancelled)
+    // TODO problem solution should prevent sell orders from cancelling!
+    (3 to 4).foreach { i =>
+      dex1.api.waitForOrderStatus(sellOrders(i), OrderStatus.Cancelled)
+    }
+
+    (0 to 2).foreach { i =>
+      dex1.api.waitForOrderStatus(sellOrders(i), OrderStatus.Accepted)
+    }
   }
 }

--- a/dex/src/main/resources/application.conf
+++ b/dex/src/main/resources/application.conf
@@ -424,6 +424,9 @@ waves.dex {
           # Wait responses from all kafka brokers
           acks = all
 
+          # At Most Once semantics
+          retries = 0
+
           # Buffer messages into a batch for this duration
           linger.ms = 10
 
@@ -434,7 +437,7 @@ waves.dex {
           max.in.flight.requests.per.connection = 1
 
           # A timeout for sending one message
-          request.timeout.ms = 4000
+          request.timeout.ms = 8000
 
           # A maximum timeout for sending one message. Note, max_retries = delivery.timeout.ms / request.timeout.ms
           delivery.timeout.ms = 15000
@@ -454,6 +457,21 @@ waves.dex {
           connections.max.idle.ms = 30000
         }
       }
+    }
+
+    # Circuit breaker for a queue.
+    # For now it is make sense in a case of kafka queue.
+    # See https://doc.akka.io/docs/akka/current/common/circuitbreaker.html for more information.
+    circuit-breaker {
+      # Maximum number of failures before opening the circuit.
+      max-failures = 10
+
+      # Time after which a call is considered as failed.
+      # The default value is based on kafka producer settings.
+      call-timeout = ${waves.dex.events-queue.kafka.producer.client.request.timeout.ms}ms
+
+      # Time after which to attempt to close the circuit.
+      reset-timeout = 30s
     }
   }
 

--- a/dex/src/main/resources/application.conf
+++ b/dex/src/main/resources/application.conf
@@ -440,7 +440,7 @@ waves.dex {
           request.timeout.ms = 8000
 
           # A maximum timeout for sending one message. Note, max_retries = delivery.timeout.ms / request.timeout.ms
-          delivery.timeout.ms = 15000
+          delivery.timeout.ms = 9000
 
           # Wait before attempting to reconnect x ∊ [reconnect.backoff.ms; reconnect.backoff.max.ms]
           reconnect.backoff {
@@ -471,7 +471,7 @@ waves.dex {
       call-timeout = ${waves.dex.events-queue.kafka.producer.client.request.timeout.ms}ms
 
       # Time after which to attempt to close the circuit.
-      reset-timeout = 30s
+      reset-timeout = 10s
     }
   }
 

--- a/dex/src/main/resources/application.conf
+++ b/dex/src/main/resources/application.conf
@@ -454,7 +454,7 @@ waves.dex {
           compression.type = "none"
 
           # Close idle connections after
-          connections.max.idle.ms = 30000
+          connections.max.idle.ms = 10000
         }
       }
     }
@@ -468,7 +468,7 @@ waves.dex {
 
       # Time after which a call is considered as failed.
       # The default value is based on kafka producer settings.
-      call-timeout = ${waves.dex.events-queue.kafka.producer.client.request.timeout.ms}ms
+      call-timeout = ${waves.dex.events-queue.kafka.producer.client.delivery.timeout.ms}ms
 
       # Time after which to attempt to close the circuit.
       reset-timeout = 10s

--- a/dex/src/main/scala/com/wavesplatform/dex/queue/KafkaMatcherQueue.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/queue/KafkaMatcherQueue.scala
@@ -154,7 +154,7 @@ object KafkaMatcherQueue {
           new Callback {
             override def onCompletion(metadata: RecordMetadata, exception: Exception): Unit = {
               if (exception == null) {
-                log.debug(s"$event stored, offset=${metadata.offset()}, timestamp=${metadata.timestamp()}")
+                log.debug(s"Stored $event, offset=${metadata.offset()}, timestamp=${metadata.timestamp()}")
                 p.success(
                   QueueEventWithMeta(
                     offset = metadata.offset(),

--- a/dex/src/main/scala/com/wavesplatform/dex/settings/EventsQueueSettings.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/settings/EventsQueueSettings.scala
@@ -1,11 +1,17 @@
 package com.wavesplatform.dex.settings
 
 import com.wavesplatform.dex.queue.{KafkaMatcherQueue, LocalMatcherQueue}
+import com.wavesplatform.dex.settings.EventsQueueSettings.CircuitBreakerSettings
 import net.ceedubs.ficus.Ficus._
 import net.ceedubs.ficus.readers.ArbitraryTypeReader.arbitraryTypeValueReader
 import net.ceedubs.ficus.readers.{NameMapper, ValueReader}
 
-case class EventsQueueSettings(tpe: String, local: LocalMatcherQueue.Settings, kafka: KafkaMatcherQueue.Settings)
+import scala.concurrent.duration.FiniteDuration
+
+case class EventsQueueSettings(tpe: String,
+                               local: LocalMatcherQueue.Settings,
+                               kafka: KafkaMatcherQueue.Settings,
+                               circuitBreaker: CircuitBreakerSettings)
 
 object EventsQueueSettings {
 
@@ -15,7 +21,10 @@ object EventsQueueSettings {
     EventsQueueSettings(
       tpe = cfg.getString(s"$path.type"),
       local = cfg.as[LocalMatcherQueue.Settings](s"$path.local"),
-      kafka = cfg.as[KafkaMatcherQueue.Settings](s"$path.kafka")
+      kafka = cfg.as[KafkaMatcherQueue.Settings](s"$path.kafka"),
+      circuitBreaker = cfg.as[CircuitBreakerSettings](s"$path.circuit-breaker")
     )
   }
+
+  case class CircuitBreakerSettings(maxFailures: Int, callTimeout: FiniteDuration, resetTimeout: FiniteDuration)
 }

--- a/dex/src/test/scala/com/wavesplatform/dex/model/OrderBookSpec.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/model/OrderBookSpec.scala
@@ -181,8 +181,8 @@ ${formatEvents(events)}
 """
 
         withClue(clue) {
-          obInvariant(ob)
-          obInvariant(updatedOb)
+          obAskBidIntersectionInvariant(ob)
+          obAskBidIntersectionInvariant(updatedOb)
         }
     }
 
@@ -258,7 +258,7 @@ $updatedSnapshot
     }
 
     "order book invariant" in test(removedGen) { (_, _, obAfter, _, _) =>
-      obInvariant(obAfter)
+      obAskBidIntersectionInvariant(obAfter)
     }
 
     "no other order was removed" in test(removedGen) { (ob, orderIdToCancel, obAfter, _, _) =>
@@ -354,7 +354,7 @@ ${canceledOrders.mkString("\n")}
     }
   }
 
-  private def obInvariant(ob: OrderBook): Unit = {
+  private def obAskBidIntersectionInvariant(ob: OrderBook): Unit = {
     val firstAskPrice = ob.asks.headOption.map(_._1).getOrElse(Long.MaxValue)
     val firstBidPrice = ob.bids.headOption.map(_._1).getOrElse(Long.MinValue)
     firstAskPrice should be > firstBidPrice

--- a/dex/src/test/scala/com/wavesplatform/dex/model/OrderBookSpec.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/model/OrderBookSpec.scala
@@ -16,7 +16,6 @@ import com.wavesplatform.dex.gen.OrderBookGen
 import com.wavesplatform.dex.model.Events.{Event, OrderAdded, OrderCanceled, OrderExecuted}
 import com.wavesplatform.dex.test.matchers.DiffMatcherWithImplicits
 import org.scalacheck.Gen
-import org.scalatest.Assertion
 import org.scalatest.freespec.AnyFreeSpecLike
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
@@ -158,6 +157,35 @@ ${diff.mkString("\n")}
         }
     }
 
+    "order book invariant" in forAll(coinsInvariantPropGen) {
+      case (askOrders, bidOrders, newOrder) =>
+        val ob                     = mkOrderBook(askOrders, bidOrders)
+        val (updatedOb, events, _) = ob.add(newOrder, ts, getMakerTakerFee = (o1, o2) => (o1.matcherFee, o2.matcherFee))
+
+        val clue =
+          s"""
+Pair:
+$assetPair
+
+Order:
+${format(newOrder)}
+
+OrderBook before:
+${format(ob)}
+
+OrderBook after:
+${format(updatedOb)}
+
+Events:
+${formatEvents(events)}
+"""
+
+        withClue(clue) {
+          obInvariant(ob)
+          obInvariant(updatedOb)
+        }
+    }
+
     "result.levelChanges contains diff for updatedOrderBook.level" in forAll(coinsInvariantPropGen) {
       case (askOrders, bidOrders, newOrder) =>
         val ob       = mkOrderBook(askOrders, bidOrders)
@@ -229,6 +257,10 @@ $updatedSnapshot
       orderRemoved shouldBe true
     }
 
+    "order book invariant" in test(removedGen) { (_, _, obAfter, _, _) =>
+      obInvariant(obAfter)
+    }
+
     "no other order was removed" in test(removedGen) { (ob, orderIdToCancel, obAfter, _, _) =>
       val orderIdsBefore = orderIds(ob)
       val orderIdsAfter  = orderIds(obAfter)
@@ -250,7 +282,7 @@ $updatedSnapshot
       expectedLevelChanges should matchTo(actualLevelChanges)
     }
 
-    def test(gen: Gen[(OrderBook, Order.Id)])(f: (OrderBook, Order.Id, OrderBook, Seq[Event], LevelAmounts) => Assertion): Unit = forAll(gen) {
+    def test(gen: Gen[(OrderBook, Order.Id)])(f: (OrderBook, Order.Id, OrderBook, Seq[Event], LevelAmounts) => Any): Unit = forAll(gen) {
       case (origOb, orderIdToCancel) =>
         val (updatedOb, events, levelChanges) = origOb.cancel(orderIdToCancel, ts)
         withClue(mkClue(orderIdToCancel, origOb, updatedOb, events, levelChanges)) {
@@ -320,6 +352,12 @@ ${canceledOrders.mkString("\n")}
 
         expectedLevelChanges should matchTo(levelChanges)
     }
+  }
+
+  private def obInvariant(ob: OrderBook): Unit = {
+    val firstAskPrice = ob.asks.headOption.map(_._1).getOrElse(Long.MaxValue)
+    val firstBidPrice = ob.bids.headOption.map(_._1).getOrElse(Long.MinValue)
+    firstAskPrice should be > firstBidPrice
   }
 
   private def orderIds(ob: OrderBook): Set[Order.Id]         = ob.allOrders.map(_.order.id()).toSet

--- a/dex/src/test/scala/com/wavesplatform/dex/settings/BaseSettingsSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/settings/BaseSettingsSpecification.scala
@@ -155,6 +155,12 @@ class BaseSettingsSpecification extends AnyFlatSpec {
          |          client.bar = 3
          |        }
          |      }
+         |
+         |      circuit-breaker {
+         |        max-failures = 999
+         |        call-timeout = 123s
+         |        reset-timeout = 1d
+         |      }
          |    }
          |    process-consumed-timeout = 663s
          |    $orderFeeStr

--- a/dex/src/test/scala/com/wavesplatform/dex/settings/MatcherSettingsSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/settings/MatcherSettingsSpecification.scala
@@ -13,6 +13,7 @@ import com.wavesplatform.dex.domain.utils.EitherExt2
 import com.wavesplatform.dex.grpc.integration.settings.{GrpcClientSettings, WavesBlockchainClientSettings}
 import com.wavesplatform.dex.model.Implicits.AssetPairOps
 import com.wavesplatform.dex.queue.LocalMatcherQueue
+import com.wavesplatform.dex.settings.EventsQueueSettings.CircuitBreakerSettings
 import com.wavesplatform.dex.settings.OrderFeeSettings.{OrderFeeSettings, PercentSettings}
 import com.wavesplatform.dex.test.matchers.DiffMatcherWithImplicits
 import com.wavesplatform.dex.test.matchers.ProduceError.produce
@@ -83,6 +84,12 @@ class MatcherSettingsSpecification extends BaseSettingsSpecification with Matche
     settings.eventsQueue.kafka.consumer.maxBufferSize shouldBe 777
     settings.eventsQueue.kafka.consumer.client.getInt("foo") shouldBe 2
     settings.eventsQueue.kafka.producer.client.getInt("bar") shouldBe 3
+    settings.eventsQueue.circuitBreaker should matchTo(
+      CircuitBreakerSettings(
+        maxFailures = 999,
+        callTimeout = 123.seconds,
+        resetTimeout = 1.day
+      ))
     settings.processConsumedTimeout shouldBe 663.seconds
     settings.orderFee should matchTo(Map[Long, OrderFeeSettings](-1L -> PercentSettings(AssetType.AMOUNT, 0.1)))
     settings.deviation shouldBe DeviationsSettings(enabled = true, 1000000, 1000000, 1000000)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -55,7 +55,7 @@ object Dependencies {
     val playJson = "2.8.1"
 
     val googleGuava = "28.2-jre"
-    val kafka       = "2.4.0"
+    val kafka       = "2.5.0"
 
     val swagger   = "1.1.1"
     val swaggerUi = "3.24.3"


### PR DESCRIPTION
Fixed a potential bug with doubled orders:
* Changed semantics to At Most Once;
* Introduced a circuit breaker behind the queue;
* Added failedPlacements to AddressActor (see comments);

Fixed other bugs: 
* Orders those is cancelling doesn't cancel again;
* Ignore cancelling orders during low balance cancels.

Other:
* Little readability improvements.

Tests:
* Added new property based tests for OrderBook;
* MultipleMatchersOrderCancelTestSuite now is correct;
* Improved KafkaIssuesTestSuite, now it is correct.