### PR TITLE
DEX-1047 Orders may be canceled when queue is Kafka

### DIFF
--- a/dex-it/src/test/scala/com/wavesplatform/it/MatcherSuiteBase.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/MatcherSuiteBase.scala
@@ -21,6 +21,7 @@ import com.wavesplatform.dex.it.waves.{MkWavesEntities, ToWavesJConversions}
 import com.wavesplatform.dex.test.matchers.DiffMatcherWithImplicits
 import com.wavesplatform.dex.waves.WavesFeeConstants
 import com.wavesplatform.it.api.ApiExtensions
+import im.mak.waves.transactions.ExchangeTransaction
 import io.qameta.allure.scalatest.AllureScalatestContext
 import org.scalatest.concurrent.Eventually
 import org.scalatest.freespec.AnyFreeSpec
@@ -55,7 +56,8 @@ trait MatcherSuiteBase
 
   GenesisConfig.setupAddressScheme()
 
-  implicit val httpV0OrderBookDiff: Diff[HttpV0OrderBook] = Derived[Diff[HttpV0OrderBook]].ignore[HttpV0OrderBook, Long](_.timestamp)
+  implicit val httpV0OrderBookDiff: Derived[Diff[HttpV0OrderBook]] = Derived(Diff.gen[HttpV0OrderBook].ignore[HttpV0OrderBook, Long](_.timestamp))
+  implicit val exchangeTransactionDiff: Derived[Diff[ExchangeTransaction]] = Derived(Diff[String].contramap[ExchangeTransaction](_.id().base58))
 
   override protected val moduleName: String = "dex-it"
 

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/BroadcastUntilConfirmedTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/BroadcastUntilConfirmedTestSuite.scala
@@ -1,7 +1,6 @@
 package com.wavesplatform.it.sync
 
 import com.typesafe.config.{Config, ConfigFactory}
-import com.wavesplatform.dex.api.http.entities.HttpOrderStatus.Status
 import com.wavesplatform.dex.domain.order.OrderType
 import com.wavesplatform.dex.it.docker.WavesNodeContainer
 import com.wavesplatform.it.MatcherSuiteBase

--- a/dex/src/main/scala/com/wavesplatform/dex/actors/address/AddressActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/actors/address/AddressActor.scala
@@ -106,6 +106,7 @@ class AddressActor(
       // e.g. We need folding
       events.foreach(eventsProcessing(_))
       if (started) working(Message.BalanceChanged(balanceUpdate.keySet, balanceUpdate))
+      log.info("ApplyBatch applied")
 
     case command @ OrderCancelFailed(id, reason) =>
       if (started) pendingCommands.remove(id) match {

--- a/waves-ext/build.sbt
+++ b/waves-ext/build.sbt
@@ -71,11 +71,6 @@ inConfig(Linux)(
   )
 )
 
-Debian / debianPackageConflicts := Seq(
-  "grpc-server",
-  "waves-node-grpc-server" // TODO NODE-1999
-)
-
 inTask(docker)(
   Seq(
     nameOfImage := "wavesplatform/matcher-node",

--- a/waves-ext/src/main/scala/com/wavesplatform/dex/grpc/integration/protobuf/WavesToPbConversions.scala
+++ b/waves-ext/src/main/scala/com/wavesplatform/dex/grpc/integration/protobuf/WavesToPbConversions.scala
@@ -105,6 +105,8 @@ object WavesToPbConversions {
           }.toList,
           assets = Nil // Haven't support yet
         ).some
+        // Not useful for UTX transactions. Could be useful in the future
+        // orderFills = self.orderFills.map { case (orderId, x) => TransactionDiff.OrderFill(orderId.toPB, volume = x.volume, fee = x.fee) }.toSeq
       )
     }
 

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/combined/CombinedWavesBlockchainClient.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/combined/CombinedWavesBlockchainClient.scala
@@ -93,6 +93,19 @@ class CombinedWavesBlockchainClient(
               )
             }
             .toMap
+
+          // // Not useful for UTX, because it doesn't consider the current state of orders
+          // // Will be useful, when blockchain updates send order fills.
+          // val fillsDebugInfo = x.utxUpdate.unconfirmedTxs.flatMap { tx =>
+          //   val fills = tx.diff.toList.flatMap(_.orderFills).map { fill =>
+          //     s"${fill.orderId.toVanilla} -> v:${fill.volume} + f:${fill.fee}"
+          //   }
+          //   if (fills.isEmpty) Nil
+          //   else List(s"${tx.id.toVanilla}: ${fills.mkString(", ")}")
+          // }
+          //
+          // if (fillsDebugInfo.nonEmpty) log.info(s"Detected fills:\n${fillsDebugInfo.mkString("\n")}")
+
           (
             x.newStatus,
             WavesNodeUpdates(


### PR DESCRIPTION
* Fixed the issue;
* Removed grpc-server from debianPackageConflicts, because now it is required;
* Stabilized tests;
* Improved checks in AutoCancelOrderTestSuite.