### PR TITLE
DEX-818 Invalid asset balance on connection

### DIFF
--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/docker/WavesNodeContainer.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/docker/WavesNodeContainer.scala
@@ -9,7 +9,6 @@ import cats.instances.try_._
 import com.dimafeng.testcontainers.GenericContainer
 import com.typesafe.config.Config
 import com.wavesplatform.dex.domain.utils.ScorexLogging
-import com.wavesplatform.dex.it.api.HasWaitReady
 import com.wavesplatform.dex.it.api.node.NodeApi
 import com.wavesplatform.dex.it.cache.CachedData
 import com.wavesplatform.dex.it.fp
@@ -39,8 +38,8 @@ final case class WavesNodeContainer(override val internalIp: String, underlying:
 
   def grpcApiTarget: String = s"${grpcApiAddress.getHostName}:${grpcApiAddress.getPort}"
 
-  override def api: NodeApi[Id]               = fp.sync { NodeApi[Try](apiKey, cachedRestApiAddress.get()) }
-  override def asyncApi: HasWaitReady[Future] = NodeApi[Future](apiKey, cachedRestApiAddress.get())
+  override def api: NodeApi[Id]          = fp.sync { NodeApi[Try](apiKey, cachedRestApiAddress.get()) }
+  override def asyncApi: NodeApi[Future] = NodeApi[Future](apiKey, cachedRestApiAddress.get())
 
   override def invalidateCaches(): Unit = {
     super.invalidateCaches()

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/api/ws/WsAddressStreamTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/api/ws/WsAddressStreamTestSuite.scala
@@ -13,13 +13,15 @@ import com.wavesplatform.dex.error.SubscriptionsLimitReached
 import com.wavesplatform.dex.it.time.GlobalTimer
 import com.wavesplatform.dex.it.time.GlobalTimer.TimerOpsImplicits
 import com.wavesplatform.dex.it.waves.MkWavesEntities.IssueResults
-import com.wavesplatform.dex.model.{LimitOrder, MarketOrder, OrderStatus}
+import com.wavesplatform.dex.model.{LimitOrder, MarketOrder}
 import com.wavesplatform.dex.util.FutureOps.Implicits
+import com.wavesplatform.dex.it.api.responses.dex.OrderStatus
 import com.wavesplatform.it.WsSuiteBase
 import org.scalatest.prop.TableDrivenPropertyChecks
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
+import scala.concurrent.duration.DurationInt
 
 class WsAddressStreamTestSuite extends WsSuiteBase with TableDrivenPropertyChecks {
 
@@ -450,59 +452,181 @@ class WsAddressStreamTestSuite extends WsSuiteBase with TableDrivenPropertyCheck
       broadcastAndAwait(mkLeaseCancel(bob, leaseTx.getId))
     }
 
-    "DEX-818 Invalid asset balance after connection" in {
-      dex1.restart()
-      val bobBtcBalanceBefore = wavesNode1.api.balance(bob, btc)
-      broadcastAndAwait(IssueWctTx) // TODO
+    "DEX-818" - {
+      "Connections can affect each other" in {
+        val wscs    = (1 to 10).map(_ => mkWsAddressConnection(bob))
+        val mainWsc = mkWsAddressConnection(bob)
 
-      val now = System.currentTimeMillis()
-
-      val wsc = mkDexWsConnection(dex1)
-      wsc.send(WsAddressSubscribe(bob, WsAddressSubscribe.defaultAuthType, mkJwt(bob)))
-
-      val num = 100
-      val mkTransfers = (1 to num)
-        .map(i => mkTransfer(bob, alice, 1.btc, btc, feeAmount = minFee, timestamp = now + i))
-        .zip(
-          (1 to num).map(i => mkTransfer(bob, alice, 1.wct, wct, feeAmount = minFee, timestamp = now + i))
-        )
-        .flatMap {
-          case (a, b) => List(a, b)
+        markup("Multiple orders")
+        val now = System.currentTimeMillis()
+        val orders = (1 to 50).map { i =>
+          mkOrderDP(bob, wavesBtcPair, BUY, 1.waves, 0.00012, ts = now + i)
         }
 
-      wavesNode1.api.waitForHeightArise()
-      val interval    = wsMessagesInterval / 15
-      val simulation = Future
-        .inSeries(mkTransfers.zipWithIndex) {
-          case (tx, i) =>
-//            wavesNode1.asyncApi.currentHeight.flatMap { currentHeight =>
-//              if (currentHeight == savedHeight)
-            for {
-              _ <- wavesNode1.asyncApi.broadcast(tx)
-              _ <- GlobalTimer.instance.sleep(interval)
-//              state <- Future(wsc.receiveAtLeastN[WsAddressState](1))
-            } yield 0
-//              state.flatMap(_.balances).collect {
-//                case (asset, x) if asset == btc => i -> x
-//              }
-//            else Future.successful(List.empty)
-//            }
-        }
+        Await.result(Future.traverse(orders)(dex1.asyncApi.place), 1.minute)
+        dex1.api.cancelAll(bob)
 
-      Await.result(simulation, 1.minute)
-      val changes = wsc.receiveAtLeastN[WsAddressState](1).zipWithIndex.map {
-        case (x, i) => s"$i: btc: ${x.balances.get(btc)}, wct: ${x.balances.get(wct)}"
+        Await.result(Future.traverse(wscs)(wsc => Future(wsc.close())), 1.minute)
+        Thread.sleep(3000)
+        mainWsc.clearMessages()
+
+        markup("A new order")
+        placeAndAwaitAtDex(mkOrderDP(bob, wavesBtcPair, BUY, 2.waves, 0.00029))
+
+        eventually {
+          mainWsc.receiveAtLeastN[WsAddressState](1)
+        }
+        mainWsc.clearMessages()
       }
-      println(s"Changes:\n${changes.mkString("\n")}")
 
-//      val expectedBalance = Map[Asset, WsBalances](
-//        btc -> WsBalances(Denormalization.denormalizeAmountAndFee(bobBtcBalanceBefore - sent.btc, IssueBtcTx.getDecimals).toDouble, 0)
-//      )
-//
-//      eventually {
-//        val balance = wsc.receiveAtLeastN[WsAddressState](1).map(_.balances).squashed - Waves - wct
-//        balance should matchTo(expectedBalance)
-//      }
+      "Negative balances" in {
+        val carol = mkAccountWithBalance(5.waves -> Waves)
+        val wsc   = mkWsAddressConnection(carol)
+
+//        val order = mkOrderDP(carol, wavesUsdPair, SELL, 5.waves - matcherFee, 3, matcherFee)
+//        val simulation = dex1.asyncApi.tryPlace(order) zip {
+//          GlobalTimer.instance.sleep(150.millis).flatMap(_ => wavesNode1.asyncApi.broadcast(mkTransfer(carol, alice, 5.waves - minFee, Waves, minFee)))
+//        }
+        val now = System.currentTimeMillis()
+        val txs = (1 to 2).map { i =>
+          mkTransfer(carol, alice, 5.waves - minFee, Waves, minFee, timestamp = now + i)
+        }
+        val simulation = Future.traverse(txs)(wavesNode1.asyncApi.broadcast(_))
+        Await.result(simulation, 1.minute)
+        wavesNode1.api.waitForHeightArise()
+
+        wsc.balanceChanges.zipWithIndex.foreach {
+          case (changes, i) =>
+            changes.foreach {
+              case (asset, balance) =>
+                withClue(s"$i: $asset -> $balance: ") {
+                  balance.tradable should be >= 0.0
+                  balance.reserved should be >= 0.0
+                }
+            }
+        }
+      }
+
+      "Invalid asset balance after connection" in {
+        val carol = mkAccountWithBalance(15.waves -> Waves) // TODO amounts here and in orders too
+
+        val wsc1 = mkWsAddressConnection(carol)
+        wsc1.close()
+
+        broadcastAndAwait(
+          mkTransfer(carol, alice, 5.waves - minFee, Waves, minFee),
+          mkTransfer(alice, carol, 3.usd, usd)
+        )
+
+        val wsc2 = mkWsAddressConnection(carol)
+
+        val now = System.currentTimeMillis()
+        (1 to 5).foreach { i =>
+          info(s"Placing order #$i")
+          val order = mkOrderDP(carol, wavesUsdPair, BUY, 1.waves, 3.0, ts = now + i)
+          placeAndAwaitAtDex(order)
+          cancelAndAwait(carol, order)
+        }
+
+        placeAndAwaitAtDex(mkOrderDP(alice, wavesUsdPair, SELL, 1.waves, 3))
+        placeAndAwaitAtNode(mkOrderDP(carol, wavesUsdPair, BUY, 1.waves, 3, matcherFee)) // Spend all usd
+
+        broadcastAndAwait(
+          mkTransfer(carol, alice, 2.waves - minFee, Waves, minFee),
+          mkTransfer(alice, carol, 9.usd, usd)
+        )
+
+        val order6 = mkOrderDP(carol, wavesUsdPair, BUY, 1.waves, 3)
+        placeAndAwaitAtDex(order6)
+        cancelAndAwait(carol, order6)
+
+        placeAndAwaitAtDex(mkOrderDP(alice, wavesUsdPair, SELL, 1.waves, 4))
+        placeAndAwaitAtNode(mkOrderDP(carol, wavesUsdPair, BUY, 1.waves, 4, matcherFee)) // Spend all usd
+
+        placeAndAwaitAtDex(mkOrderDP(alice, wavesUsdPair, SELL, 1.waves, 5))
+
+        val o = mkOrderDP(carol, wavesUsdPair, BUY, 1.waves, 5, matcherFee)
+        val r = dex1.asyncApi.tryPlace(o) zip {
+          GlobalTimer.instance.sleep(150.millis).flatMap(_ => wavesNode1.asyncApi.broadcast(mkTransfer(carol, alice, 5.usd, usd)))
+        }
+        println(Await.result(r, 10.seconds))
+        // placeAndAwaitAtNode(o) // Spend all usd
+        wavesNode1.api.waitForHeightArise()
+
+        wsc2.balanceChanges.zipWithIndex.foreach {
+          case (changes, i) =>
+            changes.foreach {
+              case (asset, balance) =>
+                withClue(s"$i: $asset -> $balance: ") {
+                  balance.tradable should be >= 0.0
+                  balance.reserved should be >= 0.0
+                }
+            }
+        }
+
+        wsc2.close()
+
+        val balance = dex1.api.tradableBalance(carol, wavesUsdPair)
+        balance should matchTo(
+          Map[Asset, Long](
+            Waves -> ((15 - 5 + 1 - 2 + 1 + 1).waves - 3 * matcherFee)
+          ))
+      }
     }
+
+//    "DEX-818 Invalid asset balance after connection" in {
+//      dex1.restart()
+//      val bobBtcBalanceBefore = wavesNode1.api.balance(bob, btc)
+//      broadcastAndAwait(IssueWctTx) // TODO
+//
+//      val now = System.currentTimeMillis()
+//
+//      val wsc = mkDexWsConnection(dex1)
+//      wsc.send(WsAddressSubscribe(bob, WsAddressSubscribe.defaultAuthType, mkJwt(bob)))
+//
+//      val num = 100
+//      val mkTransfers = (1 to num)
+//        .map(i => mkTransfer(bob, alice, 1.btc, btc, feeAmount = minFee, timestamp = now + i))
+//        .zip(
+//          (1 to num).map(i => mkTransfer(bob, alice, 1.wct, wct, feeAmount = minFee, timestamp = now + i))
+//        )
+//        .flatMap {
+//          case (a, b) => List(a, b)
+//        }
+//
+//      wavesNode1.api.waitForHeightArise()
+//      val interval    = wsMessagesInterval / 15
+//      val simulation = Future
+//        .inSeries(mkTransfers.zipWithIndex) {
+//          case (tx, i) =>
+////            wavesNode1.asyncApi.currentHeight.flatMap { currentHeight =>
+////              if (currentHeight == savedHeight)
+//            for {
+//              _ <- wavesNode1.asyncApi.broadcast(tx)
+//              _ <- GlobalTimer.instance.sleep(interval)
+////              state <- Future(wsc.receiveAtLeastN[WsAddressState](1))
+//            } yield 0
+////              state.flatMap(_.balances).collect {
+////                case (asset, x) if asset == btc => i -> x
+////              }
+////            else Future.successful(List.empty)
+////            }
+//        }
+//
+//      Await.result(simulation, 1.minute)
+//      val changes = wsc.receiveAtLeastN[WsAddressState](1).zipWithIndex.map {
+//        case (x, i) => s"$i: btc: ${x.balances.get(btc)}, wct: ${x.balances.get(wct)}"
+//      }
+//      println(s"Changes:\n${changes.mkString("\n")}")
+//
+////      val expectedBalance = Map[Asset, WsBalances](
+////        btc -> WsBalances(Denormalization.denormalizeAmountAndFee(bobBtcBalanceBefore - sent.btc, IssueBtcTx.getDecimals).toDouble, 0)
+////      )
+////
+////      eventually {
+////        val balance = wsc.receiveAtLeastN[WsAddressState](1).map(_.balances).squashed - Waves - wct
+////        balance should matchTo(expectedBalance)
+////      }
+//    }
   }
 }

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/api/ws/WsAddressStreamTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/api/ws/WsAddressStreamTestSuite.scala
@@ -456,7 +456,7 @@ class WsAddressStreamTestSuite extends WsSuiteBase with TableDrivenPropertyCheck
         Await.result(Future.traverse(orders)(dex1.asyncApi.place), 1.minute)
         dex1.api.cancelAll(bob)
 
-        Await.result(Future.traverse(wscs)(wsc => Future(wsc.close())), 1.minute)
+        wscs.par.foreach(_.close())
         Thread.sleep(3000)
         mainWsc.clearMessages()
 

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/api/ws/WsOrderBookStreamTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/api/ws/WsOrderBookStreamTestSuite.scala
@@ -16,6 +16,7 @@ import com.wavesplatform.dex.settings.{DenormalizedMatchingRule, OrderRestrictio
 import com.wavesplatform.it.WsSuiteBase
 
 import scala.collection.immutable.TreeMap
+import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, Future}
 
 class WsOrderBookStreamTestSuite extends WsSuiteBase {
@@ -455,7 +456,7 @@ class WsOrderBookStreamTestSuite extends WsSuiteBase {
 
   "Bugs" - {
     "DEX-814 Connections can affect each other" in {
-      val wscs = (1 to 10).map(_ => mkWsOrderBookConnection(wavesBtcPair, dex1))
+      val wscs    = (1 to 10).map(_ => mkWsOrderBookConnection(wavesBtcPair, dex1))
       val mainWsc = mkWsOrderBookConnection(wavesBtcPair, dex1)
 
       markup("Multiple orders")
@@ -463,7 +464,6 @@ class WsOrderBookStreamTestSuite extends WsSuiteBase {
         mkOrderDP(carol, wavesBtcPair, BUY, 1.waves + i, 0.00012)
       }
 
-      import scala.concurrent.duration.DurationInt
       Await.result(Future.traverse(orders)(dex1.asyncApi.place), 1.minute)
       dex1.api.cancelAll(carol)
 
@@ -481,10 +481,10 @@ class WsOrderBookStreamTestSuite extends WsSuiteBase {
             assetPair = wavesBtcPair,
             asks = TreeMap.empty,
             bids = TreeMap(0.00029d -> 2d),
-            lastTrade = None,
+            lastTrade = none,
             updateId = 0,
             timestamp = buffer.last.timestamp,
-            settings = None
+            settings = none
           )
         )
       }

--- a/dex/src/main/scala/com/wavesplatform/dex/AddressActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/AddressActor.scala
@@ -308,6 +308,8 @@ class AddressActor(owner: Address,
       if (addressWsMutableState.hasActiveSubscriptions) {
         if (addressWsMutableState.hasChanges) {
           spendableBalancesActor ! SpendableBalancesActor.Query.GetState(owner, addressWsMutableState.getAllChangedAssets)
+          // We asked balances for current changedAssets and clean it here,
+          // because there are could be new changes between sent Query.GetState and received Reply.GetState.
           addressWsMutableState = addressWsMutableState.cleanBalanceChanges()
         } else scheduleNextDiffSending()
       }
@@ -320,8 +322,9 @@ class AddressActor(owner: Address,
           balances = mkWsBalances(spendableBalances),
           orders = addressWsMutableState.getAllOrderChanges
         )
-      } else if (addressWsMutableState.pendingSubscription.isEmpty) addressWsMutableState.cleanBalanceChanges()
-      else addressWsMutableState
+      } else if (addressWsMutableState.pendingSubscription.isEmpty) {
+        addressWsMutableState.cleanBalanceChanges() // There are neither active, nor pending connections
+      } else addressWsMutableState
 
       addressWsMutableState = addressWsMutableState.cleanOrderChanges()
 

--- a/dex/src/main/scala/com/wavesplatform/dex/AddressActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/AddressActor.scala
@@ -576,7 +576,6 @@ object AddressActor {
 
   sealed trait Message
   object Message {
-    // values of map allChanges can be used in future for tracking balances in AddressActor
     case class BalanceChanged(changedAssets: Set[Asset], changesForAudit: Map[Asset, Long]) extends Message
   }
 

--- a/dex/src/main/scala/com/wavesplatform/dex/AddressWsMutableState.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/AddressWsMutableState.scala
@@ -67,7 +67,7 @@ case class AddressWsMutableState(address: Address,
 
   def sendSnapshot(balances: Map[Asset, WsBalances], orders: Seq[WsOrder]): Unit = {
     val snapshot = WsAddressState(address, balances, orders, 0)
-    pendingSubscription.foreach(_ ! snapshot) // OR HERE
+    pendingSubscription.foreach(_ ! snapshot)
   }
 
   def sendDiffs(balances: Map[Asset, WsBalances], orders: Seq[WsOrder]): AddressWsMutableState = copy(

--- a/dex/src/main/scala/com/wavesplatform/dex/AddressWsMutableState.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/AddressWsMutableState.scala
@@ -30,9 +30,9 @@ case class AddressWsMutableState(address: Address,
     copy(activeSubscription = activeSubscription ++ pendingSubscription.iterator.map(_ -> 0L), pendingSubscription = Set.empty)
 
   def removeSubscription(subscriber: ActorRef[WsAddressState]): AddressWsMutableState = {
-    val updatedActiveSubscriptions = activeSubscription - subscriber
-    if (updatedActiveSubscriptions.isEmpty && pendingSubscription.isEmpty) copy(activeSubscription = Map.empty).cleanAllChanges()
-    else copy(activeSubscription = updatedActiveSubscriptions)
+    val updated = copy(activeSubscription = activeSubscription - subscriber)
+    if (updated.activeSubscription.isEmpty) updated.cleanAllChanges()
+    else updated
   }
 
   def putReservedAssets(diff: Set[Asset]): AddressWsMutableState  = copy(changedReservableAssets = changedReservableAssets ++ diff)
@@ -79,8 +79,9 @@ case class AddressWsMutableState(address: Address,
     }
   )
 
-  def cleanAllChanges(): AddressWsMutableState = copy(changedSpendableAssets = Set.empty, changedReservableAssets = Set.empty, ordersChanges = Map.empty)
-  def cleanOrderChanges(): AddressWsMutableState = copy(ordersChanges = Map.empty)
+  def cleanAllChanges(): AddressWsMutableState =
+    copy(changedSpendableAssets = Set.empty, changedReservableAssets = Set.empty, ordersChanges = Map.empty)
+  def cleanOrderChanges(): AddressWsMutableState   = copy(ordersChanges = Map.empty)
   def cleanBalanceChanges(): AddressWsMutableState = copy(changedSpendableAssets = Set.empty, changedReservableAssets = Set.empty)
 }
 

--- a/dex/src/main/scala/com/wavesplatform/dex/SpendableBalancesActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/SpendableBalancesActor.scala
@@ -78,7 +78,7 @@ class SpendableBalancesActor(spendableBalances: (Address, Set[Asset]) => Future[
 
     case SpendableBalancesActor.Command.SetState(address, state) =>
       val addressState = fullState.get(address) match {
-        case Some(r) => r
+        case Some(r) => r // Could be with multiple simultaneous connections
         case None =>
           val addressState = state ++ incompleteStateChanges.getOrElse(address, Map.empty) // HERE?
           fullState += address -> addressState

--- a/dex/src/main/scala/com/wavesplatform/dex/SpendableBalancesActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/SpendableBalancesActor.scala
@@ -93,7 +93,7 @@ class SpendableBalancesActor(spendableBalances: (Address, Set[Asset]) => Future[
     case SpendableBalancesActor.Command.UpdateStates(changes) =>
       changes.foreach {
         case (address, stateUpdate) =>
-          val addressFullState = fullState.get(address)
+          val addressFullState  = fullState.get(address)
           val knownBalance      = addressFullState orElse incompleteStateChanges.get(address) getOrElse Map.empty
           val (clean, forAudit) = if (knownBalance.isEmpty) (stateUpdate, stateUpdate) else getCleanAndForAuditChanges(stateUpdate, knownBalance)
 

--- a/dex/src/main/scala/com/wavesplatform/dex/SpendableBalancesActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/SpendableBalancesActor.scala
@@ -77,9 +77,14 @@ class SpendableBalancesActor(spendableBalances: (Address, Set[Asset]) => Future[
       }
 
     case SpendableBalancesActor.Command.SetState(address, state) =>
-      val addressState = state ++ incompleteStateChanges.getOrElse(address, Map.empty)
-      fullState += address -> addressState
-      incompleteStateChanges -= address
+      val addressState = fullState.get(address) match {
+        case Some(r) => r
+        case None =>
+          val addressState = state ++ incompleteStateChanges.getOrElse(address, Map.empty) // HERE?
+          fullState += address -> addressState
+          incompleteStateChanges -= address
+          addressState
+      }
       sender ! SpendableBalancesActor.Reply.GetSnapshot(addressState.asRight)
 
     case SpendableBalancesActor.Command.UpdateStates(changes) =>

--- a/dex/src/main/scala/com/wavesplatform/dex/SpendableBalancesActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/SpendableBalancesActor.scala
@@ -8,7 +8,7 @@ import com.wavesplatform.dex.domain.account.Address
 import com.wavesplatform.dex.domain.asset.Asset
 import com.wavesplatform.dex.domain.utils.ScorexLogging
 import com.wavesplatform.dex.error.{MatcherError, WavesNodeConnectionBroken}
-import com.wavesplatform.dex.fp.MapImplicits.cleaningGroup
+import com.wavesplatform.dex.fp.MapImplicits.group
 import com.wavesplatform.dex.grpc.integration.exceptions.WavesNodeConnectionLostException
 
 import scala.concurrent.Future
@@ -34,18 +34,18 @@ class SpendableBalancesActor(spendableBalances: (Address, Set[Asset]) => Future[
   def receive: Receive = {
 
     case SpendableBalancesActor.Query.GetState(address, assets) =>
-      val maybeAddressState            = fullState.get(address).orElse(incompleteStateChanges get address)
-      val assetsMaybeBalances          = assets.map(asset => asset -> maybeAddressState.flatMap(_ get asset)).toMap
+      val maybeAddressState   = fullState.get(address).orElse(incompleteStateChanges get address).getOrElse(Map.empty)
+      val assetsMaybeBalances = assets.map(asset => asset -> maybeAddressState.get(asset)).toMap
+
       val (knownAssets, unknownAssets) = assetsMaybeBalances.partition { case (_, balance) => balance.isDefined }
-
-      lazy val knownPreparedState = knownAssets.collect { case (a, Some(b)) => a -> b }
-
-      if (unknownAssets.isEmpty) sender ! SpendableBalancesActor.Reply.GetState(knownPreparedState)
-      else {
+      if (unknownAssets.isEmpty) {
+        val knownPreparedState = knownAssets.collect { case (a, Some(b)) => a -> b }
+        sender ! SpendableBalancesActor.Reply.GetState(knownPreparedState)
+      } else {
         val requestSender = sender
         spendableBalances(address, unknownAssets.keySet)
-          .map(stateFromNode => SpendableBalancesActor.NodeBalanceRequestRoundtrip(address, knownAssets.keySet, stateFromNode))
-          .andThen {
+          .map(SpendableBalancesActor.NodeBalanceRequestRoundtrip(address, knownAssets.keySet, _))
+          .onComplete {
             case Success(r) => self.tell(r, requestSender)
             case Failure(ex) =>
               log.error("Could not receive spendable balance from Waves Node", ex)
@@ -53,14 +53,17 @@ class SpendableBalancesActor(spendableBalances: (Address, Set[Asset]) => Future[
           }
       }
 
-    case SpendableBalancesActor.NodeBalanceRequestRoundtrip(address, knownAssets, stateFromNode) =>
-      if (!fullState.contains(address)) {
-        incompleteStateChanges = incompleteStateChanges.updated(address, stateFromNode ++ incompleteStateChanges.getOrElse(address, Map.empty))
+    case SpendableBalancesActor.NodeBalanceRequestRoundtrip(address, knownAssets, staleStateFromNode) =>
+      val assets = staleStateFromNode.keySet ++ knownAssets
+      val source = fullState.get(address) match {
+        case Some(state) => state
+        case None =>
+          val updated = staleStateFromNode ++ incompleteStateChanges.getOrElse(address, Map.empty) // probably we don't get an update from node?
+          incompleteStateChanges = incompleteStateChanges.updated(address, updated)
+          updated
       }
 
-      val assets = stateFromNode.keySet ++ knownAssets
-      val result = fullState.getOrElse(address, incompleteStateChanges(address)).filterKeys(assets)
-
+      val result = source.filter { case (asset, _) => assets.contains(asset) }
       sender ! SpendableBalancesActor.Reply.GetState(result)
 
     case SpendableBalancesActor.Query.GetSnapshot(address) =>
@@ -90,13 +93,14 @@ class SpendableBalancesActor(spendableBalances: (Address, Set[Asset]) => Future[
     case SpendableBalancesActor.Command.UpdateStates(changes) =>
       changes.foreach {
         case (address, stateUpdate) =>
-          val knownBalance      = fullState.get(address) orElse incompleteStateChanges.get(address) getOrElse Map.empty
+          val addressFullState = fullState.get(address)
+          val knownBalance      = addressFullState orElse incompleteStateChanges.get(address) getOrElse Map.empty
           val (clean, forAudit) = if (knownBalance.isEmpty) (stateUpdate, stateUpdate) else getCleanAndForAuditChanges(stateUpdate, knownBalance)
 
-          if (fullState contains address) fullState = fullState.updated(address, knownBalance ++ clean)
+          if (addressFullState.isDefined) fullState = fullState.updated(address, knownBalance ++ clean)
           else incompleteStateChanges = incompleteStateChanges.updated(address, knownBalance ++ clean)
 
-          addressDirectory ! AddressDirectory.Envelope(address, AddressActor.Message.BalanceChanged(clean, forAudit))
+          addressDirectory ! AddressDirectory.Envelope(address, AddressActor.Message.BalanceChanged(clean.keySet, forAudit))
       }
 
     // Subtract is called when there is a web socket connection and thus we have `fullState` for this address

--- a/dex/src/test/scala/com/wavesplatform/dex/SpendableBalancesActorSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/SpendableBalancesActorSpecification.scala
@@ -140,31 +140,31 @@ class SpendableBalancesActorSpecification
 
       val sba: ActorRef = system.actorOf(Props(new SpendableBalancesActor(spendableBalances, allAssetsSpendableBalances, testProbe.ref)))
 
-      def updateAndExpectBalanceChanges(update: (Asset, Long)*)(allChanges: Map[Asset, Long], decreasingChanges: Map[Asset, Long]): Unit = {
+      def updateAndExpectBalanceChanges(update: (Asset, Long)*)(changedAssets: Set[Asset], decreasingChanges: Map[Asset, Long]): Unit = {
         sba ! SpendableBalancesActor.Command.UpdateStates { Map(alice -> update.toMap) }
         val envelope = testProbe.expectMsgType[AddressDirectory.Envelope]
         envelope.address should matchTo(alice)
         envelope.cmd.asInstanceOf[AddressActor.Message.BalanceChanged] should matchTo {
-          AddressActor.Message.BalanceChanged(allChanges, decreasingChanges)
+          AddressActor.Message.BalanceChanged(changedAssets, decreasingChanges)
         }
       }
 
       // initial balance = Map(Waves -> 20.waves, usd -> 5.usd)
       withClue("Snapshot isn't received, increasing balance by Waves twice") {
-        updateAndExpectBalanceChanges(Waves -> 25.waves)(allChanges = Map(Waves -> 25.waves), decreasingChanges = Map(Waves -> 25.waves))
-        updateAndExpectBalanceChanges(Waves -> 26.waves)(allChanges = Map(Waves -> 26.waves), decreasingChanges = Map.empty)
+        updateAndExpectBalanceChanges(Waves -> 25.waves)(changedAssets = Set(Waves), decreasingChanges = Map(Waves -> 25.waves))
+        updateAndExpectBalanceChanges(Waves -> 26.waves)(changedAssets = Set(Waves), decreasingChanges = Map.empty)
       }
 
       withClue("Snapshot isn't received, decreasing balance by Waves") {
-        updateAndExpectBalanceChanges(Waves -> 23.waves)(allChanges = Map(Waves -> 23.waves), decreasingChanges = Map(Waves -> 23.waves))
+        updateAndExpectBalanceChanges(Waves -> 23.waves)(changedAssets = Set(Waves), decreasingChanges = Map(Waves -> 23.waves))
       }
 
       withClue("Snapshot isn't received, decreasing by USD") {
-        updateAndExpectBalanceChanges(usd -> 3.usd)(allChanges = Map(usd -> 3.usd), decreasingChanges = Map(usd -> 3.usd))
+        updateAndExpectBalanceChanges(usd -> 3.usd)(changedAssets = Set(usd), decreasingChanges = Map(usd -> 3.usd))
       }
 
       withClue("Snapshot isn't received, increasing by USD") {
-        updateAndExpectBalanceChanges(usd -> 8.usd)(allChanges = Map(usd -> 8.usd), decreasingChanges = Map.empty)
+        updateAndExpectBalanceChanges(usd -> 8.usd)(changedAssets = Set(usd), decreasingChanges = Map.empty)
       }
 
       withClue("Receiving snapshot") {
@@ -175,11 +175,11 @@ class SpendableBalancesActorSpecification
       }
 
       withClue("Snapshot received, increasing balance by Waves") {
-        updateAndExpectBalanceChanges(Waves -> 30.waves)(allChanges = Map(Waves -> 30.waves), decreasingChanges = Map.empty)
+        updateAndExpectBalanceChanges(Waves -> 30.waves)(changedAssets = Set(Waves), decreasingChanges = Map.empty)
       }
 
       withClue("Snapshot received, decreasing balance by USD") {
-        updateAndExpectBalanceChanges(usd -> 3.usd)(allChanges = Map(usd -> 3.usd), decreasingChanges = Map(usd -> 3.usd))
+        updateAndExpectBalanceChanges(usd -> 3.usd)(changedAssets = Set(usd), decreasingChanges = Map(usd -> 3.usd))
       }
     }
   }

--- a/waves-ext/src/main/scala/com/wavesplatform/dex/grpc/integration/services/WavesBlockchainApiGrpcService.scala
+++ b/waves-ext/src/main/scala/com/wavesplatform/dex/grpc/integration/services/WavesBlockchainApiGrpcService.scala
@@ -67,8 +67,7 @@ class WavesBlockchainApiGrpcService(context: ExtensionContext, balanceChangesBat
           val addressBalance  = allSpendableBalances.getOrDefault(address, Map.empty)
           val needUpdate      = !addressBalance.get(asset).contains(newAssetBalance)
 
-          val balance = spendableBalance(address, asset)
-          log.info(s"==> realTimeBalanceChanges $address: $asset -> $balance")
+          log.info(s"==> realTimeBalanceChanges $address: $asset -> $newAssetBalance")
 
           if (needUpdate) {
             allSpendableBalances.put(address, addressBalance + (asset -> newAssetBalance))

--- a/waves-ext/src/main/scala/com/wavesplatform/dex/grpc/integration/services/WavesBlockchainApiGrpcService.scala
+++ b/waves-ext/src/main/scala/com/wavesplatform/dex/grpc/integration/services/WavesBlockchainApiGrpcService.scala
@@ -67,8 +67,6 @@ class WavesBlockchainApiGrpcService(context: ExtensionContext, balanceChangesBat
           val addressBalance  = allSpendableBalances.getOrDefault(address, Map.empty)
           val needUpdate      = !addressBalance.get(asset).contains(newAssetBalance)
 
-          log.info(s"==> realTimeBalanceChanges $address: $asset -> $newAssetBalance")
-
           if (needUpdate) {
             allSpendableBalances.put(address, addressBalance + (asset -> newAssetBalance))
             Some(BalanceChangesFlattenResponse(address.toPB, asset.toPB, newAssetBalance))
@@ -213,7 +211,6 @@ class WavesBlockchainApiGrpcService(context: ExtensionContext, balanceChangesBat
       request.assetIds.map { requestedAssetRecord =>
         val asset   = requestedAssetRecord.assetId.toVanillaAsset
         val balance = spendableBalance(address, asset)
-        log.info(s"==> spendableAssetsBalances $address: $asset -> $balance")
         SpendableAssetsBalancesResponse.Record(
           requestedAssetRecord.assetId,
           balance
@@ -267,20 +264,11 @@ class WavesBlockchainApiGrpcService(context: ExtensionContext, balanceChangesBat
     Future {
       val address   = request.address.toVanillaAddress
       val portfolio = context.blockchain.portfolio(address)
-      val r = AllAssetsSpendableBalanceResponse(
+      AllAssetsSpendableBalanceResponse(
         (Waves :: portfolio.assets.keys.toList)
           .map(a => AllAssetsSpendableBalanceResponse.Record(a.toPB, spendableBalance(address, a)))
           .filterNot(_.balance == 0L)
       )
-
-      val str = r.balances
-        .map { x =>
-          s"${x.assetId.toVanillaAsset}: ${x.balance}"
-        }
-        .mkString("\n")
-      log.info(s"==> allAssetsSpendableBalance ${request.address.toVanillaAddress}:\n$str")
-
-      r
     }
   }
 

--- a/waves-ext/src/main/scala/com/wavesplatform/dex/grpc/integration/services/WavesBlockchainApiGrpcService.scala
+++ b/waves-ext/src/main/scala/com/wavesplatform/dex/grpc/integration/services/WavesBlockchainApiGrpcService.scala
@@ -209,11 +209,9 @@ class WavesBlockchainApiGrpcService(context: ExtensionContext, balanceChangesBat
 
     val assetsBalances =
       request.assetIds.map { requestedAssetRecord =>
-        val asset   = requestedAssetRecord.assetId.toVanillaAsset
-        val balance = spendableBalance(address, asset)
         SpendableAssetsBalancesResponse.Record(
           requestedAssetRecord.assetId,
-          balance
+          spendableBalance(address, requestedAssetRecord.assetId.toVanillaAsset)
         )
       }
 


### PR DESCRIPTION
A possible fix for invalid balances. The situation wasn't reproduced.

Also contains bug fixes:
* Connections with subscriptions to the address's changes can affect each other and the last subscription can be cancelled without an user's will;
* Negative balances can be propagated to the client;
* Changed assets should not be forgotten during new subscriptions. So their changes will be sent in the next WebSocket tick;
* The full state is set only once during multiple simultaneous connections. Fixes possible issues with the stale balances;

And improvements:
* AddressActor could have multiple WebSocket schedules;
