### PR TITLE
DEX-850 WS API Ping interval increasing

### DIFF
--- a/dex-it/src/test/resources/dex-servers/dex-base.conf
+++ b/dex-it/src/test/resources/dex-servers/dex-base.conf
@@ -40,6 +40,11 @@ waves.dex {
   }
 
   start-events-processing-timeout = 3m # Limit the starting time of container
+
+  web-sockets.health-check {
+    ping-interval = 10s
+    pong-timeout = 30s
+  }
 }
 
 akka {

--- a/dex/src/main/resources/application.conf
+++ b/dex/src/main/resources/application.conf
@@ -501,11 +501,11 @@ waves.dex {
   web-sockets {
     health-check {
       # Interval between ping messages sent to client
-      ping-interval = 10s
+      ping-interval = 30s
 
       # Timeout for client response with the last payload.
       # That means matcher expects pong to the last sent ping. Outdated pongs will be ignored
-      pong-timeout = 30s
+      pong-timeout = 70s
     }
 
     # Settings for
@@ -608,7 +608,7 @@ akka {
   http {
     server {
       server-header = ""
-      idle-timeout = 25s
+      idle-timeout = 110s
     }
 
     client.user-agent-header = ""


### PR DESCRIPTION
 * Ping interval, pong timeout and connection idle timeout (akka.http.server.idle-timeout) increased
 * Checked by websocat, dark web socket terminal and websocket.org/echo.html