### PR TITLE
DEX-1073 Async WriteExchangeTransactionActor

### DIFF
--- a/dex/src/main/resources/application.conf
+++ b/dex/src/main/resources/application.conf
@@ -695,6 +695,13 @@ akka {
       throughput = 10
     }
 
+    leveldb-dispatcher {
+      type = "Dispatcher"
+      executor = "thread-pool-executor"
+      thread-pool-executor.fixed-pool-size = 4
+      throughput = 10
+    }
+
   }
 
   http {

--- a/dex/src/main/scala/com/wavesplatform/dex/actors/tx/WriteExchangeTransactionActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/actors/tx/WriteExchangeTransactionActor.scala
@@ -1,45 +1,29 @@
 package com.wavesplatform.dex.actors.tx
 
 import akka.actor.{Actor, Props}
-import com.wavesplatform.dex.db.DbKeys
-import com.wavesplatform.dex.db.leveldb.{DBExt, RW}
-import com.wavesplatform.dex.domain.bytes.ByteStr
-import com.wavesplatform.dex.domain.transaction.ExchangeTransaction
+import com.wavesplatform.dex.db.ExchangeTxStorage
 import com.wavesplatform.dex.domain.utils.ScorexLogging
 import com.wavesplatform.dex.model.Events._
-import org.iq80.leveldb.DB
 
-class WriteExchangeTransactionActor(db: DB) extends Actor with ScorexLogging {
+import scala.util.Failure
 
-  import WriteExchangeTransactionActor._
+class WriteExchangeTransactionActor(storage: ExchangeTxStorage) extends Actor with ScorexLogging {
 
+  import context.dispatcher
+
+  // TODO DEX-1081 Batching
   override def receive: Receive = {
-    case ExchangeTransactionCreated(tx) => saveExchangeTx(tx)
-  }
-
-  private def saveExchangeTx(tx: ExchangeTransaction): Unit = db.readWrite { rw =>
-    log.trace(s"Appending ${tx.id()} to orders [${tx.buyOrder.idStr()}, ${tx.sellOrder.idStr()}]")
-    val txKey = DbKeys.exchangeTransaction(tx.id())
-    if (!rw.has(txKey)) {
-      rw.put(txKey, Some(tx))
-      appendTxId(rw, tx.buyOrder.id(), tx.id())
-      appendTxId(rw, tx.sellOrder.id(), tx.id())
-    }
+    case ExchangeTransactionCreated(tx) =>
+      log.trace(s"Appending ${tx.id()} to orders [${tx.buyOrder.idStr()}, ${tx.sellOrder.idStr()}]")
+      storage.put(tx).onComplete {
+        case Failure(e) => log.warn(s"Can't write ${tx.id}", e)
+        case _ =>
+      }
   }
 
 }
 
 object WriteExchangeTransactionActor {
-
-  def name: String = "WriteExchangeTransactionActor"
-
-  def props(db: DB): Props = Props(new WriteExchangeTransactionActor(db))
-
-  def appendTxId(rw: RW, orderId: ByteStr, txId: ByteStr): Unit = {
-    val key = DbKeys.orderTxIdsSeqNr(orderId)
-    val nextSeqNr = rw.get(key) + 1
-    rw.put(key, nextSeqNr)
-    rw.put(DbKeys.orderTxId(orderId, nextSeqNr), txId)
-  }
-
+  val name: String = "WriteExchangeTransactionActor"
+  def props(storage: ExchangeTxStorage): Props = Props(new WriteExchangeTransactionActor(storage))
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/db/ExchangeTxStorage.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/db/ExchangeTxStorage.scala
@@ -1,0 +1,31 @@
+package com.wavesplatform.dex.db
+
+import com.wavesplatform.dex.domain.transaction.ExchangeTransaction
+import com.wavesplatform.dex.domain.bytes.ByteStr
+import com.wavesplatform.dex.db.leveldb.{AsyncLevelDB, ReadWriteDB}
+
+import scala.concurrent.Future
+
+trait ExchangeTxStorage {
+  def put(tx: ExchangeTransaction): Future[Unit]
+}
+
+object ExchangeTxStorage {
+  def levelDB(db: AsyncLevelDB): ExchangeTxStorage = new ExchangeTxStorage {
+    override def put(tx: ExchangeTransaction): Future[Unit] = db.readWrite { rw =>
+      val txKey = DbKeys.exchangeTransaction(tx.id())
+      if (!rw.has(txKey)) {
+        rw.put(txKey, Some(tx))
+        appendTxId(rw, tx.buyOrder.id(), tx.id())
+        appendTxId(rw, tx.sellOrder.id(), tx.id())
+      }
+    }
+
+    private def appendTxId(rw: ReadWriteDB, orderId: ByteStr, txId: ByteStr): Unit = {
+      val key = DbKeys.orderTxIdsSeqNr(orderId)
+      val nextSeqNr = rw.get(key) + 1
+      rw.put(key, nextSeqNr)
+      rw.put(DbKeys.orderTxId(orderId, nextSeqNr), txId)
+    }
+  }
+}

--- a/dex/src/main/scala/com/wavesplatform/dex/db/leveldb/AsyncLevelDB.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/db/leveldb/AsyncLevelDB.scala
@@ -1,0 +1,27 @@
+package com.wavesplatform.dex.db.leveldb
+
+import com.google.common.primitives.Shorts
+import org.iq80.leveldb.DB
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait AsyncLevelDB {
+  def readOnly[A](f: ReadOnlyDB => A): Future[A]
+  def readWrite[A](f: ReadWriteDB => A): Future[A]
+  def get[A](key: Key[A]): Future[A]
+  def has(key: Key[_]): Future[Boolean]
+  def iterateOver(prefix: Short)(f: DBEntry => Unit): Future[Unit] = iterateOver(Shorts.toByteArray(prefix))(f)
+  def iterateOver(prefix: Array[Byte])(f: DBEntry => Unit): Future[Unit]
+}
+
+object AsyncLevelDB {
+
+  def apply(db: DB)(implicit ec: ExecutionContext): AsyncLevelDB = new AsyncLevelDB {
+    override def readOnly[A](f: ReadOnlyDB => A): Future[A] = Future(db.readOnly(f))
+    override def readWrite[A](f: ReadWriteDB => A): Future[A] = Future(db.readWrite(f))
+    override def get[A](key: Key[A]): Future[A] = Future(db.get(key))
+    override def has(key: Key[_]): Future[Boolean] = Future(db.has(key))
+    override def iterateOver(prefix: Array[Byte])(f: DBEntry => Unit): Future[Unit] = Future(db.iterateOver(prefix)(f))
+  }
+
+}

--- a/dex/src/main/scala/com/wavesplatform/dex/db/leveldb/ReadWriteDB.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/db/leveldb/ReadWriteDB.scala
@@ -4,7 +4,7 @@ import com.wavesplatform.dex.metrics.LevelDBStats
 import com.wavesplatform.dex.metrics.LevelDBStats.DbHistogramExt
 import org.iq80.leveldb.{DB, ReadOptions, WriteBatch}
 
-class RW(db: DB, readOptions: ReadOptions, batch: WriteBatch) extends ReadOnlyDB(db, readOptions) {
+class ReadWriteDB(db: DB, readOptions: ReadOptions, batch: WriteBatch) extends ReadOnlyDB(db, readOptions) {
 
   def put[V](key: Key[V], value: V): Unit = {
     val bytes = key.encode(value)

--- a/dex/src/main/scala/com/wavesplatform/dex/db/leveldb/package.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/db/leveldb/package.scala
@@ -36,11 +36,11 @@ package object leveldb extends ScorexLogging {
     /**
      * @note Runs operations in batch, so keep in mind, that previous changes don't appear lately in f
      */
-    def readWrite[A](f: RW => A): A = {
+    def readWrite[A](f: ReadWriteDB => A): A = {
       val snapshot = db.getSnapshot
       val readOptions = new ReadOptions().snapshot(snapshot)
       val batch = db.createWriteBatch()
-      val rw = new RW(db, readOptions, batch)
+      val rw = new ReadWriteDB(db, readOptions, batch)
       try {
         val r = f(rw)
         db.write(batch)


### PR DESCRIPTION
* WriteExchangeTransactionActor writes transactions through ExchangeTxStorage;
* Added AsyncLevelDB to migrate to asynchronous work with LevelDB. It uses a separate thread pool.