### PR TITLE
DEX-776 Checker improvements

### DIFF
--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/AuthServiceRestConnector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/AuthServiceRestConnector.scala
@@ -17,14 +17,6 @@ import scala.util.Try
 
 case class AuthServiceRestConnector(target: String, chainId: Byte) extends RestConnector with JwtUtils {
 
-  def loginPageRequest: ErrorOr[Unit] = {
-    val uri = uri"$hostPortUri/swagger-ui.html"
-    for {
-      errorOrResponse <- Try { basicRequest.get(uri).send().body }.toEither.leftMap(ex => s"Cannot load swagger UI! ${ex.getWithStackTrace}")
-      _               <- errorOrResponse
-    } yield ()
-  }
-
   private def mkAuthTokenRequestParams(keyPair: KeyPair): List[QuerySegment] = {
     val jwtPayload = mkJwtSignedPayload(keyPair, networkByte = chainId)
     List(
@@ -38,19 +30,21 @@ case class AuthServiceRestConnector(target: String, chainId: Byte) extends RestC
 
   def getAuthCredentials(maybeSeed: Option[String]): ErrorOr[AuthCredentials] = {
 
-    val keyPair       = KeyPair(crypto secureHash (maybeSeed getOrElse s"minion${ThreadLocalRandom.current.nextInt}" getBytes StandardCharsets.UTF_8))
+    val seed          = maybeSeed getOrElse s"minion${ThreadLocalRandom.current.nextInt}"
+    val keyPair       = KeyPair(crypto secureHash (seed getBytes StandardCharsets.UTF_8))
     val requestParams = mkAuthTokenRequestParams(keyPair)
     val uri           = targetUri.copy(querySegments = requestParams)
 
     mkResponse { _.post(uri) }.map { j =>
       AuthCredentials(
         keyPair = keyPair,
-        token = (j \ "access_token").as[String]
+        token = (j \ "access_token").as[String],
+        seed = seed
       )
     }
   }
 }
 
 object AuthServiceRestConnector {
-  final case class AuthCredentials(keyPair: KeyPair, token: String)
+  final case class AuthCredentials(keyPair: KeyPair, token: String, seed: String)
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/NodeRestConnector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/NodeRestConnector.scala
@@ -1,5 +1,6 @@
 package com.wavesplatform.dex.tool.connectors
 
+import cats.syntax.either._
 import com.wavesplatform.dex.cli.ErrorOr
 import com.wavesplatform.dex.tool.connectors.Connector.RepeatRequestOptions
 import com.wavesplatform.dex.tool.connectors.RestConnector.ErrorOrJsonResponse
@@ -13,9 +14,22 @@ import sttp.model.MediaType
 import scala.annotation.tailrec
 import scala.concurrent.duration._
 
-case class NodeRestConnector(target: String, chainId: Byte, timeBetweenBlocks: FiniteDuration) extends RestConnector {
+case class NodeRestConnector(target: String, chainId: Byte) extends RestConnector {
 
-  override implicit val repeatRequestOptions: RepeatRequestOptions = RepeatRequestOptions((timeBetweenBlocks * 1.5).toSeconds.toInt, 1.second)
+  override implicit val repeatRequestOptions: RepeatRequestOptions = {
+    val blocksCount = 5
+    (
+      for {
+        currentHeight <- getCurrentHeight
+        blocksTs <- getBlockHeadersAtHeightRange((currentHeight - blocksCount).max(0), currentHeight)
+          .map(_.map(json => (json \ "timestamp").as[Long]))
+          .ensure("0 or 1 blocks have been forged at the moment, try again later")(_.size > 1)
+      } yield {
+        val timeBetweenBlocks = (blocksTs.zip(blocksTs.tail).map { case (older, newer) => newer - older }.sum / blocksCount * 1.5 / 1000).toInt
+        RepeatRequestOptions(timeBetweenBlocks, 1.second)
+      }
+    ).fold(ex => throw new RuntimeException(s"Could not construct repeat request options: $ex"), identity)
+  }
 
   private val mapper: WavesJsonMapper = new WavesJsonMapper(chainId); mapper.registerModule(new PlayJsonModule(JsonParserSettings()))
 
@@ -28,6 +42,9 @@ case class NodeRestConnector(target: String, chainId: Byte, timeBetweenBlocks: F
   def getTxInfo(tx: Transaction): ErrorOrJsonResponse = getTxInfo(tx.getId.toString)
 
   def getCurrentHeight: ErrorOr[Long] = mkResponse { _.get(uri"$targetUri/blocks/height") }.map(json => (json \ "height").as[Long])
+
+  def getBlockHeadersAtHeightRange(from: Long, to: Long): ErrorOr[Seq[JsValue]] =
+    mkResponse { _.get(uri"$targetUri/blocks/headers/seq/$from/$to") }.map(_.as[Seq[JsValue]])
 
   @tailrec
   final def waitForHeightArise(): ErrorOr[Long] = getCurrentHeight match {

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/NodeRestConnector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/NodeRestConnector.scala
@@ -25,7 +25,7 @@ case class NodeRestConnector(target: String, chainId: Byte) extends RestConnecto
           .map(_.map(json => (json \ "timestamp").as[Long]))
           .ensure("0 or 1 blocks have been forged at the moment, try again later")(_.size > 1)
       } yield {
-        val timeBetweenBlocks = (blocksTs.zip(blocksTs.tail).map { case (older, newer) => newer - older }.sum / blocksCount * 1.5 / 1000).toInt
+        val timeBetweenBlocks = ((blocksTs.last - blocksTs.head) / blocksCount * 1.5 / 1000).toInt
         RepeatRequestOptions(timeBetweenBlocks, 1.second)
       }
     ).fold(ex => throw new RuntimeException(s"Could not construct repeat request options: $ex"), identity)

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/RestConnector.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/connectors/RestConnector.scala
@@ -6,7 +6,6 @@ import com.wavesplatform.dex.error.Implicits.ThrowableOps
 import com.wavesplatform.dex.tool.connectors.RestConnector.{ErrorOrJsonResponse, RequestFunction}
 import play.api.libs.json.{JsValue, Json}
 import sttp.client._
-import sttp.model.Uri
 
 import scala.util.Try
 
@@ -14,18 +13,13 @@ trait RestConnector extends Connector {
 
   implicit protected val backend: SttpBackend[Identity, Nothing, NothingT] = HttpURLConnectionBackend()
 
-  protected lazy val targetUri        = uri"$target"
-  protected lazy val hostPortUri: Uri = uri"${targetUri.scheme}://${targetUri.host}${targetUri.port.fold("")(p => s":$p")}"
+  protected lazy val targetUri = uri"$target"
 
   protected def mkResponse(request: RequestFunction): ErrorOrJsonResponse =
     for {
       errorOrResponse <- Try(request(basicRequest).send().body).toEither.leftMap(ex => s"Cannot send request! ${ex.getWithStackTrace}")
       response        <- errorOrResponse
     } yield Json.parse(response)
-
-  def swaggerRequest: ErrorOrJsonResponse = mkResponse { _.get(uri"$targetUri/api-docs/swagger.json") }
-
-  def waitForSwaggerJson: ErrorOrJsonResponse = repeatRequest(swaggerRequest)(_.isRight)
 
   override def close(): Unit = backend.close()
 }


### PR DESCRIPTION
  * Time between blocks calculated automatically and used in repeatRequestOptions
  * DEX REST API optional parameter introduced. It affects DEX WS API uri
  * Node REST API parameter is optional now
  * Used seed for address stream test printed
  * Checker doesn't check swagger pages