### PR TITLE
DEX-959 Accept an order with a previous fee

### DIFF
--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/RatesTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/RatesTestSuite.scala
@@ -85,10 +85,15 @@ class RatesTestSuite extends MatcherSuiteBase {
     dex1.httpApi.upsertRate(btc, 1).code shouldBe StatusCodes.Created
 
     // place order with admissible fee (according to btc rate = 1)
-    val order1 = newOrder
-    placeAndAwaitAtDex(order1)
+    placeAndAwaitAtDex(newOrder)
 
     // slightly increase rate for btc
+    dex1.httpApi.upsertRate(btc, 1.2).code shouldBe StatusCodes.Ok
+
+    // the same order is passed, because we choose the minimal rate between 1 and 1.1
+    placeAndAwaitAtDex(newOrder)
+
+    // now a new order doesn't matches both rates
     dex1.httpApi.upsertRate(btc, 1.1).code shouldBe StatusCodes.Ok
 
     // the same order now is rejected

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/RatesTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/RatesTestSuite.scala
@@ -93,7 +93,7 @@ class RatesTestSuite extends MatcherSuiteBase {
     // the same order is passed, because we choose the minimal rate between 1 and 1.1
     placeAndAwaitAtDex(newOrder)
 
-    // now a new order doesn't matches both rates
+    // now a new order doesn't match both rates
     dex1.httpApi.upsertRate(btc, 1.1).code shouldBe StatusCodes.Ok
 
     // the same order now is rejected

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/OrderDynamicFeeTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/OrderDynamicFeeTestSuite.scala
@@ -185,7 +185,7 @@ class OrderDynamicFeeTestSuite extends OrderFeeBaseTestSuite {
       upsertRates(eth -> 0.1)
       dex1.tryApi.place(order) should failWith(
         9441540, // UnexpectedFeeAsset
-        s"Required one of the following fee asset: $EthId, WAVES. But given $BtcId"
+        s"But given $BtcId"
       )
       dex1.api.deleteRate(eth)
     }

--- a/dex/src/main/scala/com/wavesplatform/dex/caches/DropOldestFixedBuffer2.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/caches/DropOldestFixedBuffer2.scala
@@ -1,0 +1,10 @@
+package com.wavesplatform.dex.caches
+
+private[caches] case class DropOldestFixedBuffer2(prev: Double, latest: Double) {
+  val min: Double = math.min(prev, latest)
+  def append(e: Double): DropOldestFixedBuffer2 = DropOldestFixedBuffer2(latest, e)
+}
+
+private[caches] object DropOldestFixedBuffer2 {
+  def apply(init: Double): DropOldestFixedBuffer2 = DropOldestFixedBuffer2(init, init)
+}

--- a/dex/src/main/scala/com/wavesplatform/dex/caches/RateCache.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/caches/RateCache.scala
@@ -27,9 +27,9 @@ object RateCache {
   private val WavesRateOpt = Option(WavesRate)
 
   /**
-   * 1. Stores two values for each asset
-   * 2. In getRate returns the least rate
-   * 3. In other methods returns the latest rate
+   * 1. Stores internally two values for each asset
+   * 2. getRate returns the least rate
+   * 3. other methods return the latest rate
    */
   def apply(rateDB: RateDB): RateCache = new RateCache {
 

--- a/dex/src/main/scala/com/wavesplatform/dex/db/RateDB.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/db/RateDB.scala
@@ -5,6 +5,7 @@ import com.wavesplatform.dex.domain.asset.Asset.IssuedAsset
 import com.wavesplatform.dex.domain.bytes.ByteStr
 import org.iq80.leveldb.DB
 
+import scala.collection.concurrent.TrieMap
 import scala.collection.mutable.ListBuffer
 
 trait RateDB {
@@ -36,6 +37,13 @@ object RateDB {
     }
 
     def deleteRate(asset: IssuedAsset): Unit = db.readWrite(_.delete(DbKeys.rate(asset)))
+  }
+
+  def inMem: RateDB = new RateDB {
+    private val rates = TrieMap.empty[IssuedAsset, Double]
+    override def upsertRate(asset: IssuedAsset, value: Double): Unit = rates += asset -> value
+    override def getAllRates: Map[IssuedAsset, Double] = rates.toMap
+    override def deleteRate(asset: IssuedAsset): Unit = rates -= asset
   }
 
 }

--- a/dex/src/test/scala/com/wavesplatform/dex/caches/DropOldestFixedBuffer2Spec.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/caches/DropOldestFixedBuffer2Spec.scala
@@ -8,16 +8,14 @@ import org.scalatestplus.scalacheck.{ScalaCheckPropertyChecks => PropertyChecks}
 
 class DropOldestFixedBuffer2Spec extends AnyFreeSpecLike with Matchers with PropertyChecks with NoShrink {
   private val doubleGen = Arbitrary.arbDouble.arbitrary
-  private val testGen = Gen.zip(doubleGen, Gen.listOf(Arbitrary.arbDouble.arbitrary))
+  private val testGen = Gen.zip(doubleGen, Gen.listOf(doubleGen))
 
   "DropOldestFixedBuffer2" - {
     "min" - {
       "selects the minimal value between two last" in forAll(testGen) { case (init, xs) =>
         val buff = xs.foldLeft(DropOldestFixedBuffer2(init))(_.append(_))
-
         val lastTwo = (init :: xs).takeRight(2)
-        val expectedMin = if (lastTwo.isEmpty) init else lastTwo.min
-        buff.min shouldBe expectedMin
+        buff.min shouldBe lastTwo.min
       }
     }
   }

--- a/dex/src/test/scala/com/wavesplatform/dex/caches/DropOldestFixedBuffer2Spec.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/caches/DropOldestFixedBuffer2Spec.scala
@@ -1,0 +1,24 @@
+package com.wavesplatform.dex.caches
+
+import com.wavesplatform.dex.NoShrink
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.freespec.AnyFreeSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.{ScalaCheckPropertyChecks => PropertyChecks}
+
+class DropOldestFixedBuffer2Spec extends AnyFreeSpecLike with Matchers with PropertyChecks with NoShrink {
+  private val doubleGen = Arbitrary.arbDouble.arbitrary
+  private val testGen = Gen.zip(doubleGen, Gen.listOf(Arbitrary.arbDouble.arbitrary))
+
+  "DropOldestFixedBuffer2" - {
+    "min" - {
+      "selects the minimal value between two last" in forAll(testGen) { case (init, xs) =>
+        val buff = xs.foldLeft(DropOldestFixedBuffer2(init))(_.append(_))
+
+        val lastTwo = (init :: xs).takeRight(2)
+        val expectedMin = if (lastTwo.isEmpty) init else lastTwo.min
+        buff.min shouldBe expectedMin
+      }
+    }
+  }
+}


### PR DESCRIPTION
* RateCache explicitly depends on RateDB;
* RateDB has inMem implementation;
* Added unit tests;
* Updated RatesTestSuite.