### PR TITLE
DEX-902 Scala 2.13.3 and dependencies update

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,7 +100,7 @@ lazy val root = (project in file("."))
 
 inScope(Global)(
   Seq(
-    scalaVersion := "2.13.2",
+    scalaVersion := "2.13.3",
     semanticdbEnabled := true,
     semanticdbVersion := scalafixSemanticdb.revision,
     organization := "com.wavesplatform",

--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/config/GenesisConfigGenerator.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/config/GenesisConfigGenerator.scala
@@ -38,7 +38,7 @@ object GenesisConfigGenerator {
 
   object Settings {
     implicit val chosenCase: NameMapper                = net.ceedubs.ficus.readers.namemappers.implicits.hyphenCase
-    implicit val settingsReader: ValueReader[Settings] = arbitraryTypeValueReader[Settings]
+    implicit val settingsReader: ValueReader[Settings] = arbitraryTypeValueReader[Settings].value
   }
 
   case class FullAddressInfo(seedText: SeedText,

--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/config/genesis/Block.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/config/genesis/Block.scala
@@ -85,5 +85,5 @@ object Block {
                    transactionData: Seq[GenesisTransaction],
                    signer: KeyPair): Either[GenericError, Block] =
     build(version, timestamp, reference, consensusData, transactionData, SignerData(signer, ByteStr.empty))
-      .map(unsigned => unsigned.copy(signerData = SignerData(signer, ByteStr(crypto.sign(signer, unsigned.bytes.value)))))
+      .map(unsigned => unsigned.copy(signerData = SignerData(signer, ByteStr(crypto.sign(signer, unsigned.bytes.value())))))
 }

--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/json/package.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/json/package.scala
@@ -68,7 +68,7 @@ package object json {
               case Array(amtAssetStr, prcAssetStr) => AssetPair.createAssetPair(amtAssetStr, prcAssetStr)
               case _                               => throw new Exception(s"$assetPairStr (incorrect assets count, expected 2 but got ${assetPairStrArr.size})")
             }
-          ) fold (ex => throw new Exception(s"$assetPairStr (${ex.getMessage})"), identity)
+          ).fold(ex => throw new Exception(s"$assetPairStr (${ex.getMessage})"), identity)
           assetPair -> offset
       }
     }

--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/time/GlobalTimer.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/time/GlobalTimer.scala
@@ -16,7 +16,7 @@ object GlobalTimer {
 
   implicit class TimerOpsImplicits(val timer: Timer) extends AnyVal {
     def schedule[A](f: => Future[A], delay: FiniteDuration): Future[A] = {
-      val p = Promise[A]
+      val p = Promise[A]()
       try {
         timer.newTimeout(_ => p.completeWith(f), delay.length, delay.unit)
       } catch {

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/CancelOrderTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/CancelOrderTestSuite.scala
@@ -67,7 +67,7 @@ class CancelOrderTestSuite extends MatcherSuiteBase {
       val ids = for { i <- 1 to 10 } yield {
         val o = mkOrder(acc, wavesUsdPair, OrderType.SELL, i.waves, 100 + i)
         placeAndAwaitAtDex(o)
-        o.id.value
+        o.id.value()
       }
 
       dex1.api.cancelAllByIdsWithApiKey(acc, ids.toSet)

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/PostgresHistoryDatabaseTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/PostgresHistoryDatabaseTestSuite.scala
@@ -84,7 +84,7 @@ class PostgresHistoryDatabaseTestSuite extends MatcherSuiteBase with HasPostgres
 
     def getFileContentStr(fileName: String): String = {
       val fileStream = getClass.getResourceAsStream(fileName)
-      Source.fromInputStream(fileStream).getLines.mkString
+      Source.fromInputStream(fileStream).getLines().mkString
     }
 
     def executeCreateTablesStatement(sqlConnection: Connection): Try[Unit] = Try {

--- a/dex-load/src/main/scala/com/wavesplatform/dex/load/GatlingFeeder.scala
+++ b/dex-load/src/main/scala/com/wavesplatform/dex/load/GatlingFeeder.scala
@@ -53,7 +53,7 @@ object GatlingFeeder {
   private def mkObsStrings(pairsFile: File, numberPerClient: Int): String = {
     val source = Source.fromFile(pairsFile)
     try {
-      val pairs = Random.shuffle(source.getLines.toVector)
+      val pairs = Random.shuffle(source.getLines().toVector)
       require(numberPerClient <= pairs.size, "numberPerClient > available asset pairs in file")
       pairs.take(numberPerClient).map(x => s"""{"T":"obs","S":"$x","d":100}""").mkString(";")
     } finally source.close()

--- a/dex-load/src/main/scala/com/wavesplatform/dex/load/TankGenerator.scala
+++ b/dex-load/src/main/scala/com/wavesplatform/dex/load/TankGenerator.scala
@@ -102,7 +102,7 @@ object TankGenerator {
       _ =>
         accounts.map(mkOrder(
           _,
-          if (math.random < 0.5 || !matching) Type.BUY else Type.SELL,
+          if (math.random() < 0.5 || !matching) Type.BUY else Type.SELL,
           settings.defaults.minimalOrderAmount + Random.nextInt(settings.defaults.minimalOrderAmount.toInt * 10),
           settings.defaults.minimalOrderPrice + Random.nextInt(settings.defaults.minimalOrderPrice.toInt * 10),
           pairs(Random.nextInt(pairs.length))

--- a/dex-load/src/main/scala/com/wavesplatform/dex/load/WavesDexLoadCli.scala
+++ b/dex-load/src/main/scala/com/wavesplatform/dex/load/WavesDexLoadCli.scala
@@ -49,7 +49,7 @@ object WavesDexLoadCli extends ScoptImplicits {
         cmd(Command.CreateFeederFile.name)
           .action((_, s) => s.copy(command = Command.CreateFeederFile.some))
           .text("Creates files for Gatling feeder")
-          children (
+          .children (
             opt[Int]("accounts-number")
               .abbr("an")
               .text("The number of generated accounts")

--- a/dex-load/src/main/scala/com/wavesplatform/dex/load/utils/package.scala
+++ b/dex-load/src/main/scala/com/wavesplatform/dex/load/utils/package.scala
@@ -12,14 +12,18 @@ import com.wavesplatform.wavesj.matcher.Order
 import com.wavesplatform.wavesj.matcher.Order.Type
 import com.wavesplatform.wavesj.{ApiJson, AssetPair, PrivateKeyAccount, Transactions}
 import play.api.libs.json.{JsValue, Json}
-import pureconfig._
+import pureconfig.ConfigSource
+
+import scala.annotation.nowarn
+import pureconfig.generic.auto._
 
 import scala.io.Source
 import scala.util.Random
 
 package object utils {
 
-  val settings =
+  @nowarn
+  val settings: Settings =
     ConfigSource
       .fromConfig(ConfigFactory.parseResources(scala.util.Properties.envOrElse("CONF", "devnet.conf")).getConfig("waves.dex.load"))
       .load[Settings]

--- a/dex-load/src/main/scala/com/wavesplatform/dex/load/utils/package.scala
+++ b/dex-load/src/main/scala/com/wavesplatform/dex/load/utils/package.scala
@@ -13,7 +13,6 @@ import com.wavesplatform.wavesj.matcher.Order.Type
 import com.wavesplatform.wavesj.{ApiJson, AssetPair, PrivateKeyAccount, Transactions}
 import play.api.libs.json.{JsValue, Json}
 import pureconfig._
-import pureconfig.generic.auto._
 
 import scala.io.Source
 import scala.util.Random
@@ -92,7 +91,8 @@ package object utils {
       val pairs =
         if (file.isEmpty) List.empty
         else
-          source.getLines
+          source
+            .getLines()
             .map(l => {
               val splitted = l.split("-")
               new AssetPair(splitted(0), splitted(1))

--- a/dex/src/main/scala/com/wavesplatform/dex/Matcher.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/Matcher.scala
@@ -473,7 +473,7 @@ class Matcher(settings: MatcherSettings)(implicit val actorSystem: ActorSystem) 
       }
 
       _ <- {
-        log.info("Preparing HTTP service ...")
+        log.info(s"Preparing HTTP service (Matcher's ID = ${settings.id}) ...")
         // Indirectly initializes matcherActor, so it must be after loadAllKnownAssets
         val combinedRoute = respondWithHeader(MatcherHttpServer(settings.id)) {
           new CompositeHttpService(matcherApiTypes, matcherApiRoutes, settings.restApi).compositeRoute

--- a/dex/src/main/scala/com/wavesplatform/dex/actors/MatcherActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/actors/MatcherActor.scala
@@ -130,7 +130,7 @@ class MatcherActor(settings: MatcherSettings,
 
   private def working: Receive = {
 
-    case GetMarkets         => sender ! tradedPairs.values.toSeq
+    case GetMarkets         => sender() ! tradedPairs.values.toSeq
     case GetSnapshotOffsets => sender() ! SnapshotOffsetsResponse(snapshotsState.snapshotOffsets)
 
     case request: QueueEventWithMeta =>

--- a/dex/src/main/scala/com/wavesplatform/dex/actors/SpendableBalancesActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/actors/SpendableBalancesActor.scala
@@ -38,9 +38,9 @@ class SpendableBalancesActor(spendableBalances: (Address, Set[Asset]) => Future[
       val (knownAssets, unknownAssets) = assetsMaybeBalances.partition { case (_, balance) => balance.isDefined }
       if (unknownAssets.isEmpty) {
         val knownPreparedState = knownAssets.collect { case (a, Some(b)) => a -> b }
-        sender ! SpendableBalancesActor.Reply.GetState(knownPreparedState)
+        sender() ! SpendableBalancesActor.Reply.GetState(knownPreparedState)
       } else {
-        val requestSender = sender
+        val requestSender = sender()
         spendableBalances(address, unknownAssets.keySet).onComplete {
           case Success(r) => self.tell(SpendableBalancesActor.NodeBalanceRequestRoundtrip(address, knownAssets.keySet, r), requestSender)
           case Failure(ex) =>
@@ -60,10 +60,10 @@ class SpendableBalancesActor(spendableBalances: (Address, Set[Asset]) => Future[
       }
 
       val result = source.filter { case (asset, _) => assets.contains(asset) }
-      sender ! SpendableBalancesActor.Reply.GetState(result)
+      sender() ! SpendableBalancesActor.Reply.GetState(result)
 
     case SpendableBalancesActor.Query.GetSnapshot(address) =>
-      val requestSender = sender
+      val requestSender = sender()
       fullState.get(address) match {
         case Some(state) => requestSender ! SpendableBalancesActor.Reply.GetSnapshot(state.asRight)
         case None =>
@@ -85,7 +85,7 @@ class SpendableBalancesActor(spendableBalances: (Address, Set[Asset]) => Future[
           incompleteStateChanges -= address
           addressState
       }
-      sender ! SpendableBalancesActor.Reply.GetSnapshot(addressState.asRight)
+      sender() ! SpendableBalancesActor.Reply.GetSnapshot(addressState.asRight)
 
     case SpendableBalancesActor.Command.UpdateStates(changes) =>
       changes.foreach {

--- a/dex/src/main/scala/com/wavesplatform/dex/actors/address/AddressDirectoryActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/actors/address/AddressDirectoryActor.scala
@@ -29,7 +29,7 @@ class AddressDirectoryActor(orderDB: OrderDB, addressActorProps: (Address, Boole
 
   private def forward(address: Address, msg: Any): Unit = (children get address, msg) match {
     case (None, _: AddressActor.Message.BalanceChanged) =>
-    case _                                              => children getOrElseUpdate (address, createAddressActor(address)) forward msg
+    case _                                              => children.getOrElseUpdate(address, createAddressActor(address)) forward msg
   }
 
   override def receive: Receive = {

--- a/dex/src/main/scala/com/wavesplatform/dex/actors/orderbook/AggregatedOrderBookActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/actors/orderbook/AggregatedOrderBookActor.scala
@@ -18,6 +18,7 @@ import com.wavesplatform.dex.settings.OrderRestrictionsSettings
 import com.wavesplatform.dex.time.Time
 import monocle.macros.GenLens
 
+import scala.annotation.nowarn
 import scala.collection.immutable.TreeMap
 import scala.concurrent.duration.FiniteDuration
 
@@ -251,6 +252,7 @@ object AggregatedOrderBookActor {
     case (k, v) => k -> v.view.map(_.amount).sum
   }
 
+  @nowarn
   def sum(orig: TreeMap[Price, Amount], diff: Map[Price, Amount]): TreeMap[Price, Amount] =
     diff.foldLeft(orig) {
       case (r, (price, amount)) =>

--- a/dex/src/main/scala/com/wavesplatform/dex/actors/tx/BroadcastExchangeTransactionActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/actors/tx/BroadcastExchangeTransactionActor.scala
@@ -36,7 +36,7 @@ class BroadcastExchangeTransactionActor(settings: ExchangeTransactionBroadcastSe
 
       confirmed { toCheck.map(_.id()) }
         .flatMap { confirmations =>
-          val (confirmed, unconfirmed) = toCheck.partition(tx => confirmations(tx.id.value))
+          val (confirmed, unconfirmed) = toCheck.partition(tx => confirmations(tx.id.value()))
           val (expired, ready)         = unconfirmed.partition(_.timestamp <= expireMs)
 
           Future

--- a/dex/src/main/scala/com/wavesplatform/dex/api/ws/actors/WsExternalClientHandlerActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/ws/actors/WsExternalClientHandlerActor.scala
@@ -153,7 +153,7 @@ object WsExternalClientHandlerActor {
                       clientRef ! WsError.from(e, matcherTime)
                       Behaviors.same
                     case Right(jwtPayload) =>
-                      val subscriptionLifetime = (jwtPayload.activeTokenExpirationInSeconds * 1000 - time.correctedTime).millis
+                      val subscriptionLifetime = (jwtPayload.activeTokenExpirationInSeconds * 1000 - time.correctedTime()).millis
                       val expiration           = scheduleOnce(subscriptionLifetime, CancelAddressSubscription(address))
 
                       addressSubscriptions

--- a/dex/src/main/scala/com/wavesplatform/dex/api/ws/connection/TestWsHandlerActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/ws/connection/TestWsHandlerActor.scala
@@ -30,7 +30,7 @@ class TestWsHandlerActor(testId: Int, keepAlive: Boolean) extends Actor with Sco
   }
 
   override val receive: Receive = {
-    case AssignSourceRef => context.become { awaitPings(sourceRef = sender) }
+    case AssignSourceRef => context.become { awaitPings(sourceRef = sender()) }
   }
 }
 

--- a/dex/src/main/scala/com/wavesplatform/dex/api/ws/routes/MatcherWebSocketRoute.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/ws/routes/MatcherWebSocketRoute.scala
@@ -244,7 +244,7 @@ class MatcherWebSocketRoute(wsInternalBroadcastRef: typed.ActorRef[WsInternalBro
 }
 
 object MatcherWebSocketRoute {
-  private[MatcherWebSocketRoute] class CloseHandler(val close: () => Unit, val closed: Promise[Done] = Promise[Done]) {
+  private[MatcherWebSocketRoute] class CloseHandler(val close: () => Unit, val closed: Promise[Done] = Promise[Done]()) {
     def closeOn(f: Future[Done]): Unit = closed.completeWith(f)
   }
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/api/ws/state/WsOrderBookState.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/ws/state/WsOrderBookState.scala
@@ -13,6 +13,7 @@ import com.wavesplatform.dex.domain.model.{Amount, Price}
 import com.wavesplatform.dex.model.{LastTrade, LevelAmounts}
 import monocle.macros.GenLens
 
+import scala.annotation.nowarn
 import scala.collection.immutable.TreeMap
 
 case class WsOrderBookState(wsConnections: Map[ActorRef[WsOrderBookChanges], Long],
@@ -74,6 +75,7 @@ case class WsOrderBookState(wsConnections: Map[ActorRef[WsOrderBookChanges], Lon
     changedTickSize = None
   )
 
+  @nowarn
   def take(xs: TreeMap[Price, Amount], levels: Set[Price]): TreeMap[Price, Amount] = {
     // 1. Levels will be always smaller, than xs
     // 2. A level could gone from xs

--- a/dex/src/main/scala/com/wavesplatform/dex/doc/MatcherErrorDoc.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/doc/MatcherErrorDoc.scala
@@ -4,12 +4,15 @@ import com.wavesplatform.dex.error.{Class, Entity, MatcherError}
 import com.wavesplatform.dex.meta.{DescendantSamples, getSimpleName}
 import play.api.libs.json.Json
 
+import scala.annotation.nowarn
+
 object MatcherErrorDoc {
 
   object entitySamples extends DescendantSamples[Entity]
   object classSamples  extends DescendantSamples[Class]
   object errorSamples  extends DescendantSamples[MatcherError]
 
+  @nowarn
   def mkMarkdown: String = {
     val entities = entitySamples.run
       .map(x => x.code -> getSimpleName(x))

--- a/dex/src/main/scala/com/wavesplatform/dex/meta/Sample.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/meta/Sample.scala
@@ -8,6 +8,7 @@ import com.wavesplatform.dex.domain.feature.BlockchainFeature
 import com.wavesplatform.dex.domain.order.{Order, OrderV3}
 import shapeless._
 
+import scala.annotation.nowarn
 import scala.reflect.ClassTag
 
 trait Sample[T] {
@@ -60,7 +61,8 @@ object Sample {
   implicit val assetPair: Sample[AssetPair]     = mk(AssetPair(issuedAsset.sample, asset.sample))
   implicit val address: Sample[Address]         = mk(KeyPair(ByteStr("address".getBytes)).toAddress)
   implicit val publicKey: Sample[PublicKey]     = mk(PublicKey(Sample[ByteStr]))
-  implicit val order: Sample[Order]             = mk(Sample[OrderV3])
+
+  @nowarn implicit val order: Sample[Order] = mk(Sample[OrderV3])
 
   implicit val blockchainFeature: Sample[BlockchainFeature] = mk(BlockchainFeature(777, "The most stronger feature"))
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/model/package.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/model/package.scala
@@ -4,6 +4,7 @@ import com.wavesplatform.dex.domain.bytes.ByteStr
 import com.wavesplatform.dex.domain.model.Price
 import com.wavesplatform.dex.domain.order.Order
 
+import scala.annotation.nowarn
 import scala.collection.immutable.{Queue, TreeMap}
 
 package object model {
@@ -16,6 +17,7 @@ package object model {
     /** Returns the best limit order in this side and the price of its level */
     def best: Option[(Price, LimitOrder)] = side.headOption.flatMap { case (levelPrice, level) => level.headOption.map(levelPrice -> _) }
 
+    @nowarn
     def enqueue(levelPrice: Price, lo: LimitOrder): Side = side.updated(levelPrice, side.getOrElse(levelPrice, Queue.empty).enqueue(lo))
 
     def unsafeWithoutBest: (Side, Order.Id) = side.headOption match {
@@ -34,6 +36,7 @@ package object model {
       side.updated(price, updated +: level.tail)
     }
 
+    @nowarn
     def unsafeRemove(price: Price, orderId: ByteStr): (Side, LimitOrder) = {
       val (toRemove, toKeep) = side.getOrElse(price, Queue.empty).partition(_.order.id() == orderId)
       require(toRemove.nonEmpty, s"Order $orderId not found at $price")
@@ -41,6 +44,7 @@ package object model {
       (updatedSide, toRemove.head)
     }
 
+    @nowarn
     def put(price: Price, lo: LimitOrder): Side = side.updated(price, side.getOrElse(price, Queue.empty).enqueue(lo))
 
     def aggregated: Iterable[LevelAgg] = for { (p, l) <- side.view if l.nonEmpty } yield LevelAgg(l.map(_.amount).sum, p)

--- a/dex/src/main/scala/com/wavesplatform/dex/queue/LocalMatcherQueue.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/queue/LocalMatcherQueue.scala
@@ -98,7 +98,7 @@ object LocalMatcherQueue {
     private implicit val executionContext: ExecutionContextExecutor = ExecutionContext.fromExecutor(executor)
 
     override def storeEvent(event: QueueEvent): Future[Option[QueueEventWithMeta]] = {
-      val p = Promise[QueueEventWithMeta]
+      val p = Promise[QueueEventWithMeta]()
       // Need to guarantee the order
       executor.submit(new Runnable {
         override def run(): Unit = {

--- a/dex/src/main/scala/com/wavesplatform/dex/tool/Checker.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/tool/Checker.scala
@@ -114,7 +114,7 @@ case class Checker(superConnector: SuperConnector) {
   }
 
   private def checkPlacement(assetPairInfo: AssetPairInfo): CheckLoggedResult[Order] = {
-    val orderType = if (Random.nextBoolean) BUY else SELL
+    val orderType = if (Random.nextBoolean()) BUY else SELL
     val order     = mkMatcherOrder(assetPairInfo.assetPair, orderType)
     for {
       _ <- dexRest.placeOrder(order)

--- a/dex/src/test/scala/com/wavesplatform/dex/actors/tx/BroadcastExchangeTransactionActorSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/actors/tx/BroadcastExchangeTransactionActorSpecification.scala
@@ -214,7 +214,7 @@ class BroadcastExchangeTransactionActorSpecification
   )
 
   private def sampleEvent(expiration: FiniteDuration = 1.day): ExchangeTransactionCreated = {
-    val ts = time.getTimestamp
+    val ts = time.getTimestamp()
     ExchangeTransactionCreated(
       ExchangeTransactionV2
         .create(

--- a/dex/src/test/scala/com/wavesplatform/dex/api/ws/ActorsWebSocketInteractionsSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/api/ws/ActorsWebSocketInteractionsSpecification.scala
@@ -151,7 +151,7 @@ class ActorsWebSocketInteractionsSpecification
       eventsProbe,
       wsEventsProbe,
       address,
-      () => subscribe,
+      () => subscribe(),
       placeOrder,
       cancelOrder,
       executeOrder,

--- a/dex/src/test/scala/com/wavesplatform/dex/doc/MatcherErrorDocSpec.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/doc/MatcherErrorDocSpec.scala
@@ -4,10 +4,12 @@ import com.wavesplatform.dex.meta.getSimpleName
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
+import scala.annotation.nowarn
+
 class MatcherErrorDocSpec extends AnyFreeSpec with Matchers {
   "MatcherErrorDoc" - {
     "should not contain two equal error codes" in {
-      val samples = MatcherErrorDoc.errorSamples.run.sortBy(_.code)
+      @nowarn val samples = MatcherErrorDoc.errorSamples.run.sortBy(_.code)
       samples.zip(samples.tail).foreach {
         case (e1, e2) =>
           withClue(s"${getSimpleName(e1)} and ${getSimpleName(e2)}") {

--- a/dex/src/test/scala/com/wavesplatform/dex/model/OrderBookSpec.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/model/OrderBookSpec.scala
@@ -373,10 +373,10 @@ ${canceledOrders.mkString("\n")}
   private def balancesBy(o: AcceptedOrder): Map[PublicKey, Map[Asset, Long]] = Map(o.order.senderPublicKey -> o.requiredBalance)
 
   private def spentPortfolio(ao: AcceptedOrder, executedAmount: Long, executedPrice: Long) =
-    Map(ao.spentAsset -> ao.order.getSpendAmount(executedAmount, executedPrice).explicitGet)
+    Map(ao.spentAsset -> ao.order.getSpendAmount(executedAmount, executedPrice).explicitGet())
 
   private def receivePortfolio(ao: AcceptedOrder, executedAmount: Long, executedPrice: Long) =
-    Map(ao.rcvAsset -> ao.order.getReceiveAmount(executedAmount, executedPrice).explicitGet)
+    Map(ao.rcvAsset -> ao.order.getReceiveAmount(executedAmount, executedPrice).explicitGet())
 
   private def spentFee(ao: AcceptedOrder, executedAmount: Long) =
     Map(ao.feeAsset -> AcceptedOrder.partialFee(ao.order.matcherFee, ao.order.amount, executedAmount))

--- a/dex/src/test/scala/com/wavesplatform/dex/model/OrderValidatorSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/model/OrderValidatorSpecification.scala
@@ -95,7 +95,7 @@ class OrderValidatorSpecification
       "order expires too soon" in forAll(Gen.choose[Long](1, OrderValidator.MinExpiration), accountGen) { (offset, pk) =>
         val tt       = new TestTime
         val unsigned = newBuyOrder
-        val signed   = Order.sign(unsigned.updateExpiration(tt.getTimestamp + offset).updateSender(pk), pk)
+        val signed   = Order.sign(unsigned.updateExpiration(tt.getTimestamp() + offset).updateSender(pk), pk)
 
         OrderValidator.timeAware(tt)(signed) should produce("WrongExpiration")
       }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -41,7 +41,7 @@ object Dependencies {
     val wavesProtobufSchemas = "1.2.6"
     val wavesJ               = "0.17.0"
 
-    val postgresql = "42.2.14"
+    val postgresql = "42.2.16"
     val quillJdbc  = "3.5.2"
 
     val sttp       = "1.7.2"
@@ -59,7 +59,7 @@ object Dependencies {
     val kafka       = "2.6.0"
 
     val swagger   = "1.1.2"
-    val swaggerUi = "3.26.1"
+    val swaggerUi = "3.32.5"
     val jaxbApi   = "2.3.1"
 
     val scorexCrypto = "2.1.9"
@@ -70,9 +70,9 @@ object Dependencies {
 
     val javaLevelDb = "0.12"
     val jniLevelDb  = "1.18.3"
-    val influxDb    = "2.19"
+    val influxDb    = "2.20"
 
-    val commonsNet = "3.6"
+    val commonsNet = "3.7"
     val nettyCodec = "4.1.33.Final"
     val jwt        = "4.3.0"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,10 +7,10 @@ object Dependencies {
 
     val parCollections = "0.2.0"
 
-    val akka     = "2.6.6"
+    val akka     = "2.6.8"
     val akkaHttp = "10.2.0"
 
-    val scalaTest          = "3.1.2"
+    val scalaTest          = "3.2.2"
     val scalaCheck         = "1.14.3"
     val scalaTestPlusCheck = "3.1.2.0"
     val scalaMock          = "4.4.0"
@@ -33,13 +33,13 @@ object Dependencies {
     val janino             = "3.1.2"
     val logbackJsonEncoder = "6.4"
 
-    val silencer = "1.7.0"
+    val silencer = "1.7.1"
 
     val kamonCore     = "2.1.1"
     val kamonInfluxDb = "2.1.1"
 
     val wavesProtobufSchemas = "1.2.5"
-    val wavesJ               = "0.16.0"
+    val wavesJ               = "0.17.0"
 
     val postgresql = "42.2.14"
     val quillJdbc  = "3.5.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
 
     val scalaTest          = "3.2.2"
     val scalaCheck         = "1.14.3"
-    val scalaTestPlusCheck = "3.1.2.0"
+    val scalaTestPlusCheck = "3.2.2.0"
     val scalaMock          = "4.4.0"
     val diffx              = "0.3.29"
 
@@ -22,11 +22,11 @@ object Dependencies {
     val betterMonadicFor  = "0.3.1"
     val mouse             = "0.25"
     val shapeless         = "2.3.3"
-    val monocle           = "2.0.5"
+    val monocle           = "2.1.0"
 
     val typesafeConfig = "1.4.0"
     val scopt          = "4.0.0-RC2"
-    val ficus          = "1.4.7"
+    val ficus          = "1.5.0"
 
     val logback            = "1.2.3"
     val slf4j              = "1.7.30"
@@ -35,19 +35,19 @@ object Dependencies {
 
     val silencer = "1.7.1"
 
-    val kamonCore     = "2.1.1"
-    val kamonInfluxDb = "2.1.1"
+    val kamonCore     = "2.1.6"
+    val kamonInfluxDb = "2.1.6"
 
-    val wavesProtobufSchemas = "1.2.5"
+    val wavesProtobufSchemas = "1.2.6"
     val wavesJ               = "0.17.0"
 
     val postgresql = "42.2.14"
-    val quillJdbc  = "3.5.1"
+    val quillJdbc  = "3.5.2"
 
     val sttp       = "1.7.2"
-    val sttpClient = "2.2.0"
+    val sttpClient = "2.2.7"
 
-    val testContainers          = "0.38.0"
+    val testContainers          = "0.38.1"
     val testContainersPostgres  = "1.14.3"
     val testContainersKafka     = "1.14.3"
     val testContainersToxiProxy = "1.14.3"
@@ -56,13 +56,13 @@ object Dependencies {
     val playJson = "2.9.0"
 
     val googleGuava = "28.2-jre"
-    val kafka       = "2.5.0"
+    val kafka       = "2.6.0"
 
     val swagger   = "1.1.2"
     val swaggerUi = "3.26.1"
     val jaxbApi   = "2.3.1"
 
-    val scorexCrypto = "2.1.8"
+    val scorexCrypto = "2.1.9"
 
     val monix = "3.2.2"
 

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/domain/transaction/ExchangeTransaction.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/domain/transaction/ExchangeTransaction.scala
@@ -100,7 +100,7 @@ trait ExchangeTransaction extends ByteAndJsonSerializable with Proven {
 
   override def toString: String = json().toString
 
-  def toPrettyString: String = json.map(Json.prettyPrint).value
+  def toPrettyString: String = json.map(Json.prettyPrint).value()
 
   override def equals(other: Any): Boolean = other match {
     case tx: ExchangeTransaction => id() == tx.id()

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/WavesBlockchainGrpcAsyncClient.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/WavesBlockchainGrpcAsyncClient.scala
@@ -43,7 +43,7 @@ class WavesBlockchainGrpcAsyncClient(eventLoopGroup: EventLoopGroup, channel: Ma
     case ex                                 => UnexpectedConnectionException("Unexpected connection error", ex)
   }
 
-  private def handlingErrors[A](f: => Future[A]): Future[A] = { f transform (identity, gRPCErrorsHandler) }
+  private def handlingErrors[A](f: => Future[A]): Future[A] = { f.transform(identity, gRPCErrorsHandler) }
 
   private val shuttingDown      = new AtomicBoolean(false)
   private val blockchainService = WavesBlockchainApiGrpc.stub(channel)


### PR DESCRIPTION
* Scala version, akka, scalatest, silencer, scalacheck, monocle, ficus, kamon, waves protobuf schemas, quill jdbc, sttp client, testcontainers, kafka client, scorex, postgres, swagger ui, influx db and common net updated