### PR TITLE
DEX-1084 Wrong balances debugging

### DIFF
--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/HasToxiProxy.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/HasToxiProxy.scala
@@ -9,7 +9,7 @@ trait HasToxiProxy { self: BaseContainersKit =>
 
   protected val toxiProxyHostName = s"$networkName-toxiproxy"
 
-  private val container: ToxiproxyContainer = new ToxiproxyContainer("shopify/toxiproxy:2.1.0")
+  protected val toxiContainer: ToxiproxyContainer = new ToxiproxyContainer("shopify/toxiproxy:2.1.0")
     .withNetwork(network)
     .withNetworkAliases(toxiProxyHostName)
     .withExposedPorts(8666, 8667) // Two ports for two extensions: blockchain updates and ours
@@ -19,12 +19,12 @@ trait HasToxiProxy { self: BaseContainersKit =>
     }
 
   protected def getInnerToxiProxyPort(proxy: ContainerProxy): Int =
-    container.getContainerInfo.getNetworkSettings.getPorts.getBindings.asScala
+    toxiContainer.getContainerInfo.getNetworkSettings.getPorts.getBindings.asScala
       .find { case (_, bindings) => bindings.head.getHostPortSpec == proxy.getProxyPort.toString }
       .map(_._1.getPort)
       .getOrElse(throw new IllegalStateException(s"There is no inner port for proxied one: ${proxy.getProxyPort}"))
 
-  protected def mkToxiProxy(hostname: String, port: Int): ToxiproxyContainer.ContainerProxy = container.getProxy(hostname, port)
+  protected def mkToxiProxy(hostname: String, port: Int): ToxiproxyContainer.ContainerProxy = toxiContainer.getProxy(hostname, port)
 
-  container.start()
+  toxiContainer.start()
 }

--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/MultipleVersions.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/MultipleVersions.scala
@@ -18,8 +18,8 @@ trait MultipleVersions extends HasDex with HasWavesNode { self: BaseContainersKi
   protected def dex2SuiteConfig: Config = dexInitialSuiteConfig.withFallback {
     ConfigFactory.parseString(
       s"""waves.dex.waves-blockchain-client {
-         |  grpc.target = "${wavesNode2.networkAddress.getHostName}:6887"
-         |  blockchain-updates-grpc.target = "${wavesNode2.networkAddress.getHostName}:6881"
+         |  grpc.target = "dns:///${wavesNode2.networkAddress.getHostName}:6887"
+         |  blockchain-updates-grpc.target = "dns:///${wavesNode2.networkAddress.getHostName}:6881"
          |}""".stripMargin
     )
   }

--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/test/InformativeTestStart.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/test/InformativeTestStart.scala
@@ -12,6 +12,9 @@ trait InformativeTestStart extends TestSuite { self: BaseContainersKit =>
 
   @volatile private var preventLogs = false
 
+  // As a part of the test
+  protected def step(text: String): Unit = print(text)
+
   override protected def runTest(testName: String, args: Args): Status = {
     if (shouldWrite(success = true)) print(s"STARTED: $testName")
     super.runTest(testName, args).unsafeTap {

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/networking/DexClientFaultToleranceTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/networking/DexClientFaultToleranceTestSuite.scala
@@ -24,8 +24,8 @@ class DexClientFaultToleranceTestSuite extends MatcherSuiteBase with HasToxiProx
       s"""waves.dex {
          |  price-assets = [ "$UsdId", "WAVES" ]
          |  waves-blockchain-client { 
-         |    grpc.target = "$toxiProxyHostName:${getInnerToxiProxyPort(wavesNodeProxy)}"
-         |    blockchain-updates-grpc.target = "$toxiProxyHostName:${getInnerToxiProxyPort(blockchainUpdatesExtensionProxy)}"
+         |    grpc.target = "dns:///$toxiProxyHostName:${getInnerToxiProxyPort(wavesNodeProxy)}"
+         |    blockchain-updates-grpc.target = "dns:///$toxiProxyHostName:${getInnerToxiProxyPort(blockchainUpdatesExtensionProxy)}"
          |  }
          |}""".stripMargin
     )

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/networking/DexClientFaultToleranceTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/networking/DexClientFaultToleranceTestSuite.scala
@@ -45,17 +45,17 @@ class DexClientFaultToleranceTestSuite extends MatcherSuiteBase with HasToxiProx
     lazy val alice2BobTransferTx = mkTransfer(alice, bob, amount = wavesNode1.api.balance(alice, usd), asset = usd)
     lazy val bob2AliceTransferTx = mkTransfer(bob, alice, amount = wavesNode1.api.balance(bob, usd), asset = usd)
 
-    markup("Alice places order that requires some amount of USD, DEX receives balances stream from the node 1")
+    step("Alice places order that requires some amount of USD, DEX receives balances stream from the node 1")
     dex1.api.place(aliceBuyOrder)
     dex1.api.waitForOrderStatus(aliceBuyOrder, Status.Accepted)
 
-    markup(s"Disconnect DEX from the network and perform USD transfer from Alice to Bob")
+    step(s"Disconnect DEX from the network and perform USD transfer from Alice to Bob")
     wavesNodeProxy.setConnectionCut(true)
 
     broadcastAndAwait(alice2BobTransferTx)
     usdBalancesShouldBe(wavesNode1.api, 0, defaultAssetQuantity)
 
-    markup("Connect DEX back to the network, DEX should know about transfer and cancel Alice's order")
+    step("Connect DEX back to the network, DEX should know about transfer and cancel Alice's order")
     wavesNodeProxy.setConnectionCut(false)
 
     dex1.api.waitForOrderStatus(aliceBuyOrder, Status.Cancelled)
@@ -76,11 +76,11 @@ class DexClientFaultToleranceTestSuite extends MatcherSuiteBase with HasToxiProx
     lazy val alice2BobTransferTx = mkTransfer(alice, bob, amount = wavesNode2.api.balance(alice, usd), asset = usd)
     lazy val bob2AliceTransferTx = mkTransfer(bob, alice, amount = wavesNode1.api.balance(bob, usd), asset = usd)
 
-    markup("Alice places order that requires some amount of USD, DEX receives balances stream from the node 1")
+    step("Alice places order that requires some amount of USD, DEX receives balances stream from the node 1")
     dex1.api.place(aliceBuyOrder)
     dex1.api.waitForOrderStatus(aliceBuyOrder, Status.Accepted)
 
-    markup("Up node 2")
+    step("Up node 2")
     wavesNode2.start()
     wavesNode2.api.connect(wavesNode1.networkAddress)
     wavesNode2.api.waitForConnectedPeer(wavesNode1.networkAddress)
@@ -88,33 +88,33 @@ class DexClientFaultToleranceTestSuite extends MatcherSuiteBase with HasToxiProx
     wavesNode2.api.waitForHeight(wavesNode1.api.currentHeight)
     wavesNode2.api.waitForTransaction(IssueUsdTx)
 
-    markup(s"Stop node 1 and perform USD transfer from Alice to Bob")
+    step(s"Stop node 1 and perform USD transfer from Alice to Bob")
     wavesNode1.stopWithoutRemove()
 
     broadcastAndAwait(wavesNode2.api, alice2BobTransferTx)
     usdBalancesShouldBe(wavesNode2.api, expectedAliceBalance = 0, expectedBobBalance = defaultAssetQuantity)
 
-    markup("Now DEX receives balances stream from the node 2 and cancels Alice's order")
+    step("Now DEX receives balances stream from the node 2 and cancels Alice's order")
     dex1.api.waitForOrderStatus(aliceBuyOrder, Status.Cancelled)
 
-    markup("Bob places order that requires some amount of USD, DEX receives balances stream from the node 2")
+    step("Bob places order that requires some amount of USD, DEX receives balances stream from the node 2")
     dex1.api.place(bobBuyOrder)
     dex1.api.waitForOrderStatus(bobBuyOrder, Status.Accepted)
 
-    markup("Up node 1")
+    step("Up node 1")
     wavesNode1.start()
 
     wavesNode2.api.connect(wavesNode1.networkAddress)
     wavesNode2.api.waitForConnectedPeer(wavesNode1.networkAddress)
     wavesNode1.api.waitForTransaction(alice2BobTransferTx)
 
-    markup(s"Stop node 2 and perform USD transfer from Bob to Alice")
+    step(s"Stop node 2 and perform USD transfer from Bob to Alice")
     wavesNode2.stopWithoutRemove()
 
     broadcastAndAwait(wavesNode1.api, bob2AliceTransferTx)
     usdBalancesShouldBe(wavesNode1.api, defaultAssetQuantity, 0)
 
-    markup("Now DEX receives balances stream from the node 1 and cancels Bob's order")
+    step("Now DEX receives balances stream from the node 1 and cancels Bob's order")
     dex1.api.waitForOrderStatus(bobBuyOrder, Status.Cancelled)
   }
 

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/networking/NetworkIssuesTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/networking/NetworkIssuesTestSuite.scala
@@ -31,8 +31,8 @@ class NetworkIssuesTestSuite extends WsSuiteBase with HasToxiProxy {
         s"""waves.dex {
            |  price-assets = [ "$UsdId", "WAVES" ]
            |  waves-blockchain-client {
-           |    grpc.target = "$toxiProxyHostName:${getInnerToxiProxyPort(matcherExtensionProxy)}"
-           |    blockchain-updates-grpc.target = "$toxiProxyHostName:${getInnerToxiProxyPort(blockchainUpdatesExtensionProxy)}"
+           |    grpc.target = "dns:///$toxiProxyHostName:${getInnerToxiProxyPort(matcherExtensionProxy)}"
+           |    blockchain-updates-grpc.target = "dns:///$toxiProxyHostName:${getInnerToxiProxyPort(blockchainUpdatesExtensionProxy)}"
            |  }
            |}""".stripMargin
       )
@@ -162,8 +162,8 @@ class NetworkIssuesTestSuite extends WsSuiteBase with HasToxiProxy {
       s"""waves.dex {
          |  price-assets = [ "$UsdId", "WAVES" ]
          |  waves-blockchain-client { 
-         |    grpc.target = "${WavesNodeContainer.wavesNodeNetAlias}:${WavesNodeContainer.matcherGrpcExtensionPort}"
-         |    blockchain-updates-grpc.target = "${WavesNodeContainer.wavesNodeNetAlias}:${WavesNodeContainer.blockchainUpdatesGrpcExtensionPort}"
+         |    grpc.target = "dns:///${WavesNodeContainer.wavesNodeNetAlias}:${WavesNodeContainer.matcherGrpcExtensionPort}"
+         |    blockchain-updates-grpc.target = "dns:///${WavesNodeContainer.wavesNodeNetAlias}:${WavesNodeContainer.blockchainUpdatesGrpcExtensionPort}"
          |  }
          |}""".stripMargin
     )

--- a/dex/src/main/resources/application.conf
+++ b/dex/src/main/resources/application.conf
@@ -79,15 +79,17 @@ waves.dex {
       # Sets whether keepalive will be performed when there are no outstanding RPC on a connection
       keep-alive-without-calls = true
 
-      # Sets the time without read activity before sending a keepalive ping
-      keep-alive-time = 2s
+      # Sets the time without read activity before sending a keepalive ping.
+      # 5s is an average time between micro blocks
+      # In a normal state we don't need this, because transactions come often.
+      keep-alive-time = 5s
 
       # Sets the time waiting for read activity after sending a keepalive ping.
       keep-alive-timeout = 5s
 
       # Set the duration without ongoing RPCs before going to idle mode.
       # See https://github.com/grpc/grpc/blob/master/doc/connectivity-semantics-and-api.md
-      idle-timeout = 7s
+      idle-timeout = 1d
 
       # Low level settings for connection
       channel-options {
@@ -115,15 +117,16 @@ waves.dex {
       # Sets whether keepalive will be performed when there are no outstanding RPC on a connection
       keep-alive-without-calls = true
 
-      # Sets the time without read activity before sending a keepalive ping
-      keep-alive-time = 2s
+      # Sets the time without read activity before sending a keepalive ping.
+      # 5s is an average time between blocks, we add 1s to receive a micro block
+      keep-alive-time = 6s
 
       # Sets the time waiting for read activity after sending a keepalive ping.
       keep-alive-timeout = 5s
 
       # Set the duration without ongoing RPCs before going to idle mode.
       # See https://github.com/grpc/grpc/blob/master/doc/connectivity-semantics-and-api.md
-      idle-timeout = 7s
+      idle-timeout = 1d
 
       # Low level settings for connection
       channel-options {

--- a/dex/src/main/resources/application.conf
+++ b/dex/src/main/resources/application.conf
@@ -90,7 +90,7 @@ waves.dex {
 
       # Set the duration without ongoing RPCs before going to idle mode.
       # See https://github.com/grpc/grpc/blob/master/doc/connectivity-semantics-and-api.md
-      idle-timeout = 1d
+      idle-timeout = 300d
 
       # Low level settings for connection
       channel-options {
@@ -128,7 +128,7 @@ waves.dex {
 
       # Set the duration without ongoing RPCs before going to idle mode.
       # See https://github.com/grpc/grpc/blob/master/doc/connectivity-semantics-and-api.md
-      idle-timeout = 1d
+      idle-timeout = 300d
 
       # Low level settings for connection
       channel-options {

--- a/dex/src/main/resources/application.conf
+++ b/dex/src/main/resources/application.conf
@@ -64,7 +64,8 @@ waves.dex {
     grpc {
       # Address and port of gRPC server.
       # In order to provide fault-tolerance, consider using DNS server between DEX and Node, which would resolve this
-      # address into several endpoints (ips of nodes with DEXExtension installed)
+      # address into several endpoints (ips of nodes with DEXExtension installed).
+      # Use "dns:///" prefix to specify a domain name
       target = "127.0.0.1:6887"
 
       # Internal gRPC channel settings
@@ -102,7 +103,8 @@ waves.dex {
     blockchain-updates-grpc {
       # Address and port of gRPC server.
       # In order to provide fault-tolerance, consider using DNS server between DEX and Node, which would resolve this
-      # address into several endpoints (ips of nodes with DEXExtension installed)
+      # address into several endpoints (ips of nodes with DEXExtension installed).
+      # Use "dns:///" prefix to specify a domain name
       target = "127.0.0.1:6881"
 
       # Internal gRPC channel settings

--- a/dex/src/main/scala/com/wavesplatform/dex/actors/orderbook/OrderBookActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/actors/orderbook/OrderBookActor.scala
@@ -204,7 +204,7 @@ class OrderBookActor(
         aggregatedRef ! AggregatedOrderBookActor.Command.ApplyChanges(levelChanges, None, None, cancelEvent.timestamp)
         processEvents(cancelEvent.timestamp, List(cancelEvent))
       case _ =>
-        log.warn(s"Error applying $command: order not found")
+        log.warn(s"Can't apply $command: order not found")
         eventsCoordinatorRef ! OrderEventsCoordinatorActor.Command.ProcessError(
           OrderCancelFailed(cancelCommand.orderId, error.OrderNotFound(cancelCommand.orderId))
         )

--- a/dex/src/package/doc/logback.xml
+++ b/dex/src/package/doc/logback.xml
@@ -33,6 +33,7 @@
     <!-- Networking -->
     <logger name="io.netty" level="INFO"/>
     <logger name="io.grpc.netty" level="ERROR"/>
+    <logger name="io.grpc.Context" level="INFO"/> <!-- To ignore "Storage override doesn't exist. Using default" -->
 
     <!-- Queues -->
     <logger name="org.apache.kafka" level="INFO"/>
@@ -47,6 +48,9 @@
     <!-- REST API -->
     <logger name="io.swagger" level="INFO"/>
     <logger name="com.wavesplatform.dex.api.http" level="WARN"/> <!-- Requests -->
+
+    <!-- Waves NODE interaction -->
+    <logger name="com.wavesplatform.dex.grpc.integration.clients.blockchainupdates" level="DEBUG"/>
 
     <if condition='property("logback.stdout.enabled").contains("true")'>
         <then>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -131,8 +131,7 @@ object Dependencies {
   private val toxiProxy = "org.testcontainers" % "toxiproxy" % Version.testContainersToxiProxy
   private val googleGuava = "com.google.guava" % "guava" % Version.googleGuava
   private val kafka = "org.apache.kafka" % "kafka-clients" % Version.kafka
-  private val grpcNetty = "io.grpc" % "grpc-netty" % scalapb.compiler.Version.grpcJavaVersion
-  private val nettyCodec = "io.netty" % "netty-codec-http2" % Version.nettyCodec
+  private val grpcNetty = "io.grpc" % "grpc-netty" % "1.35.0" // scalapb.compiler.Version.grpcJavaVersion // "1.31.1" on NODE 1.2.17
   private val swagger = "com.github.swagger-akka-http" %% "swagger-akka-http" % Version.swagger
   private val swaggerUi = "org.webjars" % "swagger-ui" % Version.swaggerUi
   private val playJson = "com.typesafe.play" %% "play-json" % Version.playJson
@@ -224,8 +223,7 @@ object Dependencies {
       scalaTest % Test,
       googleGuava,
       slf4j,
-      grpcNetty,
-      nettyCodec
+      grpcNetty
     ) ++ pureConfig ++ enumeratum ++ levelDBJNA
   )
 

--- a/waves-integration-it/src/test/resources/logback-test.xml
+++ b/waves-integration-it/src/test/resources/logback-test.xml
@@ -26,6 +26,7 @@
     <logger name="org.asynchttpclient" level="INFO"/>
     <logger name="io.netty" level="INFO"/>
     <logger name="io.grpc.netty" level="WARN"/>
+    <logger name="io.grpc.Context" level="INFO"/>
     <logger name="io.swagger" level="OFF"/>
     <logger name="com.github.dockerjava" level="WARN"/>
     <logger name="org.testcontainers" level="WARN"/>

--- a/waves-integration-it/src/test/scala/com/wavesplatform/dex/grpc/integration/IntegrationSuiteBase.scala
+++ b/waves-integration-it/src/test/scala/com/wavesplatform/dex/grpc/integration/IntegrationSuiteBase.scala
@@ -54,4 +54,8 @@ trait IntegrationSuiteBase
     super.afterAll()
   }
 
+  override protected def step(text: String): Unit = {
+    info(text)
+    super.step(text)
+  }
 }

--- a/waves-integration-it/src/test/scala/com/wavesplatform/dex/grpc/integration/clients/BlockchainUpdatesClientTestSuite.scala
+++ b/waves-integration-it/src/test/scala/com/wavesplatform/dex/grpc/integration/clients/BlockchainUpdatesClientTestSuite.scala
@@ -5,24 +5,35 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder
 import com.google.protobuf.ByteString
 import com.wavesplatform.dex.domain.asset.Asset
 import com.wavesplatform.dex.grpc.integration.IntegrationSuiteBase
+import com.wavesplatform.dex.grpc.integration.clients.ControlledStream.SystemEvent
 import com.wavesplatform.dex.grpc.integration.clients.blockchainupdates.{BlockchainUpdatesConversions, DefaultBlockchainUpdatesClient}
 import com.wavesplatform.dex.grpc.integration.clients.domain.portfolio.Implicits._
 import com.wavesplatform.dex.grpc.integration.clients.domain.{TransactionWithChanges, WavesNodeEvent}
+import com.wavesplatform.dex.grpc.integration.protobuf.PbToDexConversions._
 import com.wavesplatform.dex.grpc.integration.settings.GrpcClientSettings
+import com.wavesplatform.dex.it.api.HasToxiProxy
+import com.wavesplatform.dex.it.docker.WavesNodeContainer
 import com.wavesplatform.dex.it.test.NoStackTraceCancelAfterFailure
 import im.mak.waves.transactions.Transaction
 import io.grpc.ManagedChannel
 import io.grpc.internal.DnsNameResolverProvider
 import io.netty.channel.nio.NioEventLoopGroup
 import io.netty.channel.socket.nio.NioSocketChannel
+import monix.eval.Task
 import monix.execution.Scheduler
+import monix.execution.cancelables.BooleanCancelable
 
 import java.util.concurrent.Executors
 import scala.collection.immutable
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, ExecutionContext, Future}
 
-class BlockchainUpdatesClientTestSuite extends IntegrationSuiteBase with NoStackTraceCancelAfterFailure {
+class BlockchainUpdatesClientTestSuite extends IntegrationSuiteBase with HasToxiProxy with NoStackTraceCancelAfterFailure {
+
+  implicit override def patienceConfig: PatienceConfig = super.patienceConfig.copy(
+    timeout = 1.minute,
+    interval = 1.second
+  )
 
   private val grpcExecutor = Executors.newCachedThreadPool(
     new ThreadFactoryBuilder()
@@ -33,17 +44,22 @@ class BlockchainUpdatesClientTestSuite extends IntegrationSuiteBase with NoStack
 
   implicit private val monixScheduler: Scheduler = monix.execution.Scheduler.cached("monix", 1, 5)
 
+  private lazy val blockchainUpdatesProxy =
+    toxiContainer.getProxy(wavesNode1.underlying.container, WavesNodeContainer.blockchainUpdatesGrpcExtensionPort)
+
   private lazy val eventLoopGroup = new NioEventLoopGroup
+
+  private val keepAliveTimeout = 5.seconds
 
   private lazy val blockchainUpdatesChannel: ManagedChannel =
     GrpcClientSettings(
-      target = wavesNode1.blockchainUpdatesExtApiTarget,
+      target = s"127.0.0.1:${blockchainUpdatesProxy.getProxyPort}",
       maxHedgedAttempts = 5,
       maxRetryAttempts = 5,
       keepAliveWithoutCalls = true,
       keepAliveTime = 2.seconds,
-      keepAliveTimeout = 5.seconds,
-      idleTimeout = 1.minute,
+      keepAliveTimeout = keepAliveTimeout,
+      idleTimeout = 1.day,
       channelOptions = GrpcClientSettings.ChannelOptionsSettings(connectTimeout = 5.seconds)
     ).toNettyChannelBuilder
       .nameResolverFactory(new DnsNameResolverProvider)
@@ -55,11 +71,6 @@ class BlockchainUpdatesClientTestSuite extends IntegrationSuiteBase with NoStack
 
   private lazy val client =
     new DefaultBlockchainUpdatesClient(eventLoopGroup, blockchainUpdatesChannel, monixScheduler)(ExecutionContext.fromExecutor(grpcExecutor))
-
-  implicit override def patienceConfig: PatienceConfig = super.patienceConfig.copy(
-    timeout = 1.minute,
-    interval = 1.second
-  )
 
   override def beforeAll(): Unit = {
     super.beforeAll()
@@ -83,6 +94,78 @@ class BlockchainUpdatesClientTestSuite extends IntegrationSuiteBase with NoStack
     }
   }
 
+  "Bugs" - {
+    "DEX-1084 No updates from Blockchain updates" in {
+      val cancellable = BooleanCancelable()
+      @volatile var lastStatus: SystemEvent = SystemEvent.BecameReady
+
+      val eventsF = client.blockchainEvents.stream
+        .takeWhileNotCanceled(cancellable)
+        .doOnNext(_ => Task(client.blockchainEvents.requestNext()))
+        .doOnComplete(Task(log.info("events completed")))
+        .toListL.runToFuture
+
+      client.blockchainEvents.systemStream
+        .takeWhileNotCanceled(cancellable)
+        .doOnNext { evt =>
+          Task {
+            lastStatus = evt
+            log.info(s"System event: $evt")
+          }
+        }
+        .doOnComplete(Task(log.info("system events completed")))
+        .lastOptionL.runToFuture
+
+      val startHeight = wavesNode1.api.currentHeight
+      client.blockchainEvents.startFrom(startHeight)
+
+      step("transfer1")
+      val transfer1 = mkTransfer(alice, bob, 1, Asset.Waves)
+      broadcastAndAwait(transfer1)
+
+      step("Cut connection to gRPC extension")
+      blockchainUpdatesProxy.setConnectionCut(true)
+
+      val transfer2 = mkTransfer(bob, matcher, 1, Asset.Waves)
+      broadcastAndAwait(transfer2)
+
+      Thread.sleep((keepAliveTimeout + 2.seconds).toMillis)
+
+      step("Enable connection to gRPC extension")
+      blockchainUpdatesProxy.setConnectionCut(false)
+
+      // Connection should be closed, restore it
+      lastStatus shouldBe SystemEvent.Stopped
+      client.blockchainEvents.startFrom(startHeight)
+
+      Thread.sleep(5.seconds.toMillis)
+
+      cancellable.cancel()
+      val events = Await.result(eventsF, 5.seconds).map { evt =>
+        val event = BlockchainUpdatesConversions.toEvent(evt.getUpdate)
+        log.debug(s"Got $event")
+        event.flatMap {
+          case WavesNodeEvent.Appended(block) => block.confirmedTxs.map(_._1.toVanilla).toList.some
+          case _ => none
+        }
+      }
+      client.blockchainEvents.stop()
+
+      val gotTxIds = events.flatMap {
+        case None => List.empty
+        case Some(txIds) => txIds.map(_.base58)
+      }
+
+      withClue("transfer1: ") {
+        gotTxIds should contain(transfer1.id().base58)
+      }
+
+      withClue("transfer2: ") {
+        gotTxIds should contain(transfer2.id().base58)
+      }
+    }
+  }
+
   override protected def afterAll(): Unit = {
     Await.ready(client.close(), 10.seconds)
     super.afterAll()
@@ -91,6 +174,12 @@ class BlockchainUpdatesClientTestSuite extends IntegrationSuiteBase with NoStack
 
   private def sendAndWaitTxFromStream(tx: Transaction): TransactionWithChanges = {
     val pbTxId = ByteString.copyFrom(tx.id().bytes())
+    val cancellable = BooleanCancelable()
+
+    client.blockchainEvents.systemStream
+      .takeWhileNotCanceled(cancellable)
+      .doOnNext(evt => Task(log.info(s"System event: $evt")))
+      .lastOptionL.runToFuture
 
     val receivedTxFuture = client.blockchainEvents.stream
       .flatMapIterable(evt => immutable.Iterable.from(evt.update.flatMap(BlockchainUpdatesConversions.toEvent)))
@@ -113,6 +202,10 @@ class BlockchainUpdatesClientTestSuite extends IntegrationSuiteBase with NoStack
     client.blockchainEvents.startFrom(startHeight)
     val receivedTx = wait(receivedTxFuture)
     client.blockchainEvents.stop()
+
+    Thread.sleep(1000)
+    cancellable.cancel()
+
     receivedTx
   }
 

--- a/waves-integration-it/src/test/scala/com/wavesplatform/dex/grpc/integration/clients/BlockchainUpdatesClientTestSuite.scala
+++ b/waves-integration-it/src/test/scala/com/wavesplatform/dex/grpc/integration/clients/BlockchainUpdatesClientTestSuite.scala
@@ -16,7 +16,6 @@ import com.wavesplatform.dex.it.docker.WavesNodeContainer
 import com.wavesplatform.dex.it.test.NoStackTraceCancelAfterFailure
 import im.mak.waves.transactions.Transaction
 import io.grpc.ManagedChannel
-import io.grpc.internal.DnsNameResolverProvider
 import io.netty.channel.nio.NioEventLoopGroup
 import io.netty.channel.socket.nio.NioSocketChannel
 import monix.eval.Task
@@ -62,7 +61,6 @@ class BlockchainUpdatesClientTestSuite extends IntegrationSuiteBase with HasToxi
       idleTimeout = 1.day,
       channelOptions = GrpcClientSettings.ChannelOptionsSettings(connectTimeout = 5.seconds)
     ).toNettyChannelBuilder
-      .nameResolverFactory(new DnsNameResolverProvider)
       .executor((command: Runnable) => grpcExecutor.execute(command))
       .eventLoopGroup(eventLoopGroup)
       .channelType(classOf[NioSocketChannel])

--- a/waves-integration-it/src/test/scala/com/wavesplatform/dex/grpc/integration/clients/BlockchainUpdatesClientTestSuite.scala
+++ b/waves-integration-it/src/test/scala/com/wavesplatform/dex/grpc/integration/clients/BlockchainUpdatesClientTestSuite.scala
@@ -139,7 +139,7 @@ class BlockchainUpdatesClientTestSuite extends IntegrationSuiteBase with HasToxi
       Thread.sleep(5.seconds.toMillis)
 
       cancellable.cancel()
-      val events = Await.result(eventsF, 5.seconds).map { evt =>
+      val events = Await.result(eventsF, 1.minute).map { evt =>
         val event = BlockchainUpdatesConversions.toEvent(evt.getUpdate)
         log.debug(s"Got $event")
         event.flatMap {

--- a/waves-integration-it/src/test/scala/com/wavesplatform/dex/grpc/integration/clients/CombinedWavesBlockchainClientTestSuite.scala
+++ b/waves-integration-it/src/test/scala/com/wavesplatform/dex/grpc/integration/clients/CombinedWavesBlockchainClientTestSuite.scala
@@ -1,5 +1,6 @@
 package com.wavesplatform.dex.grpc.integration.clients
 
+import cats.implicits._
 import com.google.common.util.concurrent.ThreadFactoryBuilder
 import com.wavesplatform.dex.collections.MapOps.Ops2D
 import com.wavesplatform.dex.domain.account.{Address, KeyPair, PublicKey}
@@ -15,8 +16,11 @@ import com.wavesplatform.dex.grpc.integration.clients.domain.AddressBalanceUpdat
 import com.wavesplatform.dex.grpc.integration.clients.domain.portfolio.SynchronizedPessimisticPortfolios
 import com.wavesplatform.dex.grpc.integration.dto.BriefAssetDescription
 import com.wavesplatform.dex.grpc.integration.settings.{GrpcClientSettings, WavesBlockchainClientSettings}
+import com.wavesplatform.dex.it.api.HasToxiProxy
+import com.wavesplatform.dex.it.docker.WavesNodeContainer
 import com.wavesplatform.dex.it.test.{NoStackTraceCancelAfterFailure, Scripts}
 import monix.execution.Scheduler
+import monix.execution.cancelables.BooleanCancelable
 
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.Executors
@@ -25,7 +29,12 @@ import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.util.Random
 
-class CombinedWavesBlockchainClientTestSuite extends IntegrationSuiteBase with NoStackTraceCancelAfterFailure {
+class CombinedWavesBlockchainClientTestSuite extends IntegrationSuiteBase with HasToxiProxy with NoStackTraceCancelAfterFailure {
+
+  implicit override def patienceConfig: PatienceConfig = super.patienceConfig.copy(
+    timeout = 1.minute,
+    interval = 1.second
+  )
 
   private val grpcExecutor = Executors.newCachedThreadPool(
     new ThreadFactoryBuilder()
@@ -36,27 +45,34 @@ class CombinedWavesBlockchainClientTestSuite extends IntegrationSuiteBase with N
 
   implicit private val monixScheduler: Scheduler = monix.execution.Scheduler.cached("monix", 1, 5)
 
+  private lazy val blockchainUpdatesProxy =
+    toxiContainer.getProxy(wavesNode1.underlying.container, WavesNodeContainer.blockchainUpdatesGrpcExtensionPort)
+
+  private lazy val matcherExtProxy = toxiContainer.getProxy(wavesNode1.underlying.container, WavesNodeContainer.matcherGrpcExtensionPort)
+
+  private val keepAliveTimeout = 5.seconds
+
   private lazy val client =
     CombinedWavesBlockchainClient(
       wavesBlockchainClientSettings = WavesBlockchainClientSettings(
         grpc = GrpcClientSettings(
-          target = wavesNode1.matcherExtApiTarget,
+          target = s"127.0.0.1:${matcherExtProxy.getProxyPort}",
           maxHedgedAttempts = 5,
           maxRetryAttempts = 5,
           keepAliveWithoutCalls = true,
           keepAliveTime = 2.seconds,
-          keepAliveTimeout = 5.seconds,
+          keepAliveTimeout = keepAliveTimeout,
           idleTimeout = 1.minute,
           channelOptions = GrpcClientSettings.ChannelOptionsSettings(connectTimeout = 5.seconds)
         ),
         blockchainUpdatesGrpc = GrpcClientSettings(
-          target = wavesNode1.blockchainUpdatesExtApiTarget,
+          target = s"127.0.0.1:${blockchainUpdatesProxy.getProxyPort}",
           maxHedgedAttempts = 5,
           maxRetryAttempts = 5,
           keepAliveWithoutCalls = true,
           keepAliveTime = 2.seconds,
-          keepAliveTimeout = 5.seconds,
-          idleTimeout = 1.minute,
+          keepAliveTimeout = keepAliveTimeout,
+          idleTimeout = 1.day,
           channelOptions = GrpcClientSettings.ChannelOptionsSettings(connectTimeout = 5.seconds)
         ),
         defaultCachesExpiration = 100.milliseconds,
@@ -73,53 +89,16 @@ class CombinedWavesBlockchainClientTestSuite extends IntegrationSuiteBase with N
       grpcExecutionContext = ExecutionContext.fromExecutor(grpcExecutor)
     )
 
-  implicit override def patienceConfig: PatienceConfig = super.patienceConfig.copy(
-    timeout = 1.minute,
-    interval = 1.second
-  )
+  private lazy val updates = client.updates.share
 
   private val regularBalance = new AtomicReference(Map.empty[Address, Map[Asset, Long]])
 
   private val trueScript = Option(Scripts.alwaysTrue)
 
-  private def assertRegularBalanceChanges(expectedBalanceChanges: Map[Address, Map[Asset, Long]]): Unit = eventually {
-    // Remove pairs (address, asset) those expectedBalanceChanges has not
-    val actual = simplify(
-      regularBalance.get.view
-        .filterKeys(expectedBalanceChanges.keys.toSet)
-        .map {
-          case (address, balance) => address -> balance.view.filterKeys(expectedBalanceChanges(address).contains).toMap
-        }
-        .toMap
-    )
-    val expected = simplify(expectedBalanceChanges)
-    withClue(s"actual=$actual vs expected=$expected\n") {
-      actual should matchTo(expected)
-    }
-  }
-
-  private def simplify(xs: Map[Address, Map[Asset, Long]]): String =
-    xs.toList
-      .map {
-        case (address, assets) =>
-          val xs = assets
-            .map { case (asset, v) => asset.toString -> v }
-            .toList
-            .sortBy(_._1)
-            .map { case (asset, v) => s"$v $asset" }
-            .mkString(", ")
-          address.stringRepr -> xs
-      }
-      .sortBy(_._1)
-      .map {
-        case (address, assets) => s"$address: ($assets)"
-      }
-      .mkString("; ")
-
   override def beforeAll(): Unit = {
     super.beforeAll()
     broadcastAndAwait(IssueUsdTx, IssueBtcTx)
-    client.updates.foreach { update =>
+    updates.foreach { update =>
       log.info(s"Got in test: $update")
       regularBalance.updateAndGet { orig =>
         update.balanceUpdates.foldLeft(orig) { case (r, (address, xs)) =>
@@ -424,6 +403,63 @@ class CombinedWavesBlockchainClientTestSuite extends IntegrationSuiteBase with N
     }
   }
 
+  "Bugs" - {
+    "DEX-1084 No updates from Blockchain updates" in {
+      val aliceBalanceBefore = wavesNode1.api.balance(alice, Waves)
+      val bobBalanceBefore = wavesNode1.api.balance(bob, Waves)
+
+      val cancellable = BooleanCancelable()
+
+      val eventsF = updates
+        .takeWhileNotCanceled(cancellable)
+        .toListL.runToFuture
+
+      step("transfer1")
+      val transfer1 = mkTransfer(alice, bob, 1.waves, Asset.Waves)
+      broadcastAndAwait(transfer1)
+
+      step("Cut connection to gRPC extension")
+      blockchainUpdatesProxy.setConnectionCut(true)
+
+      val transfer2 = mkTransfer(bob, matcher, 2.waves, Asset.Waves)
+      broadcastAndAwait(transfer2)
+
+      Thread.sleep((keepAliveTimeout + 1.second).toMillis) // Connection should be closed
+
+      step("Enable connection to gRPC extension")
+      blockchainUpdatesProxy.setConnectionCut(false)
+
+      // Connection should be restored without our intervention
+      Thread.sleep(5.seconds.toMillis)
+      val leasing = mkLease(bob, alice, 3.waves)
+      broadcastAndAwait(leasing)
+
+      cancellable.cancel()
+      val r = Await.result(eventsF, 5.seconds).foldMap(_.balanceUpdates)
+
+      def filtered(in: AddressBalanceUpdates): AddressBalanceUpdates = in.copy(
+        regular = in.regular.view.filterKeys(_ == Waves).toMap,
+        pessimisticCorrection = Map(Waves -> in.pessimisticCorrection.getOrElse(Waves, 0L))
+      )
+
+      withClue("alice: ") {
+        r.get(alice).map(filtered) should matchTo(AddressBalanceUpdates(
+          regular = Map(Waves -> (aliceBalanceBefore - 1.waves - minFee)),
+          outgoingLeasing = 0L.some,
+          pessimisticCorrection = Map(Waves -> 0)
+        ).some)
+      }
+
+      withClue("bob: ") {
+        r.get(bob).map(filtered) should matchTo(AddressBalanceUpdates(
+          regular = Map(Waves -> (bobBalanceBefore + 1.waves - 2.waves - minFee - leasingFee)),
+          outgoingLeasing = 3.waves.some,
+          pessimisticCorrection = Map(Waves -> 0)
+        ).some)
+      }
+    }
+  }
+
   // TODO check that the functions returns new data after the state is changed?
 
   override protected def afterAll(): Unit = {
@@ -431,6 +467,40 @@ class CombinedWavesBlockchainClientTestSuite extends IntegrationSuiteBase with N
     super.afterAll()
     grpcExecutor.shutdownNow()
   }
+
+  private def assertRegularBalanceChanges(expectedBalanceChanges: Map[Address, Map[Asset, Long]]): Unit = eventually {
+    // Remove pairs (address, asset) those expectedBalanceChanges has not
+    val actual = simplify(
+      regularBalance.get.view
+        .filterKeys(expectedBalanceChanges.keys.toSet)
+        .map {
+          case (address, balance) => address -> balance.view.filterKeys(expectedBalanceChanges(address).contains).toMap
+        }
+        .toMap
+    )
+    val expected = simplify(expectedBalanceChanges)
+    withClue(s"actual=$actual vs expected=$expected\n") {
+      actual should matchTo(expected)
+    }
+  }
+
+  private def simplify(xs: Map[Address, Map[Asset, Long]]): String =
+    xs.toList
+      .map {
+        case (address, assets) =>
+          val xs = assets
+            .map { case (asset, v) => asset.toString -> v }
+            .toList
+            .sortBy(_._1)
+            .map { case (asset, v) => s"$v $asset" }
+            .mkString(", ")
+          address.stringRepr -> xs
+      }
+      .sortBy(_._1)
+      .map {
+        case (address, assets) => s"$address: ($assets)"
+      }
+      .mkString("; ")
 
   private def wait[T](f: => Future[T]): T = Await.result(f, 10.seconds)
 

--- a/waves-integration-it/src/test/scala/com/wavesplatform/dex/grpc/integration/clients/CombinedWavesBlockchainClientTestSuite.scala
+++ b/waves-integration-it/src/test/scala/com/wavesplatform/dex/grpc/integration/clients/CombinedWavesBlockchainClientTestSuite.scala
@@ -435,7 +435,7 @@ class CombinedWavesBlockchainClientTestSuite extends IntegrationSuiteBase with H
       broadcastAndAwait(leasing)
 
       cancellable.cancel()
-      val r = Await.result(eventsF, 5.seconds).foldMap(_.balanceUpdates)
+      val r = Await.result(eventsF, 1.minute).foldMap(_.balanceUpdates)
 
       def filtered(in: AddressBalanceUpdates): AddressBalanceUpdates = in.copy(
         regular = in.regular.view.filterKeys(_ == Waves).toMap,

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/blockchainupdates/GrpcBlockchainUpdatesControlledStream.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/blockchainupdates/GrpcBlockchainUpdatesControlledStream.scala
@@ -3,8 +3,12 @@ package com.wavesplatform.dex.grpc.integration.clients.blockchainupdates
 import cats.syntax.option._
 import com.wavesplatform.dex.domain.utils.ScorexLogging
 import com.wavesplatform.dex.grpc.integration.clients.ControlledStream.SystemEvent
+import com.wavesplatform.dex.grpc.integration.clients.domain.BlockRef
+import com.wavesplatform.dex.grpc.integration.protobuf.PbToDexConversions._
 import com.wavesplatform.dex.grpc.observers.IntegrationObserver
 import com.wavesplatform.events.api.grpc.protobuf.{BlockchainUpdatesApiGrpc, SubscribeEvent, SubscribeRequest}
+import com.wavesplatform.events.protobuf.BlockchainUpdated.Append.Body
+import com.wavesplatform.events.protobuf.BlockchainUpdated.Update
 import io.grpc.stub.ClientCalls
 import io.grpc.{CallOptions, ClientCall, Grpc, ManagedChannel}
 import monix.execution.Scheduler
@@ -19,6 +23,9 @@ import monix.reactive.subjects.ConcurrentSubject
 class GrpcBlockchainUpdatesControlledStream(channel: ManagedChannel)(implicit scheduler: Scheduler)
     extends BlockchainUpdatesControlledStream
     with ScorexLogging {
+
+  private val logPrefix = s"[${hashCode()}]" // TODO remove in future versions
+
   @volatile private var grpcObserver: Option[BlockchainUpdatesObserver] = None
 
   private val internalStream = ConcurrentSubject.publish[SubscribeEvent]
@@ -29,7 +36,7 @@ class GrpcBlockchainUpdatesControlledStream(channel: ManagedChannel)(implicit sc
 
   override def startFrom(height: Int): Unit = {
     require(height >= 1, "We can not get blocks on height <= 0")
-    log.info("Connecting to Blockchain events stream")
+    log.info(s"$logPrefix Connecting to Blockchain events stream")
 
     val call = channel.newCall(BlockchainUpdatesApiGrpc.METHOD_SUBSCRIBE, CallOptions.DEFAULT.withWaitForReady()) // TODO DEX-1001
     val observer = new BlockchainUpdatesObserver(call, height)
@@ -40,13 +47,13 @@ class GrpcBlockchainUpdatesControlledStream(channel: ManagedChannel)(implicit sc
   override def requestNext(): Unit = grpcObserver.foreach(_.requestNext())
 
   override def stop(): Unit = if (grpcObserver.nonEmpty) {
-    log.info("Stopping balance updates stream")
+    log.info(s"$logPrefix Stopping balance updates stream")
     stopGrpcObserver()
     internalSystemStream.onNext(SystemEvent.Stopped)
   }
 
   override def close(): Unit = {
-    log.info("Closing balance updates stream")
+    log.info(s"$logPrefix Closing balance updates stream")
     stopGrpcObserver()
     internalStream.onComplete()
     internalSystemStream.onNext(SystemEvent.Closed)
@@ -64,15 +71,37 @@ class GrpcBlockchainUpdatesControlledStream(channel: ManagedChannel)(implicit sc
     override def onReady(): Unit = {
       internalSystemStream.onNext(SystemEvent.BecameReady)
       val address = Option(call.getAttributes.get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR)).fold("unknown")(_.toString)
-      log.info(s"Getting blockchain events from $address starting from $startHeight")
+      log.info(s"$logPrefix Getting blockchain events from $address starting from $startHeight")
     }
 
-    override def onError(e: Throwable): Unit = if (!isClosed) {
-      log.warn(s"Got an error in blockchain events", e)
-      internalSystemStream.onNext(SystemEvent.Stopped)
+    override def onNext(value: SubscribeEvent): Unit = {
+      def message = {
+        val update = value.getUpdate
+        def ref = BlockRef(update.height, update.id.toVanilla)
+        update.update match {
+          case Update.Empty => "empty"
+          case Update.Rollback(x) => s"rollback tpe=${x.`type`}, $ref"
+          case Update.Append(x) =>
+            val tpe = x.body match {
+              case Body.Empty => "empty"
+              case _: Body.Block => "f"
+              case _: Body.MicroBlock => "m"
+            }
+            s"append tpe=$tpe, $ref"
+        }
+      }
+      log.debug(s"$logPrefix Got $message")
+      super.onNext(value)
     }
 
-    override def onCompleted(): Unit = log.error("Unexpected onCompleted")
+    override def onError(e: Throwable): Unit =
+      if (isClosed) log.trace(s"$logPrefix Got an expected error during closing: ${Option(e.getMessage).getOrElse("null")}")
+      else {
+        log.warn(s"$logPrefix Got an error in blockchain events", e)
+        internalSystemStream.onNext(SystemEvent.Stopped)
+      }
+
+    override def onCompleted(): Unit = log.error(s"$logPrefix Unexpected onCompleted")
   }
 
 }

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/combined/CombinedStream.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/combined/CombinedStream.scala
@@ -82,8 +82,8 @@ class CombinedStream(
         mergedEvents.onNext(x)
         Ack.Continue
       },
-      e => log.error(s"utxEvents failed", e), // Won't happen
-      () => log.info(s"utxEvents completed") // We do this manually in finish()
+      e => log.error("utxEvents system stream failed", e), // Won't happen
+      () => log.info("utxEvents system stream completed") // We do this manually in finish()
     )
 
   blockchainUpdates.systemStream
@@ -93,8 +93,8 @@ class CombinedStream(
         mergedEvents.onNext(x)
         Ack.Continue
       },
-      e => log.error(s"bu failed", e), // Won't happen
-      () => log.info(s"bu completed") // We do this manually in finish()
+      e => log.error("bu system stream failed", e), // Won't happen
+      () => log.info("bu system stream completed") // We do this manually in finish()
     )
 
   // TODO DEX-1034

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/combined/CombinedWavesBlockchainClient.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/combined/CombinedWavesBlockchainClient.scala
@@ -36,6 +36,7 @@ import monix.execution.Scheduler
 import monix.reactive.Observable
 import monix.reactive.subjects.ConcurrentSubject
 
+import scala.annotation.nowarn
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.chaining._
 import scala.util.{Failure, Success}
@@ -254,7 +255,7 @@ object CombinedWavesBlockchainClient extends ScorexLogging {
     val eventLoopGroup = new NioEventLoopGroup
 
     log.info(s"Building Matcher Extension gRPC client for server: ${wavesBlockchainClientSettings.grpc.target}")
-    val matcherExtensionChannel: ManagedChannel =
+    @nowarn val matcherExtensionChannel: ManagedChannel =
       wavesBlockchainClientSettings.grpc.toNettyChannelBuilder
         .nameResolverFactory(new DnsNameResolverProvider)
         .executor((command: Runnable) => grpcExecutionContext.execute(command))
@@ -264,7 +265,7 @@ object CombinedWavesBlockchainClient extends ScorexLogging {
         .build
 
     log.info(s"Building Blockchain Updates Extension gRPC client for server: ${wavesBlockchainClientSettings.blockchainUpdatesGrpc.target}")
-    val blockchainUpdatesChannel: ManagedChannel =
+    @nowarn val blockchainUpdatesChannel: ManagedChannel =
       wavesBlockchainClientSettings.blockchainUpdatesGrpc.toNettyChannelBuilder
         .nameResolverFactory(new DnsNameResolverProvider)
         .executor((command: Runnable) => grpcExecutionContext.execute(command))

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/combined/CombinedWavesBlockchainClient.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/combined/CombinedWavesBlockchainClient.scala
@@ -28,7 +28,6 @@ import com.wavesplatform.dex.grpc.integration.services.UtxTransaction
 import com.wavesplatform.dex.grpc.integration.settings.WavesBlockchainClientSettings
 import com.wavesplatform.protobuf.transaction.SignedTransaction
 import io.grpc.ManagedChannel
-import io.grpc.internal.DnsNameResolverProvider
 import io.netty.channel.nio.NioEventLoopGroup
 import io.netty.channel.socket.nio.NioSocketChannel
 import monix.eval.Task
@@ -36,7 +35,6 @@ import monix.execution.Scheduler
 import monix.reactive.Observable
 import monix.reactive.subjects.ConcurrentSubject
 
-import scala.annotation.nowarn
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.chaining._
 import scala.util.{Failure, Success}
@@ -255,9 +253,8 @@ object CombinedWavesBlockchainClient extends ScorexLogging {
     val eventLoopGroup = new NioEventLoopGroup
 
     log.info(s"Building Matcher Extension gRPC client for server: ${wavesBlockchainClientSettings.grpc.target}")
-    @nowarn val matcherExtensionChannel: ManagedChannel =
+    val matcherExtensionChannel: ManagedChannel =
       wavesBlockchainClientSettings.grpc.toNettyChannelBuilder
-        .nameResolverFactory(new DnsNameResolverProvider)
         .executor((command: Runnable) => grpcExecutionContext.execute(command))
         .eventLoopGroup(eventLoopGroup)
         .channelType(classOf[NioSocketChannel])
@@ -265,9 +262,8 @@ object CombinedWavesBlockchainClient extends ScorexLogging {
         .build
 
     log.info(s"Building Blockchain Updates Extension gRPC client for server: ${wavesBlockchainClientSettings.blockchainUpdatesGrpc.target}")
-    @nowarn val blockchainUpdatesChannel: ManagedChannel =
+    val blockchainUpdatesChannel: ManagedChannel =
       wavesBlockchainClientSettings.blockchainUpdatesGrpc.toNettyChannelBuilder
-        .nameResolverFactory(new DnsNameResolverProvider)
         .executor((command: Runnable) => grpcExecutionContext.execute(command))
         .eventLoopGroup(eventLoopGroup)
         .channelType(classOf[NioSocketChannel])

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/BlockRef.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/BlockRef.scala
@@ -3,5 +3,5 @@ package com.wavesplatform.dex.grpc.integration.clients.domain
 import com.wavesplatform.dex.domain.bytes.ByteStr
 
 case class BlockRef(height: Int, id: ByteStr) {
-  override def toString: String = s"BlockRef(h=$height, $id)"
+  override def toString: String = s"Ref(h=$height, ${id.base58.take(5)})"
 }

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/BlockchainBalance.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/BlockchainBalance.scala
@@ -26,7 +26,9 @@ case class BlockchainBalance(regular: Map[Address, Map[Asset, Long]], outgoingLe
 
   def isEmpty: Boolean = regular.isEmpty && outgoingLeasing.isEmpty
 
-  override def toString: String = s"BlockchainBalance(r={${regular.keys.mkString(", ")}}, ol={${outgoingLeasing.keys.mkString(", ")}})"
+  override def toString: String =
+    s"BlockchainBalance(r={${regular.keys.map(_.stringRepr.take(5)).mkString(", ")}}, ol={${outgoingLeasing.keys.map(_.stringRepr.take(5)).mkString(", ")}})"
+
 }
 
 object BlockchainBalance {

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/WavesBlock.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/WavesBlock.scala
@@ -16,7 +16,7 @@ case class WavesBlock(
     outgoingLeasing = changes.outgoingLeasing.keySet
   )
 
-  override def toString: String = s"WavesBlock(id=${ref.id.base58.take(5)}, h=${ref.height}, tpe=$tpe, c=${confirmedTxs.size})"
+  override def toString: String = s"B($ref, tpe=$tpe, c=${confirmedTxs.size})"
 
 }
 

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/WavesChain.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/WavesChain.scala
@@ -16,8 +16,11 @@ import scala.annotation.tailrec
  * @param blocksCapacity How many full blocks we can append
  */
 case class WavesChain(history: Vector[WavesBlock], height: Int, blocksCapacity: Int) {
-  require(history.headOption.map(_.ref.height).forall(_ == height), "height corresponds last block")
-  require(blocksCapacity >= 0, "blocksCapacity >= 0")
+  {
+    val historyHeight = history.headOption.map(_.ref.height)
+    require(historyHeight.forall(_ == height), s"height=$height should correspond the height of the last block=$historyHeight")
+    require(blocksCapacity >= 0, "blocksCapacity >= 0")
+  }
 
   // We prepend block, because it is easier to use dropWhile
 

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/matcherext/GrpcUtxEventsControlledStream.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/matcherext/GrpcUtxEventsControlledStream.scala
@@ -20,10 +20,12 @@ import monix.reactive.subjects.ConcurrentSubject
 class GrpcUtxEventsControlledStream(channel: ManagedChannel)(implicit scheduler: Scheduler)
     extends UtxEventsControlledStream
     with ScorexLogging {
+
+  private val logPrefix = s"[${hashCode()}]" // TODO remove in future versions
+
   @volatile private var grpcObserver: Option[UtxEventObserver] = None
 
   private val internalStream = ConcurrentSubject.publish[UtxEvent]
-  // HACK: Monix skips the first few messages! So we have to turn it into a hot
   override val stream: Observable[UtxEvent] = internalStream
 
   private val internalSystemStream = ConcurrentSubject.publish[SystemEvent]
@@ -32,7 +34,7 @@ class GrpcUtxEventsControlledStream(channel: ManagedChannel)(implicit scheduler:
   private val empty: Empty = Empty()
 
   override def start(): Unit = {
-    log.info("Connecting to UTX stream")
+    log.info(s"$logPrefix Connecting to UTX stream")
     val call = channel.newCall(WavesBlockchainApiGrpc.METHOD_GET_UTX_EVENTS, CallOptions.DEFAULT.withWaitForReady()) // TODO DEX-1001
     val observer = new UtxEventObserver(call)
     grpcObserver = observer.some
@@ -40,13 +42,13 @@ class GrpcUtxEventsControlledStream(channel: ManagedChannel)(implicit scheduler:
   }
 
   override def stop(): Unit = if (grpcObserver.nonEmpty) {
-    log.info("Stopping utx events stream")
+    log.info(s"$logPrefix Stopping utx events stream")
     stopGrpcObserver()
     internalSystemStream.onNext(SystemEvent.Stopped)
   }
 
   override def close(): Unit = {
-    log.info("Closing utx events stream")
+    log.info(s"$logPrefix Closing utx events stream")
     stopGrpcObserver()
     internalStream.onComplete()
     internalSystemStream.onNext(SystemEvent.Closed)
@@ -64,7 +66,7 @@ class GrpcUtxEventsControlledStream(channel: ManagedChannel)(implicit scheduler:
 
     override def onReady(): Unit = {
       val address = Option(call.getAttributes.get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR)).fold("unknown")(_.toString)
-      log.info(s"Getting utx events from $address")
+      log.info(s"$logPrefix Getting utx events from $address")
     }
 
     override def onNext(value: UtxEvent): Unit = {
@@ -72,17 +74,17 @@ class GrpcUtxEventsControlledStream(channel: ManagedChannel)(implicit scheduler:
 
       // To guarantee UtxSwitch before readiness and thus before resolving a temporary rollback (StatusTransitions)
       if (ready.compareAndSet(false, true)) {
-        if (!value.`type`.isSwitch) log.error(s"Expected UtxSwitch, received: ${value.`type`}")
+        if (!value.`type`.isSwitch) log.error(s"$logPrefix Expected UtxSwitch, received: ${value.`type`}")
         internalSystemStream.onNext(SystemEvent.BecameReady)
       }
     }
 
     override def onError(e: Throwable): Unit = if (!isClosed) {
-      log.warn(s"Got an error in utx events", e)
+      log.warn(s"$logPrefix Got an error in utx events", e)
       internalSystemStream.onNext(SystemEvent.Stopped)
     }
 
-    override def onCompleted(): Unit = log.error("Unexpected onCompleted")
+    override def onCompleted(): Unit = log.error(s"$logPrefix Unexpected onCompleted")
   }
 
 }

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/settings/GrpcClientSettings.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/settings/GrpcClientSettings.scala
@@ -1,7 +1,7 @@
 package com.wavesplatform.dex.grpc.integration.settings
 
 import com.wavesplatform.dex.grpc.integration.settings.GrpcClientSettings.ChannelOptionsSettings
-import io.grpc.netty.NettyChannelBuilder
+import io.grpc.netty.{InternalNettyChannelBuilder, NettyChannelBuilder}
 import io.netty.channel.ChannelOption
 
 import scala.concurrent.duration.FiniteDuration
@@ -17,8 +17,8 @@ case class GrpcClientSettings(
   channelOptions: ChannelOptionsSettings
 ) {
 
-  def toNettyChannelBuilder: NettyChannelBuilder =
-    NettyChannelBuilder
+  def toNettyChannelBuilder: NettyChannelBuilder = {
+    val r = NettyChannelBuilder
       .forTarget(target)
       .maxHedgedAttempts(maxHedgedAttempts)
       .maxRetryAttempts(maxRetryAttempts)
@@ -27,6 +27,10 @@ case class GrpcClientSettings(
       .keepAliveTimeout(keepAliveTimeout.length, keepAliveTimeout.unit)
       .idleTimeout(idleTimeout.length, idleTimeout.unit)
       .withOption[Integer](ChannelOption.CONNECT_TIMEOUT_MILLIS, channelOptions.connectTimeout.toMillis.toInt)
+    InternalNettyChannelBuilder.setStatsEnabled(r, false)
+    InternalNettyChannelBuilder.setTracingEnabled(r, false)
+    r
+  }
 
 }
 

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/observers/IntegrationObserver.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/observers/IntegrationObserver.scala
@@ -1,9 +1,9 @@
 package com.wavesplatform.dex.grpc.observers
 
+import monix.reactive.Observer
+
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicBoolean
-
-import monix.reactive.Observer
 
 /**
  * 1. Pushes events to monix observer
@@ -11,8 +11,10 @@ import monix.reactive.Observer
  */
 abstract class IntegrationObserver[ArgT, EventT](dest: Observer[EventT]) extends ClosingObserver[ArgT, EventT] {
 
-  private val awaitNext = new AtomicBoolean(true)
-  private val buffer = new ConcurrentLinkedQueue[EventT]()
+  // Invariant: awaitNext == buffer.isEmpty
+
+  private[observers] val awaitNext = new AtomicBoolean(true)
+  private[observers] val buffer = new ConcurrentLinkedQueue[EventT]()
 
   override def onNext(value: EventT): Unit = {
     buffer.add(value)

--- a/waves-integration/src/test/scala/com/wavesplatform/dex/grpc/integration/clients/domain/WavesForkTestSuite.scala
+++ b/waves-integration/src/test/scala/com/wavesplatform/dex/grpc/integration/clients/domain/WavesForkTestSuite.scala
@@ -77,7 +77,7 @@ class WavesForkTestSuite extends WavesIntegrationSuiteBase with ScalaCheckDriven
 
         fork.withBlock(invalidBlock) should matchTo(Status.Failed(
           updatedFork = expectedUpdatedFork,
-          reason = "The new block BlockRef(h=2, ZvGf) (reference=3j) must be after BlockRef(h=1, 8TZ)"
+          reason = "The new block Ref(h=2, ZvGf) (reference=3j) must be after Ref(h=1, 8TZ)"
         ): Status)
       }
 

--- a/waves-integration/src/test/scala/com/wavesplatform/dex/grpc/observers/IntegrationObserverSpec.scala
+++ b/waves-integration/src/test/scala/com/wavesplatform/dex/grpc/observers/IntegrationObserverSpec.scala
@@ -1,0 +1,65 @@
+package com.wavesplatform.dex.grpc.observers
+
+import com.wavesplatform.dex.{NoShrink, WavesIntegrationSuiteBase}
+import monix.execution.UncaughtExceptionReporter
+import monix.reactive.Observer
+import org.scalacheck.Gen
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+
+class IntegrationObserverSpec extends WavesIntegrationSuiteBase with ScalaCheckDrivenPropertyChecks with NoShrink {
+
+  "IntegrationObserver" - {
+    "invariant: awaitNext == buffer.isEmpty" - {
+      "awaitNext is false if the buffer isn't empty" - {
+        "onNext" in {
+          val t = mkDefault
+          t.onNext(0)
+          t.awaitNext.get() shouldBe false
+        }
+
+        "onNext, paired" in forAll(pairedGen) { calls =>
+          val t = mkDefault
+          t.onNext(0)
+          calls.foreach { callRequestNext =>
+            if (callRequestNext) t.requestNext()
+            else t.onNext(0)
+          }
+          t.awaitNext.get() shouldBe false
+        }
+      }
+
+      "awaitNext is true if the buffer is empty" - {
+        "requestNext" in {
+          val t = mkDefault
+          t.requestNext()
+          t.awaitNext.get() shouldBe true
+        }
+
+        "paired" in forAll(pairedGen) { calls =>
+          val t = mkDefault
+          calls.foreach { callRequestNext =>
+            if (callRequestNext) t.requestNext()
+            else t.onNext(0)
+          }
+          t.awaitNext.get() shouldBe true
+        }
+      }
+    }
+  }
+
+  private def pairedGen: Gen[Vector[Boolean]] =
+    Gen.containerOf[Vector, Int](Gen.choose(1, 3)).flatMap { pairsSeq =>
+      pairsSeq
+        .foldLeft(Vector.empty[Boolean]) { case (r, pairs) =>
+          r ++ List.fill(pairs)(false) ++ List.fill(pairs)(true)
+        }
+    }
+
+  private def mkDefault = new TestIntegrationObserver(Observer.empty(UncaughtExceptionReporter.default))
+
+  private class TestIntegrationObserver(dest: Observer[Int]) extends IntegrationObserver[Boolean, Int](dest) {
+    override def onError(t: Throwable): Unit = throw t
+    override def onCompleted(): Unit = {}
+  }
+
+}


### PR DESCRIPTION
Configuration: tuned keep-alive-time and idle-timeout of gRPC settings. See application.conf for more information;

Dependencies: updated grpc-netty dependency.

gRPC: temporarily disabled metrics and tracing.

Unit tests: IntegrationObserverSpec: added invariant tests.

Integration tests: BlockchainUpdatesClientTestSuite and CombinedWavesBlockchainClientTestSuite contains tests with simulation of network issues.