### PR TITLE
DEX-1004 Replace transactions in PessimisticPortfolio on reconnect

### DIFF
--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/blockchainupdates/BlockchainUpdatesConversions.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/blockchainupdates/BlockchainUpdatesConversions.scala
@@ -41,10 +41,11 @@ object BlockchainUpdatesConversions {
             ref = blockRef,
             reference = reference,
             changes = BlockchainBalance(regularBalanceChanges, outLeasesChanges),
-            tpe = tpe
+            tpe = tpe,
+            forgedTxIds = updates.transactionIds.toSet
           )
 
-          WavesNodeEvent.Appended(block, updates.transactionIds)
+          WavesNodeEvent.Appended(block)
         }
 
       case Update.Rollback(value) =>

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/blockchainupdates/GrpcBlockchainUpdatesControlledStream.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/blockchainupdates/GrpcBlockchainUpdatesControlledStream.scala
@@ -21,11 +21,11 @@ class GrpcBlockchainUpdatesControlledStream(channel: ManagedChannel)(implicit sc
     with ScorexLogging {
   @volatile private var grpcObserver: Option[BlockchainUpdatesObserver] = None
 
-  private val internalStream = ConcurrentSubject.publish[SubscribeEvent] // .replayLimited[SubscribeEvent](10)
-  override val stream: Observable[SubscribeEvent] = internalStream // .publish // See GrpcUtxEventsControlledStream
+  private val internalStream = ConcurrentSubject.publish[SubscribeEvent]
+  override val stream: Observable[SubscribeEvent] = internalStream
 
-  private val internalSystemStream = ConcurrentSubject.publish[SystemEvent] // .replayLimited[SystemEvent](10)
-  override val systemStream: Observable[SystemEvent] = internalSystemStream // .publish
+  private val internalSystemStream = ConcurrentSubject.publish[SystemEvent]
+  override val systemStream: Observable[SystemEvent] = internalSystemStream
 
   override def startFrom(height: Int): Unit = {
     require(height >= 1, "We can not get blocks on height <= 0")

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/BlockchainStatus.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/BlockchainStatus.scala
@@ -1,9 +1,6 @@
 package com.wavesplatform.dex.grpc.integration.clients.domain
 
-import com.wavesplatform.dex.grpc.integration.clients.domain.WavesNodeEvent.WavesNodeUtxEvent
 import com.wavesplatform.dex.meta.getSimpleName
-
-import scala.collection.immutable.Queue
 
 sealed trait BlockchainStatus extends Product with Serializable {
   def name: String = getSimpleName(this)
@@ -15,19 +12,12 @@ object BlockchainStatus {
     override def toString: String = s"Normal(${main.history.headOption.map(_.ref)})"
   }
 
-  case class TransientRollback(fork: WavesFork, utxEventsStash: Queue[WavesNodeUtxEvent]) extends BlockchainStatus {
-    override def toString: String = s"TransientRollback(f=$fork, utx=${utxEventsStash.size})"
+  case class TransientRollback(fork: WavesFork, utxUpdate: UtxUpdate) extends BlockchainStatus {
+    override def toString: String = s"TransientRollback(f=$fork, $utxUpdate)"
   }
 
-  case class TransientResolving(
-                                 main: WavesChain,
-                                 stashChanges: BlockchainBalance,
-                                 utxEventsStash: Queue[WavesNodeUtxEvent]
-  ) extends BlockchainStatus {
-
-    override def toString: String =
-      s"TransientResolving(${main.history.headOption.map(_.ref)}, u=${utxEventsStash.length})"
-
+  case class TransientResolving(main: WavesChain, stashChanges: BlockchainBalance, utxUpdate: UtxUpdate) extends BlockchainStatus {
+    override def toString: String = s"TransientResolving(${main.history.headOption.map(_.ref)}, $utxUpdate)"
   }
 
 }

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/StatusTransitions.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/StatusTransitions.scala
@@ -102,20 +102,14 @@ object StatusTransitions extends ScorexLogging {
 
               case Status.NotResolved(updatedFork) =>
                 StatusUpdate(
-                  newStatus = TransientRollback(
-                    fork = updatedFork,
-                    utxUpdate = origStatus.utxUpdate
-                  ),
+                  newStatus = origStatus.copy(fork = updatedFork),
                   requestNextBlockchainEvent = true
                 )
 
               case Status.Failed(updatedFork, reason) =>
                 log.error(s"Forcibly rollback, because of error: $reason")
                 StatusUpdate(
-                  newStatus = TransientRollback(
-                    fork = updatedFork,
-                    utxUpdate = origStatus.utxUpdate
-                  ),
+                  origStatus.copy(fork = updatedFork),
                   updatedLastBlockHeight = LastBlockHeight.RestartRequired(updatedFork.height + 1)
                 )
             }
@@ -133,7 +127,7 @@ object StatusTransitions extends ScorexLogging {
           case UtxSwitched(newTxs) =>
             StatusUpdate(
               newStatus = origStatus.copy(
-                utxUpdate = UtxUpdate(unconfirmedTxs = newTxs, resetCaches = true) // Forget a previous
+                utxUpdate = UtxUpdate(unconfirmedTxs = newTxs, resetCaches = true) // Forget the previous
               )
             )
 
@@ -178,7 +172,7 @@ object StatusTransitions extends ScorexLogging {
             log.error("Unexpected UTxSwitched, reset utxUpdate")
             StatusUpdate(
               newStatus = origStatus.copy(
-                utxUpdate = UtxUpdate(unconfirmedTxs = newTxs, resetCaches = true) // Forget a previous
+                utxUpdate = UtxUpdate(unconfirmedTxs = newTxs, resetCaches = true) // Forget the previous
               )
             )
 

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/StatusUpdate.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/StatusUpdate.scala
@@ -2,9 +2,6 @@ package com.wavesplatform.dex.grpc.integration.clients.domain
 
 import cats.Monoid
 import com.wavesplatform.dex.grpc.integration.clients.domain.StatusUpdate.LastBlockHeight
-import com.wavesplatform.dex.grpc.integration.clients.domain.WavesNodeEvent.WavesNodeUtxEvent
-
-import scala.collection.immutable.Queue
 
 // TODO DEX-1004
 case class StatusUpdate(
@@ -12,12 +9,12 @@ case class StatusUpdate(
   updatedBalances: BlockchainBalance = Monoid.empty[BlockchainBalance],
   requestBalances: DiffIndex = Monoid.empty[DiffIndex],
   updatedLastBlockHeight: LastBlockHeight = LastBlockHeight.NotChanged, // DEX-999 Probably need to move to Observer
-  processUtxEvents: Queue[WavesNodeUtxEvent] = Queue.empty,
+  utxUpdate: UtxUpdate = Monoid.empty[UtxUpdate],
   requestNextBlockchainEvent: Boolean = false // DEX-999 Can't be true if LastBlockHeight.RestartRequired
 ) {
 
   override def toString: String =
-    s"StatusUpdate($newStatus, ub=$updatedBalances, rb=$requestBalances, lbh=$updatedLastBlockHeight, utx=${processUtxEvents.size}, rnbe=$requestNextBlockchainEvent)"
+    s"StatusUpdate($newStatus, ub=$updatedBalances, rb=$requestBalances, lbh=$updatedLastBlockHeight, rnbe=$requestNextBlockchainEvent, $utxUpdate)"
 
 }
 

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/StatusUpdate.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/StatusUpdate.scala
@@ -3,7 +3,6 @@ package com.wavesplatform.dex.grpc.integration.clients.domain
 import cats.Monoid
 import com.wavesplatform.dex.grpc.integration.clients.domain.StatusUpdate.LastBlockHeight
 
-// TODO DEX-1004
 case class StatusUpdate(
   newStatus: BlockchainStatus,
   updatedBalances: BlockchainBalance = Monoid.empty[BlockchainBalance],

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/UtxUpdate.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/UtxUpdate.scala
@@ -18,7 +18,7 @@ object UtxUpdate {
   implicit val utxUpdateMonoid: Monoid[UtxUpdate] = new Monoid[UtxUpdate] {
     override val empty: UtxUpdate = UtxUpdate()
 
-    // TODO resetCaches optimization: only unconfirmedTxs
+    // TODO DEX-1002 resetCaches optimization: only unconfirmedTxs
     override def combine(x: UtxUpdate, y: UtxUpdate): UtxUpdate = UtxUpdate(
       unconfirmedTxs = removeDone(x.unconfirmedTxs, y) ++ removeDone(y.unconfirmedTxs, x),
       forgedTxIds = x.forgedTxIds.union(y.forgedTxIds),

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/UtxUpdate.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/UtxUpdate.scala
@@ -1,0 +1,36 @@
+package com.wavesplatform.dex.grpc.integration.clients.domain
+
+import cats.kernel.Monoid
+import com.google.protobuf.ByteString
+import com.wavesplatform.dex.grpc.integration.services.UtxTransaction
+
+case class UtxUpdate(
+  unconfirmedTxs: Seq[UtxTransaction] = Nil,
+  forgedTxIds: Set[ByteString] = Set.empty,
+  failedTxIds: Set[ByteString] = Set.empty,
+  resetCaches: Boolean = false
+) {
+  override def toString: String = s"UtxUpdate(u=${unconfirmedTxs.size}, fgtx=${forgedTxIds.size}, fltx=${failedTxIds.size}, r=$resetCaches)"
+}
+
+object UtxUpdate {
+
+  implicit val utxUpdateMonoid: Monoid[UtxUpdate] = new Monoid[UtxUpdate] {
+    override val empty: UtxUpdate = UtxUpdate()
+
+    // TODO resetCaches optimization: only unconfirmedTxs
+    override def combine(x: UtxUpdate, y: UtxUpdate): UtxUpdate = UtxUpdate(
+      unconfirmedTxs = removeDone(x.unconfirmedTxs, y) ++ removeDone(y.unconfirmedTxs, x),
+      forgedTxIds = x.forgedTxIds.union(y.forgedTxIds),
+      failedTxIds = x.failedTxIds.union(y.failedTxIds),
+      resetCaches = x.resetCaches || y.resetCaches
+    )
+
+    private def removeDone(
+      unconfirmedTxs: Seq[UtxTransaction],
+      by: UtxUpdate
+    ): Seq[UtxTransaction] = unconfirmedTxs.filterNot(tx => by.forgedTxIds.contains(tx.id) || by.failedTxIds.contains(tx.id))
+
+  }
+
+}

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/WavesBlock.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/WavesBlock.scala
@@ -1,15 +1,16 @@
 package com.wavesplatform.dex.grpc.integration.clients.domain
 
+import com.google.protobuf.ByteString
 import com.wavesplatform.dex.domain.bytes.ByteStr
 
-case class WavesBlock(ref: BlockRef, reference: ByteStr, changes: BlockchainBalance, tpe: WavesBlock.Type) {
+case class WavesBlock(ref: BlockRef, reference: ByteStr, changes: BlockchainBalance, tpe: WavesBlock.Type, forgedTxIds: Set[ByteString]) {
 
   def diffIndex: DiffIndex = DiffIndex(
     regular = changes.regular.view.mapValues(_.keySet).toMap,
     outLeases = changes.outLeases.keySet
   )
 
-  override def toString: String = s"WavesBlock(id=${ref.id.base58.take(5)}, h=${ref.height}, tpe=$tpe)"
+  override def toString: String = s"WavesBlock(id=${ref.id.base58.take(5)}, h=${ref.height}, tpe=$tpe, ftx=${forgedTxIds.size})"
 
 }
 

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/WavesChain.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/WavesChain.scala
@@ -115,7 +115,8 @@ object WavesChain {
         ref = y.ref,
         reference = x.reference,
         changes = x.changes |+| y.changes,
-        tpe = x.tpe
+        tpe = x.tpe,
+        forgedTxIds = x.forgedTxIds.union(y.forgedTxIds)
       )
     }
 

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/WavesNodeEvent.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/WavesNodeEvent.scala
@@ -10,8 +10,8 @@ object WavesNodeEvent {
 
   sealed trait BlockchainUpdates
 
-  case class Appended(block: WavesBlock, forgedTxIds: Seq[ByteString]) extends WavesNodeEvent with BlockchainUpdates {
-    override def toString: String = s"Appended(${block.tpe}, h=${block.ref.height}, ${block.ref.id}, ftx=${txIdsToString(forgedTxIds)})"
+  case class Appended(block: WavesBlock) extends WavesNodeEvent with BlockchainUpdates {
+    override def toString: String = s"Appended(${block.tpe}, h=${block.ref.height}, ${block.ref.id})"
   }
 
   // Could also happen on appending of a key block
@@ -49,7 +49,7 @@ object WavesNodeEvent {
 
   object WavesNodeUtxEvent {
     case class Updated(newTxs: Seq[UtxTransaction], failedTxs: Seq[UtxTransaction]) extends WavesNodeUtxEvent
-    case class Forged(txIds: Seq[ByteString]) extends WavesNodeUtxEvent
+    case class Forged(txIds: Set[ByteString]) extends WavesNodeUtxEvent
     case class Switched(newTxs: Seq[UtxTransaction]) extends WavesNodeUtxEvent
   }
 
@@ -60,6 +60,5 @@ object WavesNodeEvent {
   }
 
   private def txsToString(txs: Seq[UtxTransaction]): String = txs.map(_.id.toBase58).mkString(", ")
-  private def txIdsToString(txs: Seq[ByteString]): String = txs.map(_.toBase58).mkString(", ")
 
 }

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/portfolio/LookAheadPessimisticPortfolios.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/portfolio/LookAheadPessimisticPortfolios.scala
@@ -36,7 +36,7 @@ class LookAheadPessimisticPortfolios(orig: PessimisticPortfolios, maxForgedTrans
     }
 
   override def removeFailed(txIds: Iterable[ByteString]): Set[Address] =
-    // txIds.foreach(remove) // a transaction can't be forged and failed both. Also we update caches in replaceWith, DEX-1004
+    // txIds.foreach(remove) // a transaction can't be forged and failed both.
     orig.removeFailed(txIds)
 
   private def put(txId: ByteString): Unit = forgedTxs.add(txId).tap { added =>

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/portfolio/LookAheadPessimisticPortfolios.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/portfolio/LookAheadPessimisticPortfolios.scala
@@ -17,7 +17,6 @@ class LookAheadPessimisticPortfolios(orig: PessimisticPortfolios, maxForgedTrans
 
   override def getAggregated(address: Address): Map[Asset, Long] = orig.getAggregated(address)
 
-  // DEX-1004
   override def replaceWith(setTxs: Seq[PessimisticTransaction]): Set[Address] = {
     forgedTxs.clear()
     forgedTxsEvictionQueue.clear()

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/portfolio/SynchronizedPessimisticPortfolios.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/portfolio/SynchronizedPessimisticPortfolios.scala
@@ -32,12 +32,12 @@ class SynchronizedPessimisticPortfolios(settings: Settings) {
   /**
    * @return (affected addresses, unknown transactions)
    */
-  def processForged(txIds: Seq[ByteString]): (Set[Address], List[ByteString]) = write {
+  def processForged(txIds: Set[ByteString]): (Set[Address], List[ByteString]) = write {
     orig.processForged(txIds)
   }
 
   // TODO DEX-1013
-  def removeFailed(txIds: Seq[ByteString]): Set[Address] = write {
+  def removeFailed(txIds: Set[ByteString]): Set[Address] = write {
     orig.removeFailed(txIds)
   }
 

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/matcherext/GrpcUtxEventsControlledStream.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/matcherext/GrpcUtxEventsControlledStream.scala
@@ -22,12 +22,12 @@ class GrpcUtxEventsControlledStream(channel: ManagedChannel)(implicit scheduler:
     with ScorexLogging {
   @volatile private var grpcObserver: Option[UtxEventObserver] = None
 
-  private val internalStream = ConcurrentSubject.publish[UtxEvent] // .replayLimited[UtxEvent](10)
+  private val internalStream = ConcurrentSubject.publish[UtxEvent]
   // HACK: Monix skips the first few messages! So we have to turn it into a hot
-  override val stream: Observable[UtxEvent] = internalStream // .publish
+  override val stream: Observable[UtxEvent] = internalStream
 
-  private val internalSystemStream = ConcurrentSubject.publish[SystemEvent] // .replayLimited[SystemEvent](10)
-  override val systemStream: Observable[SystemEvent] = internalSystemStream // .publish
+  private val internalSystemStream = ConcurrentSubject.publish[SystemEvent]
+  override val systemStream: Observable[SystemEvent] = internalSystemStream
 
   private val empty: Empty = Empty()
 

--- a/waves-integration/src/test/scala/com/wavesplatform/dex/WavesIntegrationSuiteBase.scala
+++ b/waves-integration/src/test/scala/com/wavesplatform/dex/WavesIntegrationSuiteBase.scala
@@ -1,6 +1,6 @@
 package com.wavesplatform.dex
 
-import com.google.protobuf.ByteString
+import com.google.protobuf.{ByteString, UnsafeByteOperations}
 import com.softwaremill.diffx.{ConsoleColorConfig, Derived, Diff, DiffResultDifferent, DiffResultValue, FieldPath, Identical}
 import com.wavesplatform.dex.domain.bytes.ByteStr
 import com.wavesplatform.dex.grpc.integration.services.UtxTransaction
@@ -34,6 +34,11 @@ trait WavesIntegrationSuiteBase extends AnyFreeSpecLike with Matchers with Allur
         MatchResult(matches = false, s"Matching error:\n$diff\nleft: $left", "")
       case _ => MatchResult(matches = true, "", "")
     }
+  }
+
+  protected def mkTxId(n: Int): ByteString = {
+    require(n <= 127) // or we need complex implementation
+    UnsafeByteOperations.unsafeWrap(new Array[Byte](n))
   }
 
 }

--- a/waves-integration/src/test/scala/com/wavesplatform/dex/grpc/integration/clients/combined/CombinedStreamTestSuite.scala
+++ b/waves-integration/src/test/scala/com/wavesplatform/dex/grpc/integration/clients/combined/CombinedStreamTestSuite.scala
@@ -104,8 +104,8 @@ class CombinedStreamTestSuite extends WavesIntegrationSuiteBase {
             val t = mkStarted()
             t.blockchainUpdates.systemStream.onNext(SystemEvent.Stopped)
 
-            logged(t.blockchainUpdates.systemStream)(_.last shouldBe SystemEvent.BecameReady)
             logged(t.utxEvents.systemStream)(_.last shouldBe SystemEvent.BecameReady)
+            logged(t.blockchainUpdates.systemStream)(_.last shouldBe SystemEvent.BecameReady)
           }
         }
 
@@ -177,7 +177,7 @@ class CombinedStreamTestSuite extends WavesIntegrationSuiteBase {
   private def mkStarted(): TestClasses = mk().tap(_.utxEvents.systemStream.onNext(SystemEvent.BecameReady))
 
   private def logged[T](subject: Observable[T])(f: List[T] => Unit): Unit = {
-    val xs = subject.takeByTimespan(100.millis).toListL.runSyncUnsafe()
+    val xs = subject.takeByTimespan(200.millis).toListL.runSyncUnsafe()
     withClue(s"$xs: ") {
       try f(xs)
       catch {

--- a/waves-integration/src/test/scala/com/wavesplatform/dex/grpc/integration/clients/domain/WavesChainTestSuite.scala
+++ b/waves-integration/src/test/scala/com/wavesplatform/dex/grpc/integration/clients/domain/WavesChainTestSuite.scala
@@ -6,6 +6,7 @@ import cats.Monoid
 import cats.syntax.either._
 import cats.syntax.option._
 import cats.syntax.semigroup._
+import com.google.protobuf.{ByteString, UnsafeByteOperations}
 import com.wavesplatform.dex.domain.account.KeyPair
 import com.wavesplatform.dex.domain.asset.Asset.{IssuedAsset, Waves}
 import com.wavesplatform.dex.domain.bytes.ByteStr
@@ -31,7 +32,8 @@ class WavesChainTestSuite extends WavesIntegrationSuiteBase with ScalaCheckDrive
       regular = Map(alice -> Map(Waves -> 10, usd -> 2L)),
       outLeases = Map(bob -> 23L)
     ),
-    tpe = WavesBlock.Type.FullBlock
+    tpe = WavesBlock.Type.FullBlock,
+    forgedTxIds = Set(mkTxId(1))
   )
 
   private val block2 = WavesBlock(
@@ -41,7 +43,8 @@ class WavesChainTestSuite extends WavesIntegrationSuiteBase with ScalaCheckDrive
       regular = Map(bob -> Map(usd -> 35)),
       outLeases = Map.empty
     ),
-    tpe = WavesBlock.Type.FullBlock
+    tpe = WavesBlock.Type.FullBlock,
+    forgedTxIds = Set(mkTxId(2))
   )
 
   private val emptyChain = Vector.empty[WavesBlock]
@@ -61,7 +64,8 @@ class WavesChainTestSuite extends WavesIntegrationSuiteBase with ScalaCheckDrive
                 ref = BlockRef(headBlock.fold(1)(_.ref.height + 1), ByteStr(Array[Byte](-7))),
                 reference = headBlock.fold(ByteStr(Array[Byte](-8)))(_.ref.id),
                 changes = Monoid.empty[BlockchainBalance],
-                tpe = WavesBlock.Type.FullBlock
+                tpe = WavesBlock.Type.FullBlock,
+                forgedTxIds = Set.empty // TODO
               ),
               history
             )
@@ -346,7 +350,8 @@ class WavesChainTestSuite extends WavesIntegrationSuiteBase with ScalaCheckDrive
             regular = Map(bob -> Map(usd -> 7), alice -> Map(usd -> 24)),
             outLeases = Map.empty
           ),
-          tpe = WavesBlock.Type.MicroBlock
+          tpe = WavesBlock.Type.MicroBlock,
+          forgedTxIds = Set(mkTxId(1))
         )
 
         val init = WavesChain(Vector(microBlock1, block1), 99)
@@ -361,7 +366,8 @@ class WavesChainTestSuite extends WavesIntegrationSuiteBase with ScalaCheckDrive
                   regular = Map(alice -> Map(Waves -> 9), bob -> Map(usd -> 2L)),
                   outLeases = Map(alice -> 1L)
                 ),
-                tpe = WavesBlock.Type.FullBlock
+                tpe = WavesBlock.Type.FullBlock,
+                forgedTxIds = Set(mkTxId(10))
               )
 
               val hardenedBlock = block1.copy(
@@ -407,7 +413,8 @@ class WavesChainTestSuite extends WavesIntegrationSuiteBase with ScalaCheckDrive
                   regular = Map(alice -> Map(Waves -> 9), bob -> Map(usd -> 2L)),
                   outLeases = Map(alice -> 1L)
                 ),
-                tpe = WavesBlock.Type.FullBlock
+                tpe = WavesBlock.Type.FullBlock,
+                forgedTxIds = Set(mkTxId(10))
               )
 
               init.withBlock(newBlock) should produce("(?s)^The new block.+must be after.+".r)
@@ -443,7 +450,8 @@ class WavesChainTestSuite extends WavesIntegrationSuiteBase with ScalaCheckDrive
             regular = Map(bob -> Map(usd -> 7), alice -> Map(usd -> 24)),
             outLeases = Map.empty
           ),
-          tpe = WavesBlock.Type.MicroBlock
+          tpe = WavesBlock.Type.MicroBlock,
+          forgedTxIds = Set(mkTxId(1))
         )
 
         val microBlock2 = WavesBlock(
@@ -453,7 +461,8 @@ class WavesChainTestSuite extends WavesIntegrationSuiteBase with ScalaCheckDrive
             regular = Map(bob -> Map(usd -> 3), alice -> Map(usd -> 11)),
             outLeases = Map.empty
           ),
-          tpe = WavesBlock.Type.MicroBlock
+          tpe = WavesBlock.Type.MicroBlock,
+          forgedTxIds = Set(mkTxId(2))
         )
 
         val init = WavesChain(Vector(microBlock2, microBlock1, block1), 99)
@@ -467,7 +476,8 @@ class WavesChainTestSuite extends WavesIntegrationSuiteBase with ScalaCheckDrive
                 regular = Map(alice -> Map(Waves -> 9), bob -> Map(usd -> 2L)),
                 outLeases = Map(alice -> 1L)
               ),
-              tpe = WavesBlock.Type.FullBlock
+              tpe = WavesBlock.Type.FullBlock,
+              forgedTxIds = Set(mkTxId(10))
             )
 
             init.withBlock(newBlock) should produce("(?s)^The new block.+must be after.+".r)
@@ -482,7 +492,8 @@ class WavesChainTestSuite extends WavesIntegrationSuiteBase with ScalaCheckDrive
                   regular = Map(bob -> Map(usd -> 3), alice -> Map(usd -> 11)),
                   outLeases = Map.empty
                 ),
-                tpe = WavesBlock.Type.MicroBlock
+                tpe = WavesBlock.Type.MicroBlock,
+                forgedTxIds = Set(mkTxId(10))
               )
 
               init.withBlock(microBlock3) should produce("(?s)^The new micro block.+must reference the last block.+".r)
@@ -499,7 +510,8 @@ class WavesChainTestSuite extends WavesIntegrationSuiteBase with ScalaCheckDrive
             regular = Map(bob -> Map(usd -> 7), alice -> Map(usd -> 24)),
             outLeases = Map.empty
           ),
-          tpe = WavesBlock.Type.MicroBlock
+          tpe = WavesBlock.Type.MicroBlock,
+          forgedTxIds = Set(mkTxId(1))
         )
 
         val init = WavesChain(Vector(microBlock, block2, block1), 98)
@@ -511,7 +523,8 @@ class WavesChainTestSuite extends WavesIntegrationSuiteBase with ScalaCheckDrive
             regular = Map(bob -> Map(usd -> 35)),
             outLeases = Map.empty
           ),
-          tpe = WavesBlock.Type.FullBlock
+          tpe = WavesBlock.Type.FullBlock,
+          forgedTxIds = Set(mkTxId(2))
         )
 
         init.withBlock(newBlock) should produce("(?s)^The new block.+must be after.+".r)
@@ -753,7 +766,8 @@ class WavesChainTestSuite extends WavesIntegrationSuiteBase with ScalaCheckDrive
     ref = BlockRef(0, ByteStr(Array[Byte](0))),
     reference = ByteStr.empty,
     changes = Monoid.empty[BlockchainBalance],
-    tpe = WavesBlock.Type.FullBlock
+    tpe = WavesBlock.Type.FullBlock,
+    forgedTxIds = Set.empty
   )
 
   private def historyGen(blocksNumber: Range, microBlocksNumber: Range, startHeightRange: Range = 0 to 2): Gen[Vector[WavesBlock]] =

--- a/waves-integration/src/test/scala/com/wavesplatform/dex/grpc/integration/clients/domain/WavesForkTestSuite.scala
+++ b/waves-integration/src/test/scala/com/wavesplatform/dex/grpc/integration/clients/domain/WavesForkTestSuite.scala
@@ -25,7 +25,8 @@ class WavesForkTestSuite extends WavesIntegrationSuiteBase with ScalaCheckDriven
       regular = Map(alice -> Map(Waves -> 10, usd -> 2L)),
       outLeases = Map(bob -> 23L)
     ),
-    tpe = WavesBlock.Type.FullBlock
+    tpe = WavesBlock.Type.FullBlock,
+    forgedTxIds = Set(mkTxId(1))
   )
 
   private val block2 = WavesBlock(
@@ -35,7 +36,8 @@ class WavesForkTestSuite extends WavesIntegrationSuiteBase with ScalaCheckDriven
       regular = Map(bob -> Map(usd -> 35)),
       outLeases = Map.empty
     ),
-    tpe = WavesBlock.Type.FullBlock
+    tpe = WavesBlock.Type.FullBlock,
+    forgedTxIds = Set(mkTxId(2))
   )
 
   private val block3 = WavesBlock(
@@ -45,7 +47,8 @@ class WavesForkTestSuite extends WavesIntegrationSuiteBase with ScalaCheckDriven
       regular = Map(alice -> Map(usd -> 30)),
       outLeases = Map(alice -> 1L)
     ),
-    tpe = WavesBlock.Type.FullBlock
+    tpe = WavesBlock.Type.FullBlock,
+    forgedTxIds = Set(mkTxId(3))
   )
 
   "WavesFork" - {
@@ -63,7 +66,8 @@ class WavesForkTestSuite extends WavesIntegrationSuiteBase with ScalaCheckDriven
             regular = Map(bob -> Map(usd -> 35)),
             outLeases = Map.empty
           ),
-          tpe = WavesBlock.Type.FullBlock
+          tpe = WavesBlock.Type.FullBlock,
+          forgedTxIds = Set(mkTxId(10))
         )
 
         val expectedUpdatedFork = WavesFork(
@@ -105,7 +109,8 @@ class WavesForkTestSuite extends WavesIntegrationSuiteBase with ScalaCheckDriven
               regular = Map(alice -> Map(usd -> 30)),
               outLeases = Map(alice -> 1L)
             ),
-            tpe = WavesBlock.Type.MicroBlock
+            tpe = WavesBlock.Type.MicroBlock,
+            forgedTxIds = Set(mkTxId(10))
           )
 
           val expectedUpdatedFork = WavesFork(
@@ -124,7 +129,8 @@ class WavesForkTestSuite extends WavesIntegrationSuiteBase with ScalaCheckDriven
               regular = Map(alice -> Map(usd -> 69)),
               outLeases = Map(bob -> 2L)
             ),
-            tpe = WavesBlock.Type.MicroBlock
+            tpe = WavesBlock.Type.MicroBlock,
+            forgedTxIds = Set(mkTxId(10))
           )
 
           val fork = WavesFork(
@@ -155,7 +161,8 @@ class WavesForkTestSuite extends WavesIntegrationSuiteBase with ScalaCheckDriven
               regular = Map(bob -> Map(usd -> 31)),
               outLeases = Map(bob -> 10L)
             ),
-            tpe = WavesBlock.Type.MicroBlock
+            tpe = WavesBlock.Type.MicroBlock,
+            forgedTxIds = Set(mkTxId(10))
           )
 
           fork.withBlock(microBlock) should matchTo(Status.Resolved(
@@ -164,7 +171,9 @@ class WavesForkTestSuite extends WavesIntegrationSuiteBase with ScalaCheckDriven
               regular = Map(bob -> Map(usd -> 31)),
               outLeases = Map(bob -> 10L)
             ),
-            lostDiffIndex = Monoid.empty[DiffIndex]
+            lostDiffIndex = Monoid.empty[DiffIndex],
+            lostTxIds = Set.empty,
+            forgedTxIds = microBlock.forgedTxIds
           ): Status)
         }
 
@@ -176,7 +185,8 @@ class WavesForkTestSuite extends WavesIntegrationSuiteBase with ScalaCheckDriven
               regular = Map(alice -> Map(usd -> 69)),
               outLeases = Map(bob -> 2L)
             ),
-            tpe = WavesBlock.Type.MicroBlock
+            tpe = WavesBlock.Type.MicroBlock,
+            forgedTxIds = Set(mkTxId(10))
           )
 
           val microBlock2 = WavesBlock(
@@ -186,7 +196,8 @@ class WavesForkTestSuite extends WavesIntegrationSuiteBase with ScalaCheckDriven
               regular = Map(bob -> Map(Waves -> 11)),
               outLeases = Map(alice -> 9L)
             ),
-            tpe = WavesBlock.Type.MicroBlock
+            tpe = WavesBlock.Type.MicroBlock,
+            forgedTxIds = Set(mkTxId(11))
           )
 
           val fork = WavesFork(
@@ -197,7 +208,9 @@ class WavesForkTestSuite extends WavesIntegrationSuiteBase with ScalaCheckDriven
           fork.withBlock(microBlock2) should matchTo(Status.Resolved(
             activeChain = WavesChain(Vector(microBlock2, microBlock1, block1), 99),
             newChanges = microBlock2.changes,
-            lostDiffIndex = Monoid.empty[DiffIndex]
+            lostDiffIndex = Monoid.empty[DiffIndex],
+            lostTxIds = Set.empty,
+            forgedTxIds = microBlock2.forgedTxIds
           ): Status)
         }
       }

--- a/waves-integration/src/test/scala/com/wavesplatform/dex/grpc/integration/clients/domain/portfolio/LookAheadPessimisticPortfoliosTestSuite.scala
+++ b/waves-integration/src/test/scala/com/wavesplatform/dex/grpc/integration/clients/domain/portfolio/LookAheadPessimisticPortfoliosTestSuite.scala
@@ -12,14 +12,27 @@ class LookAheadPessimisticPortfoliosTestSuite extends PessimisticPortfoliosTestS
     "default behavior" - defaultBehaviorTests()
 
     "forged transactions" - {
-      // DEX-1004
-      "replaceWith" ignore {}
+      "replaceWith" - {
+        val testGen = for {
+          origTxs <- Gen.listOf(pessimisticTransactionGen)
+          newTxs <- Gen.listOf(pessimisticTransactionGen)
+          unknownTxIds <- Gen.listOf(pbTxIdGen.suchThat { txId =>
+            !newTxs.exists(_.txId == txId) && !origTxs.exists(_.txId == txId)
+          })
+          maxForgedTransactions <- Gen.choose(0, unknownTxIds.size + 1)
+        } yield (mkPessimisticPortfolios(origTxs, maxForgedTransactions), newTxs, unknownTxIds)
+
+        "caches cleared" in forAll(testGen) { case (pp, newTxs, unknownTxIds) =>
+          pp.processForged(unknownTxIds)._2 should matchTo(unknownTxIds) // Add to the cache, see below
+          pp.replaceWith(newTxs)
+          pp.processForged(unknownTxIds)._2 should matchTo(unknownTxIds)
+        }
+      }
 
       "unknown forged transactions" - {
-        val testGen = Gen.zip(Gen.listOf(pessimisticTransactionGen), pessimisticTransactionGen)
+        val testGen = Gen.zip(pessimisticPortfoliosGen, pessimisticTransactionGen)
 
-        "are stored in a cache and observed in processForged" in forAll(testGen) { case (initTxs, unknownTx) =>
-          val pp = mkPessimisticPortfolios(initTxs)
+        "are stored in a cache and observed in processForged" in forAll(testGen) { case (pp, unknownTx) =>
           val expectedUnknownTxIds = List(unknownTx.txId)
 
           val (_, actualUnknownTxIds) = pp.processForged(expectedUnknownTxIds)
@@ -27,8 +40,7 @@ class LookAheadPessimisticPortfoliosTestSuite extends PessimisticPortfoliosTestS
           actualUnknownTxIds should matchTo(expectedUnknownTxIds)
         }
 
-        "doesn't affect getAggregated" in forAll(testGen) { case (initTxs, unknownTx) =>
-          val pp = mkPessimisticPortfolios(initTxs)
+        "doesn't affect getAggregated" in forAll(testGen) { case (pp, unknownTx) =>
           val before = getState(pp)
 
           pp.processForged(List(unknownTx.txId))
@@ -36,8 +48,7 @@ class LookAheadPessimisticPortfoliosTestSuite extends PessimisticPortfoliosTestS
           getState(pp) should matchTo(before)
         }
 
-        "don't count in addPending" in forAll(testGen) { case (initTxs, unknownTx) =>
-          val pp = mkPessimisticPortfolios(initTxs)
+        "don't count in addPending" in forAll(testGen) { case (pp, unknownTx) =>
           val before = getState(pp)
 
           pp.processForged(List(unknownTx.txId))
@@ -46,8 +57,7 @@ class LookAheadPessimisticPortfoliosTestSuite extends PessimisticPortfoliosTestS
           getState(pp) should matchTo(before)
         }
 
-        "are limited by maxForgedTransactions" in forAll(testGen, pessimisticTransactionGen) { case ((initTxs, unknownTx1), unknownTx2) =>
-          val pp = mkPessimisticPortfolios(initTxs)
+        "are limited by maxForgedTransactions" in forAll(testGen, pessimisticTransactionGen) { case ((pp, unknownTx1), unknownTx2) =>
           val before = getState(pp)
 
           // unknownTx1 is removed from the cache, because maxForgedTransactions = 1
@@ -61,12 +71,14 @@ class LookAheadPessimisticPortfoliosTestSuite extends PessimisticPortfoliosTestS
     }
   }
 
-  override def mkPessimisticPortfolios(initialTxs: List[PessimisticTransaction]) = new LookAheadPessimisticPortfolios(
+  override def mkPessimisticPortfolios(initialTxs: List[PessimisticTransaction]) = mkPessimisticPortfolios(initialTxs, 1)
+
+  private def mkPessimisticPortfolios(initialTxs: List[PessimisticTransaction], maxForgedTransactions: Int) = new LookAheadPessimisticPortfolios(
     new DefaultPessimisticPortfolios(
       initialTxs.foldMap(_.pessimisticPortfolio),
       initialTxs.map(tx => tx.txId -> tx.pessimisticPortfolio).toMap
     ),
-    maxForgedTransactions = 1
+    maxForgedTransactions = maxForgedTransactions
   )
 
 }


### PR DESCRIPTION
* Added UtxUpdate to collect and combine changes from UTX stream and then apply them to PessimisticPortfolio;
* WavesBlock contains forged transactions' ids;
* WavesFork:
  * Status.Resolved contains lost and forged transactions' ids;
  * Transactions diffs calculated during resolving;
* Updated StatusTransitions: TransientResolving now reacts on Utx* events correctly;
* CombinedStream: better streams merging;
* GrpcUtxEventsControlledStream.internalSystemStream: BecameReady happens after the first message, see comments for more details.