### PR TITLE
DEX-1010 Moving common block

### DIFF
--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/WavesBlock.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/WavesBlock.scala
@@ -17,8 +17,15 @@ object WavesBlock {
   sealed trait Type extends Product with Serializable
 
   object Type {
-    case object FullBlock extends Type
-    case object MicroBlock extends Type
+
+    case object FullBlock extends Type {
+      override val toString = "f"
+    }
+
+    case object MicroBlock extends Type {
+      override val toString = "m"
+    }
+
   }
 
 }

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/WavesFork.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/WavesFork.scala
@@ -25,8 +25,11 @@ case class WavesFork private[domain] (origChain: WavesChain, forkChain: WavesCha
     case Right(updatedForkChain) =>
       // TODO DEX-1010 if we are restoring the origChain in forkChain, hold NotResolved until we get all micro blocks
       // Compare heights to solve a situation when there no transactions in the network since some height
-      if (block.tpe == WavesBlock.Type.FullBlock || block.ref.height < origChain.height)
-        Status.NotResolved(copy(forkChain = updatedForkChain))
+      if (
+        block.ref.height < origChain.height
+        || block.tpe == WavesBlock.Type.FullBlock
+        || block.tpe == WavesBlock.Type.MicroBlock && origChain.has(block.ref) // On the same chain
+      ) Status.NotResolved(copy(forkChain = updatedForkChain))
       else {
         val (origDropped, forkDropped) = WavesChain.dropDifference(origChain, updatedForkChain)
 

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/WavesFork.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/WavesFork.scala
@@ -8,7 +8,6 @@ import cats.syntax.semigroup._
 import com.wavesplatform.dex.grpc.integration.clients.domain.WavesFork.Status
 
 // TODO DEX-1009 Unit test
-// TODO DEX-1010 Can be connected again if forkChain rolled back behind origChain and restored the same chain
 // TODO DEX-1011 This class is too slow for his purposes
 case class WavesFork private[domain] (origChain: WavesChain, forkChain: WavesChain) {
 
@@ -26,7 +25,7 @@ case class WavesFork private[domain] (origChain: WavesChain, forkChain: WavesCha
     case Right(updatedForkChain) =>
       // TODO DEX-1010 if we are restoring the origChain in forkChain, hold NotResolved until we get all micro blocks
       // Compare heights to solve a situation when there no transactions in the network since some height
-      if (block.tpe == WavesBlock.Type.FullBlock && block.ref.height < origChain.height)
+      if (block.tpe == WavesBlock.Type.FullBlock || block.ref.height < origChain.height)
         Status.NotResolved(copy(forkChain = updatedForkChain))
       else {
         val (origDropped, forkDropped) = WavesChain.dropDifference(origChain, updatedForkChain)

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/WavesFork.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/WavesFork.scala
@@ -19,12 +19,10 @@ case class WavesFork private[domain] (origChain: WavesChain, forkChain: WavesCha
 
   def height: Int = forkChain.height
 
-  // TODO DEX-1010 if we have e.g. 10 blocks and did rollback for 2, we don't need to request balances. Check this case
   def withBlock(block: WavesBlock): Status = forkChain.withBlock(block) match {
     case Left(e) => Status.Failed(withoutLast, e)
     case Right(updatedForkChain) =>
-      // TODO DEX-1010 if we are restoring the origChain in forkChain, hold NotResolved until we get all micro blocks
-      // Compare heights to solve a situation when there no transactions in the network since some height
+      // Compare heights to solve a situation when there are no transactions in the network since some height
       if (
         block.ref.height < origChain.height
         || block.tpe == WavesBlock.Type.FullBlock

--- a/waves-integration/src/test/scala/com/wavesplatform/dex/grpc/integration/clients/domain/StatusTransitionsTestSuite.scala
+++ b/waves-integration/src/test/scala/com/wavesplatform/dex/grpc/integration/clients/domain/StatusTransitionsTestSuite.scala
@@ -164,7 +164,7 @@ class StatusTransitionsTestSuite extends WavesIntegrationSuiteBase {
       )
 
       val block2B = WavesBlock(
-        ref = BlockRef(height = 2, id = ByteStr(Array[Byte](98, 1, 0))),
+        ref = BlockRef(height = 2, id = ByteStr(Array[Byte](98, 1, 1, 0))),
         reference = block1.ref.id,
         changes = BlockchainBalance(
           regular = Map(bob -> Map(usd -> 12), alice -> Map(usd -> 41)),
@@ -184,7 +184,7 @@ class StatusTransitionsTestSuite extends WavesIntegrationSuiteBase {
       "Appended ->" - {
         "Normal" in {
           val microBlock = WavesBlock(
-            ref = BlockRef(height = 2, id = ByteStr(Array[Byte](98, 1, 1))),
+            ref = BlockRef(height = 2, id = ByteStr(Array[Byte](98, 1, 1, 1))),
             reference = block2B.ref.id,
             changes = BlockchainBalance(
               regular = Map(alice -> Map(usd -> 8), carol -> Map(Waves -> 4)),

--- a/waves-integration/src/test/scala/com/wavesplatform/dex/grpc/integration/clients/domain/WavesForkTestSuite.scala
+++ b/waves-integration/src/test/scala/com/wavesplatform/dex/grpc/integration/clients/domain/WavesForkTestSuite.scala
@@ -1,0 +1,157 @@
+package com.wavesplatform.dex.grpc.integration.clients.domain
+
+import java.nio.charset.StandardCharsets
+
+import cats.Monoid
+import cats.syntax.either._
+import cats.syntax.option._
+import cats.syntax.semigroup._
+import com.wavesplatform.dex.domain.account.KeyPair
+import com.wavesplatform.dex.domain.asset.Asset.{IssuedAsset, Waves}
+import com.wavesplatform.dex.domain.bytes.ByteStr
+import com.wavesplatform.dex.domain.bytes.codec.Base58
+import com.wavesplatform.dex.grpc.integration.clients.domain.WavesFork.Status
+import com.wavesplatform.dex.test.matchers.ProduceError.produce
+import com.wavesplatform.dex.{NoShrink, WavesIntegrationSuiteBase}
+import org.scalacheck.Gen
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+
+import scala.util.matching.Regex
+
+class WavesForkTestSuite extends WavesIntegrationSuiteBase with ScalaCheckDrivenPropertyChecks with NoShrink {
+
+  private val alice = KeyPair(ByteStr("alice".getBytes(StandardCharsets.UTF_8))).toAddress
+  private val bob = KeyPair(ByteStr("bob".getBytes(StandardCharsets.UTF_8))).toAddress
+
+  private val usd = IssuedAsset(Base58.decode("usd"))
+
+  private val block1 = WavesBlock(
+    ref = BlockRef(height = 1, id = ByteStr(Array[Byte](98, 0))),
+    reference = ByteStr.empty,
+    changes = BlockchainBalance(
+      regular = Map(alice -> Map(Waves -> 10, usd -> 2L)),
+      outLeases = Map(bob -> 23L)
+    ),
+    tpe = WavesBlock.Type.FullBlock
+  )
+
+  private val block2 = WavesBlock(
+    ref = BlockRef(height = 2, id = ByteStr(Array[Byte](98, 1, 0))),
+    reference = block1.ref.id,
+    changes = BlockchainBalance(
+      regular = Map(bob -> Map(usd -> 35)),
+      outLeases = Map.empty
+    ),
+    tpe = WavesBlock.Type.FullBlock
+  )
+
+  private val block3 = WavesBlock(
+    ref = BlockRef(height = 3, id = ByteStr(Array[Byte](98, 1, 1, 0))),
+    reference = block2.ref.id,
+    changes = BlockchainBalance(
+      regular = Map(alice -> Map(usd -> 30)),
+      outLeases = Map(alice -> 1L)
+    ),
+    tpe = WavesBlock.Type.FullBlock
+  )
+
+  "WavesFork" - {
+    "withBlock" - {
+      "Failed - on an unexpected block, removes the last block" in {
+        val fork = WavesFork(
+          WavesChain(Vector(block2, block1), 98),
+          WavesChain(Vector(block1), 98)
+        )
+
+        val invalidBlock = WavesBlock(
+          ref = BlockRef(height = 2, id = ByteStr(Array[Byte](98, 1, 0))),
+          reference = ByteStr(Array[Byte](-98)),
+          changes = BlockchainBalance(
+            regular = Map(bob -> Map(usd -> 35)),
+            outLeases = Map.empty
+          ),
+          tpe = WavesBlock.Type.FullBlock
+        )
+
+        val expectedUpdatedFork = WavesFork(
+          WavesChain(Vector(block2, block1), 98),
+          WavesChain(Vector.empty, 99)
+        )
+
+        fork.withBlock(invalidBlock) should matchTo(Status.Failed(
+          updatedFork = expectedUpdatedFork,
+          reason = "The new block BlockRef(h=2, ZvGf) (reference=3j) must be after BlockRef(h=1, 8TZ)"
+        ): Status)
+      }
+
+      "NotResolved - the height is still less than on the previous chain" - {
+        "full block" in {
+          val fork = WavesFork(
+            WavesChain(Vector(block3, block2, block1), 97),
+            WavesChain(Vector(block1), 99)
+          )
+
+          val expectedUpdatedFork = WavesFork(
+            WavesChain(Vector(block3, block2, block1), 97),
+            WavesChain(Vector(block2, block1), 98)
+          )
+
+          fork.withBlock(block2) should matchTo(Status.NotResolved(expectedUpdatedFork): Status)
+        }
+
+        "micro block" in {
+          val fork = WavesFork(
+            WavesChain(Vector(block3, block2, block1), 97),
+            WavesChain(Vector(block2, block1), 98)
+          )
+
+          val microBlock = WavesBlock(
+            ref = BlockRef(height = 2, id = ByteStr(Array[Byte](98, 1, 1))),
+            reference = block2.ref.id,
+            changes = BlockchainBalance(
+              regular = Map(alice -> Map(usd -> 30)),
+              outLeases = Map(alice -> 1L)
+            ),
+            tpe = WavesBlock.Type.MicroBlock
+          )
+
+          val expectedUpdatedFork = WavesFork(
+            WavesChain(Vector(block3, block2, block1), 97),
+            WavesChain(Vector(microBlock, block2, block1), 98)
+          )
+
+          fork.withBlock(microBlock) should matchTo(Status.NotResolved(expectedUpdatedFork): Status)
+        }
+      }
+
+      "Resolved on micro block" in {
+        val fork = WavesFork(
+          WavesChain(Vector(block2, block1), 98),
+          WavesChain(Vector(block2, block1), 98)
+        )
+
+        val microBlock = WavesBlock(
+          ref = BlockRef(height = 2, id = ByteStr(Array[Byte](98, 1, 1))),
+          reference = block2.ref.id,
+          changes = BlockchainBalance(
+            regular = Map(bob -> Map(usd -> 31)),
+            outLeases = Map(bob -> 10L)
+          ),
+          tpe = WavesBlock.Type.MicroBlock
+        )
+
+        fork.withBlock(microBlock) should matchTo(Status.Resolved(
+          activeChain = WavesChain(Vector(microBlock, block2, block1), 98),
+          newChanges = BlockchainBalance(
+            regular = Map(bob -> Map(usd -> 31)),
+            outLeases = Map(bob -> 10L)
+          ),
+          lostDiffIndex = Monoid.empty[DiffIndex]
+        ): Status)
+      }
+    }
+    // "withoutLast" - {} // No need, delegates to WavesChain
+    // "rollbackTo" - {} // No need, delegates to WavesChain
+  }
+
+}


### PR DESCRIPTION
* Fixed bugs in WavesChain.dropDifference;
* WavesChain.dropDifference now can work with micro blocks too;
* WavesFork.withBlock:
    * Don't resolve the fork if we receive a known micro block, thus we can follow up the original chain;
    * doesn't resolve by a full block, a micro block is required now.

Tests:
* StatusTransitionsTestSuite fixed same ids of two different blocks;
* WavesChainTestSuite more tests for dropDifference;
* Added a basic unit tests for WavesFork.