### PR TITLE
DEX-1041 Cover OrderEventsCoordinator state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 .ensime_cache/
 .metals/
 .bsp/
+.bloop/
+project/metals.sbt
+project/project/
 
 # scala build folders and files
 target

--- a/.sbtopts
+++ b/.sbtopts
@@ -1,5 +1,6 @@
 -J-server
 -J-Xss256m
+-J-Xmx2G
 -J-XX:MetaspaceSize=256m
 -J-XX:MaxMetaspaceExpansion=0
 -J-XX:+UseG1GC

--- a/dex/src/main/scala/com/wavesplatform/dex/actors/events/OrderEventsCoordinatorActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/actors/events/OrderEventsCoordinatorActor.scala
@@ -61,7 +61,7 @@ object OrderEventsCoordinatorActor {
       case Confirmed(tx) => Command.ApplyConfirmed(tx)
     }
 
-    def holdUntilAppearOnNode(state: OrderEventsActorState): Behavior[Message] =
+    def holdUntilAppearOnNode(state: OrderEventsCoordinatorActorState): Behavior[Message] =
       Behaviors.receive[Message] { (context, message) =>
         message match {
           case Command.Process(event) =>
@@ -173,7 +173,7 @@ object OrderEventsCoordinatorActor {
           sendBalances(updates.updatedBalances)
           Behaviors.same
 
-        case Command.Start => holdUntilAppearOnNode(OrderEventsActorState(Map.empty, FifoSet.limited(10000))) // TODO DEX-1042 settings
+        case Command.Start => holdUntilAppearOnNode(OrderEventsCoordinatorActorState(Map.empty, FifoSet.limited(10000))) // TODO DEX-1042 settings
         case _: Command.ApplyConfirmed => Behaviors.same
       }
     }

--- a/dex/src/main/scala/com/wavesplatform/dex/actors/events/OrderEventsCoordinatorActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/actors/events/OrderEventsCoordinatorActor.scala
@@ -78,7 +78,7 @@ object OrderEventsCoordinatorActor {
                     dbWriterRef ! txCreated
                     broadcasterRef ! Broadcaster.Broadcast(broadcastAdapter, tx)
 
-                    val (updatedState, resolved) = state.withExecuted(tx.id(), event)
+                    val (updatedState, resolved) = state.withKnownOnMatcher(tx.id(), event)
                     sendResolved(resolved) // TODO DEX-1042 pipeToSelf is needed if resolved?
 
                     holdUntilAppearOnNode(updatedState)
@@ -120,7 +120,7 @@ object OrderEventsCoordinatorActor {
                 case ((state, restBalances), (txId, tx)) if tx.tx.isExchangeTransaction =>
                   val traderAddresses = tx.tx.exchangeTransactionTraders
 
-                  val (updatedState, updatedRestBalances, resolved) = state.withKnownOnNodeTx(traderAddresses, txId, restBalances)
+                  val (updatedState, updatedRestBalances, resolved) = state.withKnownOnNode(traderAddresses, txId, restBalances)
                   sendResolved(resolved)
 
                   (updatedState, updatedRestBalances)
@@ -138,7 +138,7 @@ object OrderEventsCoordinatorActor {
             // * If it was before in UTX, then we received this before during UtxSwitched
             // * If it was added to UTX, then we will receive it
             // * If it won't retry, then we haven't received (neither as unconfirmed, nor confirmed) it and won't receive
-            val (updated, restBalances, resolved) = state.withKnownOnNodeTx(tx.traders, tx.id(), Map.empty)
+            val (updated, restBalances, resolved) = state.withKnownOnNode(tx.traders, tx.id(), Map.empty)
             sendResolved(resolved)
             sendBalances(restBalances) // Actually, they should be empty, but anyway
             holdUntilAppearOnNode(updated)

--- a/dex/src/main/scala/com/wavesplatform/dex/actors/events/OrderEventsCoordinatorActorState.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/actors/events/OrderEventsCoordinatorActorState.scala
@@ -10,12 +10,12 @@ import com.wavesplatform.dex.model.Events
 import scala.collection.immutable.Queue
 
 // TODO DEX-1041
-case class OrderEventsActorState(addresses: Map[Address, PendingAddress], knownOnNodeCache: FifoSet[ExchangeTransaction.Id]) {
+case class OrderEventsCoordinatorActorState(addresses: Map[Address, PendingAddress], knownOnNodeCache: FifoSet[ExchangeTransaction.Id]) {
 
   /**
    * @return (updated, passUpdates), passUpdates can be sent to recipients
    */
-  def withBalanceUpdates(updates: AddressAssets): (OrderEventsActorState, AddressAssets) = {
+  def withBalanceUpdates(updates: AddressAssets): (OrderEventsCoordinatorActorState, AddressAssets) = {
     // TODO DEX-1041 probably, we need fold on addresses, because updates.size >> addresses.size
     val (updatedAddresses, passUpdates) = updates.foldLeft((addresses, Map.empty: AddressAssets)) {
       case ((addresses, passUpdates), item @ (address, updates)) =>
@@ -25,16 +25,16 @@ case class OrderEventsActorState(addresses: Map[Address, PendingAddress], knownO
         }
     }
 
-    (OrderEventsActorState(updatedAddresses, knownOnNodeCache), passUpdates)
+    (OrderEventsCoordinatorActorState(updatedAddresses, knownOnNodeCache), passUpdates)
   }
 
   /**
    * @return (updated, passEvent), passEvent can be sent to a recipient
    */
-  def withPendingCancel(event: Events.OrderCanceled): (OrderEventsActorState, Option[Events.OrderCanceled]) = {
+  def withPendingCancel(event: Events.OrderCanceled): (OrderEventsCoordinatorActorState, Option[Events.OrderCanceled]) = {
     val address = event.acceptedOrder.order.senderPublicKey.toAddress
     addresses.get(address) match {
-      case Some(x) => (OrderEventsActorState(addresses.updated(address, x.withEvent(event)), knownOnNodeCache), none)
+      case Some(x) => (OrderEventsCoordinatorActorState(addresses.updated(address, x.withEvent(event)), knownOnNodeCache), none)
       case _ => (this, event.some)
     }
   }
@@ -42,7 +42,7 @@ case class OrderEventsActorState(addresses: Map[Address, PendingAddress], knownO
   /**
    * @return (updated, resolved)
    */
-  def withExecuted(txId: ExchangeTransaction.Id, event: Events.OrderExecuted): (OrderEventsActorState, Map[Address, PendingAddress]) = {
+  def withExecuted(txId: ExchangeTransaction.Id, event: Events.OrderExecuted): (OrderEventsCoordinatorActorState, Map[Address, PendingAddress]) = {
     lazy val defaultPendingAddress = PendingAddress(
       pendingTxs = Map[ExchangeTransaction.Id, PendingTransactionType](txId -> PendingTransactionType.KnownOnMatcher),
       stashedBalance = Map.empty,
@@ -56,7 +56,7 @@ case class OrderEventsActorState(addresses: Map[Address, PendingAddress], knownO
         else (addresses.updated(address, x), resolved)
     }
 
-    (OrderEventsActorState(updatedAddresses, knownOnNodeCache), resolved)
+    (OrderEventsCoordinatorActorState(updatedAddresses, knownOnNodeCache), resolved)
   }
 
   /**
@@ -66,7 +66,7 @@ case class OrderEventsActorState(addresses: Map[Address, PendingAddress], knownO
     traders: Set[Address],
     txId: ExchangeTransaction.Id,
     balanceUpdates: AddressAssets
-  ): (OrderEventsActorState, AddressAssets, Map[Address, PendingAddress]) =
+  ): (OrderEventsCoordinatorActorState, AddressAssets, Map[Address, PendingAddress]) =
     if (knownOnNodeCache.contains(txId)) (this, balanceUpdates, Map.empty)
     else {
       val (updatedAddresses, restUpdates, resolved) = traders.foldLeft((addresses, balanceUpdates, Map.empty[Address, PendingAddress])) {
@@ -87,7 +87,7 @@ case class OrderEventsActorState(addresses: Map[Address, PendingAddress], knownO
       }
 
       (
-        OrderEventsActorState(updatedAddresses, knownOnNodeCache.append(txId)),
+        OrderEventsCoordinatorActorState(updatedAddresses, knownOnNodeCache.append(txId)),
         restUpdates,
         resolved
       )

--- a/dex/src/main/scala/com/wavesplatform/dex/actors/events/OrderEventsCoordinatorActorState.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/actors/events/OrderEventsCoordinatorActorState.scala
@@ -29,7 +29,6 @@ case class OrderEventsCoordinatorActorState(addresses: Map[Address, PendingAddre
    * @return (updated, passUpdates), passUpdates can be sent to recipients
    */
   def withBalanceUpdates(updates: AddressAssets): (OrderEventsCoordinatorActorState, AddressAssets) = {
-    // TODO DEX-1041 probably, we need fold on addresses, because updates.size >> addresses.size
     val (updatedAddresses, passUpdates) = updates.foldLeft((addresses, Map.empty: AddressAssets)) {
       case ((addresses, passUpdates), item @ (address, updates)) =>
         addresses.get(address) match {

--- a/dex/src/main/scala/com/wavesplatform/dex/actors/events/PendingAddress.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/actors/events/PendingAddress.scala
@@ -6,7 +6,6 @@ import com.wavesplatform.dex.model.Events
 
 import scala.collection.immutable.Queue
 
-// TODO DEX-1041
 case class PendingAddress(
   pendingTxs: Map[ExchangeTransaction.Id, PendingTransactionType],
   stashedBalance: Map[Asset, Long],
@@ -35,7 +34,7 @@ case class PendingAddress(
 
   def withKnownOnMatcher(txId: ExchangeTransaction.Id, event: Events.OrderExecuted): PendingAddress =
     pendingTxs.get(txId) match {
-      case Some(PendingTransactionType.KnownOnMatcher) => this // ???
+      case Some(PendingTransactionType.KnownOnMatcher) => this
       case Some(PendingTransactionType.KnownOnNode) =>
         copy(
           pendingTxs = pendingTxs - txId,

--- a/dex/src/main/scala/com/wavesplatform/dex/model/ExchangeTransactionCreator.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/model/ExchangeTransactionCreator.scala
@@ -9,14 +9,12 @@ import com.wavesplatform.dex.domain.transaction.{ExchangeTransaction, ExchangeTr
 import com.wavesplatform.dex.model.Events.OrderExecuted
 import com.wavesplatform.dex.model.ExchangeTransactionCreator._
 
-import scala.concurrent.ExecutionContext
-
 class ExchangeTransactionCreator(
   matcherPrivateKey: KeyPair,
   exchangeTxBaseFee: Long,
   hasMatcherAccountScript: => Boolean,
   hasAssetScript: IssuedAsset => Boolean
-)(implicit ec: ExecutionContext) {
+) {
 
   def createTransaction(orderExecutedEvent: OrderExecuted): Either[ValidationError, ExchangeTransaction] = {
     import orderExecutedEvent.{counter, executedAmount, submitted, timestamp}

--- a/dex/src/main/scala/com/wavesplatform/dex/model/MatcherModel.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/model/MatcherModel.scala
@@ -273,7 +273,7 @@ object LimitOrder {
 }
 
 case class BuyLimitOrder(amount: Long, fee: Long, order: Order, avgWeighedPriceNominator: BigInteger) extends BuyOrder with LimitOrder {
-  override def toString: String = s"BuyLimitOrder($amount,$fee,$id,$avgWeighedPriceNominator)"
+  override def toString: String = s"BuyLimitOrder($amount,$fee,$id,$avgWeighedPriceNominator,o=${order.sender.toAddress})"
 
   def partial(amount: Long, fee: Long, avgWeighedPriceNominator: BigInteger): BuyLimitOrder =
     copy(amount = amount, fee = fee, avgWeighedPriceNominator = avgWeighedPriceNominator)
@@ -281,7 +281,7 @@ case class BuyLimitOrder(amount: Long, fee: Long, order: Order, avgWeighedPriceN
 }
 
 case class SellLimitOrder(amount: Long, fee: Long, order: Order, avgWeighedPriceNominator: BigInteger) extends SellOrder with LimitOrder {
-  override def toString: String = s"SellLimitOrder($amount,$fee,$id,$avgWeighedPriceNominator)"
+  override def toString: String = s"SellLimitOrder($amount,$fee,$id,$avgWeighedPriceNominator,o=${order.sender.toAddress})"
 
   def partial(amount: Long, fee: Long, avgWeighedPriceNominator: BigInteger): SellLimitOrder =
     copy(amount = amount, fee = fee, avgWeighedPriceNominator = avgWeighedPriceNominator)

--- a/dex/src/test/scala/com/wavesplatform/dex/actors/events/Generators.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/actors/events/Generators.scala
@@ -1,0 +1,78 @@
+package com.wavesplatform.dex.actors.events
+
+import com.wavesplatform.dex.collections.FifoSet
+import com.wavesplatform.dex.domain.account.KeyPair.toPublicKey
+import com.wavesplatform.dex.domain.account.{Address, KeyPair}
+import com.wavesplatform.dex.domain.asset.Asset
+import com.wavesplatform.dex.domain.bytes.ByteStr
+import com.wavesplatform.dex.domain.order.OrderType
+import com.wavesplatform.dex.domain.transaction.ExchangeTransaction
+import com.wavesplatform.dex.gen.bytes32gen
+import com.wavesplatform.dex.model.Events.OrderCanceledReason
+import com.wavesplatform.dex.model.{Events, LimitOrder}
+import com.wavesplatform.dex.test.WavesEntitiesGen
+import org.scalacheck.Gen
+
+import scala.collection.immutable.Queue
+
+trait Generators extends WavesEntitiesGen {
+  protected val definedAssets: List[Asset] = Asset.Waves :: Gen.listOfN(2, assetGen).sample.get
+
+  protected val definedAssetsGen: Gen[Asset] = Gen.oneOf(definedAssets)
+
+  protected val addressGen: Gen[Address] = keyPairGen.map(_.toAddress)
+
+  protected val txIdGen: Gen[ExchangeTransaction.Id] = bytes32gen.map(ByteStr(_))
+
+  protected val pendingTxTypeGen: Gen[PendingTransactionType] =
+    Gen.oneOf(PendingTransactionType.KnownOnMatcher, PendingTransactionType.KnownOnNode)
+
+  protected val balancesGen: Gen[Map[Asset, Long]] = Gen.choose(0, definedAssets.size).flatMap { size =>
+    Gen.mapOfN(size, Gen.zip(definedAssetsGen, Gen.choose(0, 10L)))
+  }
+
+  protected def executedEventGen(counterGen: Gen[KeyPair] = keyPairGen, submitterGen: Gen[KeyPair] = keyPairGen): Gen[Events.OrderExecuted] =
+    for {
+      (counter, _) <- orderAndSenderGen(sideGen = Gen.const(OrderType.SELL), senderGen = counterGen, matcherGen = toPublicKey(matcher))
+      (submitted, _) <- orderAndSenderGen(sideGen = Gen.const(OrderType.BUY), senderGen = submitterGen, matcherGen = toPublicKey(matcher))
+    } yield Events.OrderExecuted(
+      submitted = LimitOrder(submitted),
+      counter = LimitOrder(counter),
+      timestamp = submitted.timestamp,
+      counterExecutedFee = counter.matcherFee,
+      submittedExecutedFee = submitted.matcherFee
+    )
+
+  protected def canceledEventGen(senderGen: Gen[KeyPair] = keyPairGen): Gen[Events.OrderCanceled] =
+    for {
+      (order, _) <- orderAndSenderGen(senderGen = senderGen, matcherGen = toPublicKey(matcher))
+    } yield Events.OrderCanceled(
+      acceptedOrder = LimitOrder(order),
+      reason = OrderCanceledReason.BecameInvalid,
+      timestamp = order.timestamp
+    )
+
+  protected val eventGen: Gen[Events.Event] = Gen.oneOf(executedEventGen(), canceledEventGen())
+
+  protected def pendingAddressGen(
+    pendingTxsSizeGen: Gen[Int] = Gen.choose(1, 3),
+    pendingTxTypeGen: Gen[PendingTransactionType] = pendingTxTypeGen
+  ): Gen[PendingAddress] =
+    for {
+      pendingTxsSize <- pendingTxsSizeGen
+      pendingTxs <- Gen.mapOfN(pendingTxsSize, Gen.zip(txIdGen, pendingTxTypeGen))
+      balances <- balancesGen
+      events <- Gen.containerOf[Queue, Events.Event](eventGen)
+    } yield PendingAddress(
+      pendingTxs = pendingTxs,
+      stashedBalance = balances,
+      events = events
+    )
+
+  protected val knownOnNodeCacheGen: Gen[FifoSet[ExchangeTransaction.Id]] = Gen.choose(0, 2).flatMap { size =>
+    Gen.listOfN(size, txIdGen).map { xs =>
+      xs.foldLeft(FifoSet.limited[ExchangeTransaction.Id](100))(_.append(_))
+    }
+  }
+
+}

--- a/dex/src/test/scala/com/wavesplatform/dex/actors/events/OrderEventsCoordinatorActorStateSpec.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/actors/events/OrderEventsCoordinatorActorStateSpec.scala
@@ -1,0 +1,168 @@
+package com.wavesplatform.dex.actors.events
+
+import com.softwaremill.diffx.DiffxSupport
+import com.softwaremill.diffx.scalatest.DiffMatcher
+import com.wavesplatform.dex.NoShrink
+import com.wavesplatform.dex.collections.FifoSet
+import com.wavesplatform.dex.domain.account.Address
+import com.wavesplatform.dex.domain.account.KeyPair.toPublicKey
+import com.wavesplatform.dex.domain.asset.Asset
+import com.wavesplatform.dex.domain.bytes.ByteStr
+import com.wavesplatform.dex.domain.order.OrderType
+import com.wavesplatform.dex.domain.transaction.ExchangeTransaction
+import com.wavesplatform.dex.gen.{byteArrayGen, bytes32gen}
+import com.wavesplatform.dex.model.Events.OrderCanceledReason
+import com.wavesplatform.dex.model.{Events, LimitOrder}
+import com.wavesplatform.dex.test.WavesEntitiesGen
+import org.scalacheck.Gen
+import org.scalatest.freespec.AnyFreeSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+import scala.collection.immutable.Queue
+
+class OrderEventsCoordinatorActorStateSpec
+    extends AnyFreeSpecLike
+    with WavesEntitiesGen
+    with DiffMatcher
+    with Matchers
+    with ScalaCheckPropertyChecks
+    with NoShrink {
+
+  // TODO properties:
+  // 1. KnownOnNode in cache + KnownOnMatcher
+  // 2. PendingAddress non empty list of txId
+
+  private val definedAssets: List[Asset] = Asset.Waves :: Gen.listOfN(2, assetGen).sample.get
+
+  private val definedAssetsGen: Gen[Asset] = Gen.oneOf(definedAssets)
+
+  private val addressGen: Gen[Address] = keyPairGen.map(_.toAddress)
+
+  private val txIdGen: Gen[ExchangeTransaction.Id] = bytes32gen.map(ByteStr(_))
+
+  private val pendingTxTypeGen: Gen[PendingTransactionType] = Gen.oneOf(PendingTransactionType.KnownOnMatcher, PendingTransactionType.KnownOnNode)
+
+  private val balancesGen: Gen[Map[Asset, Long]] = Gen.mapOf(Gen.zip(definedAssetsGen, Gen.choose(0, 10L)))
+
+  private val executedEventGen: Gen[Events.OrderExecuted] =
+    for {
+      (submitted, _) <- orderAndSenderGen(sideGen = Gen.const(OrderType.BUY), matcherGen = toPublicKey(matcher))
+      (counter, _) <- orderAndSenderGen(sideGen = Gen.const(OrderType.SELL), matcherGen = toPublicKey(matcher))
+    } yield Events.OrderExecuted(
+      submitted = LimitOrder(submitted),
+      counter = LimitOrder(counter),
+      timestamp = submitted.timestamp,
+      counterExecutedFee = counter.matcherFee,
+      submittedExecutedFee = submitted.matcherFee
+    )
+
+  private val canceledEventGen: Gen[Events.OrderCanceled] =
+    for {
+      (order, _) <- orderAndSenderGen(matcherGen = toPublicKey(matcher))
+    } yield Events.OrderCanceled(
+      acceptedOrder = LimitOrder(order),
+      reason = OrderCanceledReason.BecameInvalid,
+      timestamp = order.timestamp
+    )
+
+  private val eventGen: Gen[Events.Event] = Gen.oneOf(executedEventGen, canceledEventGen)
+
+  private val pendingAddressGen: Gen[PendingAddress] =
+    for {
+      pendingTxs <- Gen.nonEmptyMap(Gen.zip(txIdGen, pendingTxTypeGen))
+      balances <- balancesGen
+      events <- Gen.containerOf[Queue, Events.Event](eventGen)
+    } yield PendingAddress(
+      pendingTxs = pendingTxs,
+      stashedBalance = balances,
+      events = events
+    )
+
+  private val knownOnNodeCacheGen: Gen[FifoSet[ExchangeTransaction.Id]] = Gen.listOf(txIdGen).map { xs =>
+    xs.foldLeft(FifoSet.limited[ExchangeTransaction.Id](100))(_.append(_))
+  }
+
+  private val stateGen: Gen[OrderEventsCoordinatorActorState] = for {
+    addresses <- Gen.mapOf(Gen.zip(addressGen, pendingAddressGen))
+    knownOnNodeCache <- knownOnNodeCacheGen
+  } yield {
+    val knownOnNodeByPending = addresses.values.flatMap(_.pendingTxs).collect {
+      case (txId, PendingTransactionType.KnownOnNode) => txId
+    }
+    OrderEventsCoordinatorActorState(addresses, knownOnNodeByPending.foldLeft(knownOnNodeCache)(_.append(_)))
+  }
+
+  "OrderEventsCoordinatorActorState" - {
+    "withBalanceUpdates" - {
+      val testGen = for {
+        state <- stateGen
+        knownAddresses = state.addresses.keySet
+        balances <- {
+          val unknownAddressesGen = addressGen.filterNot(knownAddresses.contains)
+          Gen.mapOf(Gen.zip(
+            if (knownAddresses.isEmpty) unknownAddressesGen
+            else Gen.oneOf(
+              Gen.oneOf(knownAddresses),
+              unknownAddressesGen
+            ),
+            balancesGen
+          ))
+        }
+      } yield (state, knownAddresses, balances)
+
+      "passes updates for not tracked addresses" in forAll(testGen) {
+        case (state, knownAddresses, balances) =>
+          val (_, passedBalances) = state.withBalanceUpdates(balances)
+          passedBalances.keySet should matchTo(balances.keySet -- knownAddresses)
+      }
+
+      "tracked information contains fresh updates if an address is tracked" in forAll(testGen) {
+        case (state, _, balances) =>
+          val (updatedState, _) = state.withBalanceUpdates(balances)
+
+          val expected = balances.view.filterKeys(updatedState.addresses.contains).toMap
+
+          val actual = updatedState.addresses.view.filterKeys(balances.contains)
+            .map { case (address, x) => address -> x.stashedBalance.view.filterKeys(expected(address).contains).toMap }
+            .toMap
+
+          actual should matchTo(expected)
+      }
+
+      "tracked information is not changed if an address is not tracked" in {
+        val testGen = for {
+          state <- stateGen
+          balances <- {
+            val knownAddresses = state.addresses.keySet
+            Gen.mapOf(Gen.zip(
+              addressGen.filterNot(knownAddresses.contains),
+              balancesGen
+            ))
+          }
+        } yield (state, state.withBalanceUpdates(balances)._1)
+
+        forAll(testGen) { case (orig, updated) =>
+          orig should matchTo(updated)
+        }
+      }
+    }
+
+    "withPendingCancel" - {
+      "passes updates for not tracked addresses, holds updates for tracked addresses" in {}
+      "tracked information contains fresh updates if an address is tracked" in {}
+      "tracked information is not changed if an address is not tracked" in {}
+    }
+
+    "withExecuted" - {
+      "for not tracked addresses - passes updates" in {}
+
+      "for tracked addresses" - {
+        "passes updates" in {}
+        "updates a tracked address information" in {}
+      }
+
+      "tracked and not tracked case" in {}
+    }
+  }
+}

--- a/dex/src/test/scala/com/wavesplatform/dex/actors/events/PendingAddressSpec.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/actors/events/PendingAddressSpec.scala
@@ -1,0 +1,196 @@
+package com.wavesplatform.dex.actors.events
+
+import com.softwaremill.diffx.scalatest.DiffMatcher
+import com.wavesplatform.dex.NoShrink
+import com.wavesplatform.dex.domain.asset.Asset
+import com.wavesplatform.dex.domain.transaction.ExchangeTransaction
+import com.wavesplatform.dex.fp.MapImplicits.MapOps
+import com.wavesplatform.dex.model.Events
+import com.wavesplatform.dex.model.Events.OrderExecuted
+import org.scalacheck.Gen
+import org.scalatest.freespec.AnyFreeSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+import scala.collection.immutable.Queue
+
+class PendingAddressSpec extends AnyFreeSpecLike with Generators with DiffMatcher with Matchers with ScalaCheckPropertyChecks with NoShrink {
+
+  "PendingAddress" - {
+    "withUpdatedBalances appends updated balances" in forAll(nonEmptyStateGen, balancesGen) { (state, balanceUpdates) =>
+      val updated = state.withUpdatedBalances(balanceUpdates)
+      updated.stashedBalance.filterByMap(balanceUpdates) shouldBe balanceUpdates
+    }
+
+    "withEvent appends events" in forAll(nonEmptyStateGen, canceledEventGen()) { (state, event) =>
+      val updated = state.withEvent(event)
+      updated.events.last shouldBe event
+    }
+
+    "withKnownOnNode if the transaction is" - {
+      "known on node" - {
+        val testGen = for {
+          (state, knownOnNodeTxId) <- autoStateGen(PendingTransactionType.KnownOnNode)
+          balanceUpdates <- balancesGen
+        } yield (state, knownOnNodeTxId, balanceUpdates)
+
+        def test(f: (PendingAddress, Map[Asset, Long]) => Unit): Unit = forAll(testGen) {
+          case (state, knownOnNodeTxId, balanceUpdates) => f(state.withKnownOnNode(knownOnNodeTxId, balanceUpdates), balanceUpdates)
+        }
+
+        "doesn't resolve" in test { case (updated, _) =>
+          updated.isResolved shouldBe false
+        }
+
+        "updates the balance" in test { case (updated, balanceUpdates) =>
+          updated.stashedBalance.filterByMap(balanceUpdates) shouldBe balanceUpdates
+        }
+      }
+
+      "known on matcher" - {
+        val testGen = for {
+          (state, knownOnMatcherTxId) <- autoStateGen(PendingTransactionType.KnownOnMatcher)
+          balanceUpdates <- balancesGen
+        } yield (state, state.pendingTxs.size, knownOnMatcherTxId, balanceUpdates)
+
+        def test(f: (PendingAddress, Int, Map[Asset, Long]) => Unit): Unit = forAll(testGen) {
+          case (state, txsNumber, knownOnMatcherTxId, balanceUpdates) =>
+            f(state.withKnownOnNode(knownOnMatcherTxId, balanceUpdates), txsNumber, balanceUpdates)
+        }
+
+        "resolves if this is the last pending transaction" in test { case (updated, txsNumber, _) =>
+          if (txsNumber > 1) updated.isResolved shouldBe false
+          else updated.isResolved shouldBe true
+        }
+
+        "updates the balance" in test { case (updated, _, balanceUpdates) =>
+          updated.stashedBalance.filterByMap(balanceUpdates) shouldBe balanceUpdates
+        }
+      }
+
+      "unknown" - {
+        val testGen = for {
+          state <- nonEmptyStateGen
+          unknownTxId <- txIdGen.filterNot(state.pendingTxs.contains)
+          balanceUpdates <- balancesGen
+        } yield (state, unknownTxId, balanceUpdates)
+
+        def test(f: (PendingAddress, Map[Asset, Long]) => Unit): Unit = forAll(testGen) {
+          case (state, unknownTxId, balanceUpdates) =>
+            f(state.withKnownOnNode(unknownTxId, balanceUpdates), balanceUpdates)
+        }
+
+        "holds" in test { case (updated, _) => updated.isResolved shouldBe false }
+
+        "updates the balance" in test { case (updated, balanceUpdates) =>
+          updated.stashedBalance.filterByMap(balanceUpdates) shouldBe balanceUpdates
+        }
+      }
+    }
+
+    "withKnownOnMatcher if the transaction is" - {
+      "known on node" - {
+        val testGen = for {
+          (state, knownOnNodeTxId) <- autoStateGen(PendingTransactionType.KnownOnNode)
+          event <- executedEventGen()
+        } yield (state, state.pendingTxs.size, knownOnNodeTxId, event)
+
+        def test(f: (PendingAddress, Int, OrderExecuted) => Unit): Unit = forAll(testGen) {
+          case (state, txsNumber, knownOnNodeTxId, event) =>
+            f(state.withKnownOnMatcher(knownOnNodeTxId, event), txsNumber, event)
+        }
+
+        "resolves if this is the last pending transaction" in test { case (updated, txsNumber, _) =>
+          if (txsNumber > 1) updated.isResolved shouldBe false
+          else updated.isResolved shouldBe true
+        }
+
+        "adds the event" in test { case (updated, _, event) => updated.events.last should matchTo[Events.Event](event) }
+      }
+
+      "known on matcher" - {
+        val testGen = for {
+          (state, knownOnMatcherTxId) <- autoStateGen(PendingTransactionType.KnownOnMatcher)
+          event <- executedEventGen()
+        } yield (state, knownOnMatcherTxId, event)
+
+        def test(f: (PendingAddress, OrderExecuted) => Unit): Unit = forAll(testGen) {
+          case (state, knownOnMatcherTxId, event) => f(state.withKnownOnMatcher(knownOnMatcherTxId, event), event)
+        }
+
+        "doesn't resolve" in test { case (updated, _) => updated.isResolved shouldBe false }
+        "doesn't add the event" in test { case (updated, event) => updated.events shouldNot contain(event) }
+      }
+
+      "unknown" - {
+        val testGen = for {
+          state <- nonEmptyStateGen
+          unknownTxId <- txIdGen.filterNot(state.pendingTxs.contains)
+          event <- executedEventGen()
+        } yield (state, unknownTxId, event)
+
+        def test(f: (PendingAddress, OrderExecuted) => Unit): Unit = forAll(testGen) {
+          case (state, unknownTxId, event) =>
+            f(state.withKnownOnMatcher(unknownTxId, event), event)
+        }
+
+        "holds" in test { case (updated, _) => updated.isResolved shouldBe false }
+        "adds the event" in test { case (updated, event) => updated.events.last should matchTo[Events.Event](event) }
+      }
+    }
+  }
+
+  private def pendingAddressSizedGen(
+    knownOnNodeSize: Int,
+    knownOnMatcherSize: Int
+  ): Gen[PendingAddress] = pendingAddressSizedGen(Gen.const(knownOnNodeSize), Gen.const(knownOnMatcherSize))
+
+  private def pendingAddressSizedGen(
+    knownOnNodeSizeGen: Gen[Int],
+    knownOnMatcherSizeGen: Gen[Int]
+  ): Gen[PendingAddress] =
+    for {
+      knownOnNodeSize <- knownOnNodeSizeGen
+      knownOnNode <- Gen.mapOfN(knownOnNodeSize, Gen.zip(txIdGen, Gen.const(PendingTransactionType.KnownOnNode)))
+
+      knownOnMatcherSize <- knownOnMatcherSizeGen
+      knownOnMatcher <- Gen.mapOfN(
+        knownOnMatcherSize,
+        Gen.zip(txIdGen.filterNot(knownOnNode.contains), Gen.const(PendingTransactionType.KnownOnMatcher))
+      )
+
+      pendingTxs = knownOnNode ++ knownOnMatcher
+      balances <- balancesGen
+      events <- Gen.containerOf[Queue, Events.Event](eventGen)
+    } yield PendingAddress(
+      pendingTxs = pendingTxs,
+      stashedBalance = balances,
+      events = events
+    )
+
+  private def stateWithTxGen(
+    knownOnNodeSize: Range,
+    knownOnMatcherSize: Range,
+    select: PendingTransactionType
+  ): Gen[(PendingAddress, ExchangeTransaction.Id)] = for {
+    state <- pendingAddressSizedGen(
+      knownOnNodeSizeGen = Gen.choose(knownOnNodeSize.head, knownOnNodeSize.last),
+      knownOnMatcherSizeGen = Gen.choose(knownOnMatcherSize.head, knownOnMatcherSize.last)
+    )
+    knownOnNodeTxId <- Gen.oneOf(state.pendingTxs.filter(_._2 == select).keys)
+  } yield (state, knownOnNodeTxId)
+
+  // For a selected type PendingAddress contains at least 1 tx
+  private def autoStateGen(select: PendingTransactionType): Gen[(PendingAddress, ExchangeTransaction.Id)] = {
+    val ranges = (0 to 2, 1 to 3)
+    val (knownOnNodeSize, knownOnMatcherSize) = if (select == PendingTransactionType.KnownOnMatcher) ranges else ranges.swap
+    stateWithTxGen(knownOnNodeSize, knownOnMatcherSize, select)
+  }
+
+  private def nonEmptyStateGen: Gen[PendingAddress] = for {
+    knownOnNodeSize <- Gen.choose(0, 2)
+    knownOnMatcherSize <- Gen.choose(if (knownOnNodeSize == 0) 1 else 0, 2)
+    state <- pendingAddressSizedGen(knownOnNodeSize, knownOnMatcherSize)
+  } yield state
+
+}

--- a/dex/src/test/scala/com/wavesplatform/dex/model/ExchangeTransactionCreatorSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/model/ExchangeTransactionCreatorSpecification.scala
@@ -17,8 +17,6 @@ import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.{Assertion, BeforeAndAfterAll}
 import org.scalatestplus.scalacheck.{ScalaCheckPropertyChecks => PropertyChecks}
 
-import scala.concurrent.ExecutionContext.Implicits.global
-
 class ExchangeTransactionCreatorSpecification
     extends AnyWordSpec
     with Matchers

--- a/dex/src/test/scala/com/wavesplatform/dex/test/WavesEntitiesGen.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/test/WavesEntitiesGen.scala
@@ -9,11 +9,15 @@ import com.wavesplatform.dex.domain.transaction.{ExchangeTransaction, ExchangeTr
 import com.wavesplatform.dex.domain.utils.EitherExt2
 import com.wavesplatform.dex.gen._
 import org.scalacheck.Gen
+import org.scalatest.enablers.Emptiness
 
 import java.nio.charset.StandardCharsets
 
 // TODO Copy from waves-ext with some modifications
 trait WavesEntitiesGen {
+
+  implicit val optionEmptiness: Emptiness[Option[Any]] = (thing: Option[Any]) => thing.isEmpty
+
   val AssetIdLength = 32
 
   val defaultWavesFee = 300000

--- a/dex/src/test/scala/com/wavesplatform/dex/test/WavesEntitiesGen.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/test/WavesEntitiesGen.scala
@@ -1,0 +1,137 @@
+package com.wavesplatform.dex.test
+
+import com.wavesplatform.dex.domain.account.{KeyPair, PublicKey}
+import com.wavesplatform.dex.domain.asset.Asset.{IssuedAsset, Waves}
+import com.wavesplatform.dex.domain.asset.{Asset, AssetPair}
+import com.wavesplatform.dex.domain.bytes.ByteStr
+import com.wavesplatform.dex.domain.order.{Order, OrderType}
+import com.wavesplatform.dex.domain.transaction.{ExchangeTransaction, ExchangeTransactionV2}
+import com.wavesplatform.dex.domain.utils.EitherExt2
+import com.wavesplatform.dex.gen._
+import org.scalacheck.Gen
+
+import java.nio.charset.StandardCharsets
+
+// TODO Copy from waves-ext with some modifications
+trait WavesEntitiesGen {
+  val AssetIdLength = 32
+
+  val matcher: KeyPair = KeyPair(ByteStr("matcher".getBytes(StandardCharsets.UTF_8)))
+
+  def issuedAssetGen: Gen[IssuedAsset] = byteArrayGen(AssetIdLength).map { xs =>
+    IssuedAsset(ByteStr(xs))
+  }
+
+  val assetGen: Gen[Asset] = Gen.frequency(
+    10 -> issuedAssetGen,
+    1 -> Gen.const(Waves)
+  )
+
+  val keyPairGen: Gen[KeyPair] = bytes32gen.map(xs => KeyPair(ByteStr(xs)))
+
+  val publicKeyGen: Gen[PublicKey] = keyPairGen.map(_.publicKey)
+
+  val assetPairGen: Gen[AssetPair] = Gen.zip(issuedAssetGen, assetGen).map {
+    case (asset1, Waves) => AssetPair(asset1, Waves)
+    case (asset1, asset2) => if (asset1 == asset2) AssetPair(asset1, Waves) else AssetPair(asset1, asset2)
+  }
+
+  val timestampGen: Gen[Long] = Gen.choose(1, Long.MaxValue - Order.MaxLiveTime)
+
+  val orderSideGen: Gen[OrderType] = Gen.oneOf(OrderType.BUY, OrderType.SELL)
+  val orderAmountGen: Gen[Long] = Gen.choose(1, 1000L)
+  val orderPriceGen: Gen[Long] = Gen.choose(1, 1000L).map(_ * Order.PriceConstant)
+  val orderTtlGen: Gen[Long] = Gen.choose(1, Order.MaxLiveTime)
+  val orderFeeGen: Gen[Long] = Gen.choose(1, Order.MaxAmount)
+
+  def orderAndSenderGen(
+    sideGen: Gen[OrderType] = orderSideGen,
+    matcherGen: Gen[PublicKey] = publicKeyGen,
+    assetPairGen: Gen[AssetPair] = assetPairGen,
+    priceGen: Gen[Long] = orderPriceGen,
+    timestampGen: Gen[Long] = timestampGen,
+    versionGen: Gen[Byte] = Gen.oneOf(1: Byte, 2: Byte, 3: Byte)
+  ): Gen[(Order, KeyPair)] =
+    for {
+      tpe <- sideGen
+      sender <- keyPairGen
+      matcher <- matcherGen
+      assetPair <- assetPairGen
+      amount <- orderAmountGen
+      price <- priceGen
+      timestamp <- timestampGen
+      ttl <- orderTtlGen
+      fee <- orderFeeGen
+      feeAsset <- assetGen
+      version <- versionGen
+    } yield {
+      val expiration = timestamp + ttl
+      val fixedVersion = if (feeAsset == Waves) version else math.max(version, 3).toByte
+      val order =
+        if (tpe == OrderType.BUY) Order.buy(sender, matcher, assetPair, amount, price, timestamp, expiration, fee, fixedVersion, feeAsset)
+        else Order.sell(sender, matcher, assetPair, amount, price, timestamp, expiration, fee, fixedVersion, feeAsset)
+      (order, sender)
+    }
+
+  val exchangeTransactionGen: Gen[ExchangeTransaction] = {
+    for {
+      version <- Gen.oneOf(1: Byte, 2: Byte)
+      matcher <- keyPairGen
+      matcherPublicKeyGen = Gen.const(matcher.publicKey)
+      timestamp <- timestampGen
+      orderTimestampGen = Gen.choose(1, 1000L).map(_ + timestamp)
+      (buyOrder, _) <- {
+        val sideGen = Gen.const(OrderType.BUY)
+        if (version == 1)
+          orderAndSenderGen(
+            sideGen = sideGen,
+            matcherGen = matcherPublicKeyGen,
+            versionGen = Gen.const(1: Byte),
+            timestampGen = orderTimestampGen
+          )
+        else orderAndSenderGen(sideGen = sideGen, matcherGen = matcherPublicKeyGen, timestampGen = orderTimestampGen)
+      }
+      (sellOrder, _) <- {
+        val sideGen = Gen.const(OrderType.SELL)
+        val priceGen = Gen.choose(1L, buyOrder.price)
+        val assetPairGen = Gen.const(buyOrder.assetPair)
+        if (version == 1)
+          orderAndSenderGen(
+            sideGen = sideGen,
+            matcherGen = matcherPublicKeyGen,
+            assetPairGen = assetPairGen,
+            priceGen = priceGen,
+            versionGen = Gen.const(1: Byte),
+            timestampGen = orderTimestampGen
+          )
+        else
+          orderAndSenderGen(
+            sideGen = sideGen,
+            matcherGen = matcherPublicKeyGen,
+            assetPairGen = assetPairGen,
+            priceGen = priceGen,
+            timestampGen = orderTimestampGen
+          )
+      }
+      fee <- orderFeeGen
+    } yield {
+      val amount = math.min(buyOrder.amount, sellOrder.amount)
+      val price = buyOrder.price
+      val fixedVersion = if (buyOrder.feeAsset == Waves && sellOrder.feeAsset == Waves) version else math.max(version, 2).toByte
+      ExchangeTransactionV2
+        .create(
+          matcher = matcher,
+          buyOrder = buyOrder,
+          sellOrder = sellOrder,
+          amount = amount,
+          price = price,
+          buyMatcherFee = buyOrder.matcherFee,
+          sellMatcherFee = sellOrder.matcherFee,
+          fee = fee,
+          timestamp = timestamp
+        )
+        .explicitGet()
+    }
+  }
+
+}

--- a/dex/src/test/scala/com/wavesplatform/dex/test/WavesEntitiesGen.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/test/WavesEntitiesGen.scala
@@ -16,6 +16,8 @@ import java.nio.charset.StandardCharsets
 trait WavesEntitiesGen {
   val AssetIdLength = 32
 
+  val defaultWavesFee = 300000
+
   val matcher: KeyPair = KeyPair(ByteStr("matcher".getBytes(StandardCharsets.UTF_8)))
 
   def issuedAssetGen: Gen[IssuedAsset] = byteArrayGen(AssetIdLength).map { xs =>
@@ -118,7 +120,6 @@ trait WavesEntitiesGen {
     } yield {
       val amount = math.min(buyOrder.amount, sellOrder.amount)
       val price = buyOrder.price
-      val fixedVersion = if (buyOrder.feeAsset == Waves && sellOrder.feeAsset == Waves) version else math.max(version, 2).toByte
       ExchangeTransactionV2
         .create(
           matcher = matcher,

--- a/dex/src/test/scala/com/wavesplatform/dex/test/WavesEntitiesGen.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/test/WavesEntitiesGen.scala
@@ -46,6 +46,7 @@ trait WavesEntitiesGen {
 
   def orderAndSenderGen(
     sideGen: Gen[OrderType] = orderSideGen,
+    senderGen: Gen[KeyPair] = keyPairGen,
     matcherGen: Gen[PublicKey] = publicKeyGen,
     assetPairGen: Gen[AssetPair] = assetPairGen,
     priceGen: Gen[Long] = orderPriceGen,
@@ -54,7 +55,7 @@ trait WavesEntitiesGen {
   ): Gen[(Order, KeyPair)] =
     for {
       tpe <- sideGen
-      sender <- keyPairGen
+      sender <- senderGen
       matcher <- matcherGen
       assetPair <- assetPairGen
       amount <- orderAmountGen

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/fp/MapImplicits.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/fp/MapImplicits.scala
@@ -42,6 +42,7 @@ object MapImplicits {
   implicit final class MapOps[K, V](val self: Map[K, V]) extends AnyVal {
     def appendIfDefined(k: K, v: Option[V]): Map[K, V] = v.fold(self)(self.updated(k, _))
     def appendIfDefinedMany(kv: (K, Option[V])*): Map[K, V] = kv.foldLeft(self) { case (r, (k, v)) => r.appendIfDefined(k, v) }
+    def filterByMap(other: Map[K, V]): Map[K, V] = self.view.filterKeys(other.contains).toMap
   }
 
 }

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/BlockchainBalance.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/BlockchainBalance.scala
@@ -5,6 +5,9 @@ import com.wavesplatform.dex.collections.MapOps.Ops2D
 import com.wavesplatform.dex.domain.account.Address
 import com.wavesplatform.dex.domain.asset.Asset
 
+/**
+  * @param outLeases Are always positive
+  */
 case class BlockchainBalance(regular: Map[Address, Map[Asset, Long]], outLeases: Map[Address, Long]) {
 
   def diffIndex: DiffIndex = DiffIndex(


### PR DESCRIPTION
* OrderEventsActorState renamed to OrderEventsCoordinatorActorState;
* OrderEventsCoordinatorActorState doesn't pass empty balances (see withBalanceUpdates, withKnownOnNode);
* OrderEventsCoordinatorActorState.withKnownOnNode processes balances even the transaction was processed before;
* Added a documentation to OrderEventsCoordinatorActorState;
* Added tests for OrderEventsCoordinatorActorState and PendingAddress.

Other:
* Added records to .gitignore to support scala-metals.