### PR TITLE
DEX-1087 WavesChain failed invariant

### DIFF
--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/api/ws/WsAddressStreamTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/api/ws/WsAddressStreamTestSuite.scala
@@ -626,9 +626,11 @@ class WsAddressStreamTestSuite extends WsSuiteBase with TableDrivenPropertyCheck
       eventually(wsc.balanceChanges should have size 1)
 
       broadcastAndAwait(mkTransfer(alice, acc.toAddress, 2.usd, usd, feeAmount = 1.waves))
-      wsc.balanceChanges.last should matchTo(Map[Asset, WsBalances](
-        usd -> WsBalances(2.0, 0.0)
-      ))
+      eventually {
+        wsc.balanceChanges.last should matchTo(Map[Asset, WsBalances](
+          usd -> WsBalances(2.0, 0.0)
+        ))
+      }
       wsc.close()
       Thread.sleep(1000)
 

--- a/dex/src/main/resources/application.conf
+++ b/dex/src/main/resources/application.conf
@@ -150,8 +150,9 @@ waves.dex {
       # HACK for Node behavior.
       # We need to store last updates and consider them as fresh, because we can face an issue during balances retrieving,
       #  when balance changes were deleted from LiquidBlock's diff, but haven't yet saved to DB.
-      # 2 could be enough (last + previous), but we add some ratio.
-      max-cached-latest-block-updates = 5
+      # Block updates are collected during blocks and micro blocks application.
+      # 12 micro blocks is an average number for each blocks, thus we preserve the data during the minute.
+      max-cached-latest-block-updates = 12
 
       # A delay before streams start during recovery or a manual restart due to unexpected events (should not happen).
       combined-stream.restart-delay = 1s

--- a/dex/src/main/resources/application.conf
+++ b/dex/src/main/resources/application.conf
@@ -81,9 +81,8 @@ waves.dex {
       keep-alive-without-calls = true
 
       # Sets the time without read activity before sending a keepalive ping.
-      # 5s is an average time between micro blocks
-      # In a normal state we don't need this, because transactions come often.
-      keep-alive-time = 5s
+      # Can't be less than 10s, see io.grpc.internal.KeepAliveManager
+      keep-alive-time = 10s
 
       # Sets the time waiting for read activity after sending a keepalive ping.
       keep-alive-timeout = 5s
@@ -120,8 +119,8 @@ waves.dex {
       keep-alive-without-calls = true
 
       # Sets the time without read activity before sending a keepalive ping.
-      # 5s is an average time between blocks, we add 1s to receive a micro block
-      keep-alive-time = 6s
+      # Can't be less than 10s, see io.grpc.internal.KeepAliveManager
+      keep-alive-time = 10s
 
       # Sets the time waiting for read activity after sending a keepalive ping.
       keep-alive-timeout = 5s

--- a/waves-integration-it/src/test/scala/com/wavesplatform/dex/grpc/integration/clients/CombinedWavesBlockchainClientTestSuite.scala
+++ b/waves-integration-it/src/test/scala/com/wavesplatform/dex/grpc/integration/clients/CombinedWavesBlockchainClientTestSuite.scala
@@ -50,6 +50,7 @@ class CombinedWavesBlockchainClientTestSuite extends IntegrationSuiteBase with H
 
   private lazy val matcherExtProxy = toxiContainer.getProxy(wavesNode1.underlying.container, WavesNodeContainer.matcherGrpcExtensionPort)
 
+  private val keepAliveTime = 2.seconds
   private val keepAliveTimeout = 5.seconds
 
   private lazy val client =
@@ -60,7 +61,7 @@ class CombinedWavesBlockchainClientTestSuite extends IntegrationSuiteBase with H
           maxHedgedAttempts = 5,
           maxRetryAttempts = 5,
           keepAliveWithoutCalls = true,
-          keepAliveTime = 2.seconds,
+          keepAliveTime = keepAliveTime,
           keepAliveTimeout = keepAliveTimeout,
           idleTimeout = 1.minute,
           channelOptions = GrpcClientSettings.ChannelOptionsSettings(connectTimeout = 5.seconds)
@@ -70,7 +71,7 @@ class CombinedWavesBlockchainClientTestSuite extends IntegrationSuiteBase with H
           maxHedgedAttempts = 5,
           maxRetryAttempts = 5,
           keepAliveWithoutCalls = true,
-          keepAliveTime = 2.seconds,
+          keepAliveTime = keepAliveTime,
           keepAliveTimeout = keepAliveTimeout,
           idleTimeout = 1.day,
           channelOptions = GrpcClientSettings.ChannelOptionsSettings(connectTimeout = 5.seconds)
@@ -424,7 +425,7 @@ class CombinedWavesBlockchainClientTestSuite extends IntegrationSuiteBase with H
       val transfer2 = mkTransfer(bob, matcher, 2.waves, Asset.Waves)
       broadcastAndAwait(transfer2)
 
-      Thread.sleep((keepAliveTimeout + 1.second).toMillis) // Connection should be closed
+      Thread.sleep((keepAliveTime + keepAliveTimeout + 2.seconds).toMillis) // Connection should be closed
 
       step("Enable connection to gRPC extension")
       blockchainUpdatesProxy.setConnectionCut(false)

--- a/waves-integration-it/src/test/scala/com/wavesplatform/dex/grpc/integration/clients/CombinedWavesBlockchainClientTestSuite.scala
+++ b/waves-integration-it/src/test/scala/com/wavesplatform/dex/grpc/integration/clients/CombinedWavesBlockchainClientTestSuite.scala
@@ -50,8 +50,8 @@ class CombinedWavesBlockchainClientTestSuite extends IntegrationSuiteBase with H
 
   private lazy val matcherExtProxy = toxiContainer.getProxy(wavesNode1.underlying.container, WavesNodeContainer.matcherGrpcExtensionPort)
 
-  private val keepAliveTime = 2.seconds
-  private val keepAliveTimeout = 5.seconds
+  private val keepAliveTime = 10.seconds
+  private val keepAliveTimeout = 1.seconds
 
   private lazy val client =
     CombinedWavesBlockchainClient(
@@ -63,18 +63,18 @@ class CombinedWavesBlockchainClientTestSuite extends IntegrationSuiteBase with H
           keepAliveWithoutCalls = true,
           keepAliveTime = keepAliveTime,
           keepAliveTimeout = keepAliveTimeout,
-          idleTimeout = 1.minute,
-          channelOptions = GrpcClientSettings.ChannelOptionsSettings(connectTimeout = 5.seconds)
+          idleTimeout = 1.day,
+          channelOptions = GrpcClientSettings.ChannelOptionsSettings(connectTimeout = 1.seconds)
         ),
         blockchainUpdatesGrpc = GrpcClientSettings(
           target = s"127.0.0.1:${blockchainUpdatesProxy.getProxyPort}",
-          maxHedgedAttempts = 5,
-          maxRetryAttempts = 5,
-          keepAliveWithoutCalls = true,
-          keepAliveTime = keepAliveTime,
-          keepAliveTimeout = keepAliveTimeout,
+          maxHedgedAttempts = 2,
+          maxRetryAttempts = 2,
+          keepAliveWithoutCalls = false,
+          keepAliveTime = 500.millis,
+          keepAliveTimeout = 1.second,
           idleTimeout = 1.day,
-          channelOptions = GrpcClientSettings.ChannelOptionsSettings(connectTimeout = 5.seconds)
+          channelOptions = GrpcClientSettings.ChannelOptionsSettings(connectTimeout = 1.seconds)
         ),
         defaultCachesExpiration = 100.milliseconds,
         balanceStreamBufferSize = 100,
@@ -421,6 +421,7 @@ class CombinedWavesBlockchainClientTestSuite extends IntegrationSuiteBase with H
 
       step("Cut connection to gRPC extension")
       blockchainUpdatesProxy.setConnectionCut(true)
+      matcherExtProxy.setConnectionCut(true)
 
       val transfer2 = mkTransfer(bob, matcher, 2.waves, Asset.Waves)
       broadcastAndAwait(transfer2)
@@ -429,6 +430,7 @@ class CombinedWavesBlockchainClientTestSuite extends IntegrationSuiteBase with H
 
       step("Enable connection to gRPC extension")
       blockchainUpdatesProxy.setConnectionCut(false)
+      matcherExtProxy.setConnectionCut(false)
 
       // Connection should be restored without our intervention
       Thread.sleep(5.seconds.toMillis)

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/blockchainupdates/GrpcBlockchainUpdatesControlledStream.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/blockchainupdates/GrpcBlockchainUpdatesControlledStream.scala
@@ -36,7 +36,7 @@ class GrpcBlockchainUpdatesControlledStream(channel: ManagedChannel)(implicit sc
 
   override def startFrom(height: Int): Unit = {
     require(height >= 1, "We can not get blocks on height <= 0")
-    log.info(s"$logPrefix Connecting to Blockchain events stream")
+    log.info(s"$logPrefix Connecting to Blockchain events stream, getting blocks from $height")
 
     val call = channel.newCall(BlockchainUpdatesApiGrpc.METHOD_SUBSCRIBE, CallOptions.DEFAULT.withWaitForReady()) // TODO DEX-1001
     val observer = new BlockchainUpdatesObserver(call, height)

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/combined/CombinedStream.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/combined/CombinedStream.scala
@@ -109,11 +109,10 @@ class CombinedStream(
 
   def currentHeightHint: Int = heightHint
 
-  def restartFrom(height: Int): Unit = {
-    updateHeightHint(height)
-
+  def restart(): Unit = {
+    log.info("Restarting")
     // Self-healed above
-    runWithDelay(() => blockchainUpdates.stop())
+    blockchainUpdates.stop()
   }
 
   private def utxEventsTransitions(origStatus: Status, event: SystemEvent): Status = {

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/combined/CombinedWavesBlockchainClient.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/combined/CombinedWavesBlockchainClient.scala
@@ -74,7 +74,7 @@ class CombinedWavesBlockchainClient(
         .mapAccumulate(init) { case (origStatus, event) =>
           val x = StatusTransitions(origStatus, event)
           x.updatedLastBlockHeight match {
-            case LastBlockHeight.Updated(to) => combinedStream.updateHeightHint(to)
+            case LastBlockHeight.Updated(to) => combinedStream.updateProcessedHeight(to)
             case LastBlockHeight.RestartRequired => combinedStream.restart()
             case _ =>
           }

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/combined/CombinedWavesBlockchainClient.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/combined/CombinedWavesBlockchainClient.scala
@@ -60,7 +60,7 @@ class CombinedWavesBlockchainClient(
   // HACK: NODE: We need to store last updates and consider them as fresh, because we can face an issue during fullBalancesSnapshot
   //   when balance changes were deleted from LiquidBlock's diff, but haven't yet saved to DB
   @volatile private var lastUpdates = List.empty[BlockchainBalance]
-  private val maxPreviousBlockUpdates = settings.maxCachedLatestBlockUpdates - 1 // TODO??? microblocks!!!!
+  private val maxPreviousBlockUpdates = settings.maxCachedLatestBlockUpdates - 1
 
   override lazy val updates: Observable[WavesNodeUpdates] = Observable.fromFuture(meClient.currentBlockInfo)
     .flatMap { startBlockInfo =>
@@ -94,6 +94,7 @@ class CombinedWavesBlockchainClient(
             }
             .toMap
 
+          // It is safe even we are during a rollback, because StatusTransitions doesn't propagate data until fork is resolved
           if (!x.updatedBalances.isEmpty) lastUpdates = x.updatedBalances :: lastUpdates.take(maxPreviousBlockUpdates)
 
           // // Not useful for UTX, because it doesn't consider the current state of orders

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/combined/CombinedWavesBlockchainClient.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/combined/CombinedWavesBlockchainClient.scala
@@ -75,7 +75,7 @@ class CombinedWavesBlockchainClient(
           val x = StatusTransitions(origStatus, event)
           x.updatedLastBlockHeight match {
             case LastBlockHeight.Updated(to) => combinedStream.updateHeightHint(to)
-            case LastBlockHeight.RestartRequired(from) => combinedStream.restartFrom(from)
+            case LastBlockHeight.RestartRequired => combinedStream.restart()
             case _ =>
           }
           if (x.requestNextBlockchainEvent) bClient.blockchainEvents.requestNext()

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/combined/CombinedWavesBlockchainClient.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/combined/CombinedWavesBlockchainClient.scala
@@ -60,13 +60,13 @@ class CombinedWavesBlockchainClient(
   // HACK: NODE: We need to store last updates and consider them as fresh, because we can face an issue during fullBalancesSnapshot
   //   when balance changes were deleted from LiquidBlock's diff, but haven't yet saved to DB
   @volatile private var lastUpdates = List.empty[BlockchainBalance]
-  private val maxPreviousBlockUpdates = settings.maxCachedLatestBlockUpdates - 1 // TODO microblocks!!!!
+  private val maxPreviousBlockUpdates = settings.maxCachedLatestBlockUpdates - 1 // TODO??? microblocks!!!!
 
   override lazy val updates: Observable[WavesNodeUpdates] = Observable.fromFuture(meClient.currentBlockInfo)
     .flatMap { startBlockInfo =>
       log.info(s"Current block: $startBlockInfo")
       val startHeight = math.max(startBlockInfo.height - settings.maxRollbackHeight - 1, 1)
-      val init: BlockchainStatus = BlockchainStatus.Normal(WavesChain(Vector.empty, startHeight, settings.maxRollbackHeight + 1))
+      val init: BlockchainStatus = BlockchainStatus.Normal(WavesChain(Vector.empty, startHeight - 1, settings.maxRollbackHeight + 1))
 
       val combinedStream = new CombinedStream(settings.combinedStream, bClient.blockchainEvents, meClient.utxEvents)
       Observable(dataUpdates, combinedStream.stream)

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/StatusTransitions.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/StatusTransitions.scala
@@ -30,13 +30,25 @@ object StatusTransitions extends ScorexLogging {
                 StatusUpdate(
                   newStatus = Normal(updatedFork),
                   updatedBalances = block.changes,
-                  updatedLastBlockHeight =
-                    if (block.tpe == WavesBlock.Type.FullBlock) LastBlockHeight.Updated(updatedFork.height)
-                    else LastBlockHeight.NotChanged,
+                  updatedLastBlockHeight = LastBlockHeight.Updated(block.ref.height),
                   utxUpdate = UtxUpdate(confirmedTxs = block.confirmedTxs),
                   requestNextBlockchainEvent = true
                 )
             }
+
+          case RolledBack(to) => // This could happen during an appending of a new key block too
+            val initFork = WavesFork(origStatus.main, origStatus.main)
+            val updatedFork = to match {
+              case To.CommonBlockRef(ref) => initFork.rollbackTo(ref)
+              case To.Height(h) => initFork.rollbackTo(h)
+            }
+            StatusUpdate(
+              newStatus = TransientRollback(
+                fork = updatedFork,
+                utxUpdate = Monoid.empty[UtxUpdate]
+              ),
+              requestNextBlockchainEvent = true
+            )
 
           case UtxUpdated(newTxs, failedTxs) =>
             StatusUpdate(
@@ -49,19 +61,6 @@ object StatusTransitions extends ScorexLogging {
             StatusUpdate(
               newStatus = origStatus,
               utxUpdate = UtxUpdate(unconfirmedTxs = newTxs, resetCaches = true)
-            )
-
-          case RolledBack(to) => // This could happen during an appending of a new key block too
-            val initFork = WavesFork(origStatus.main, origStatus.main)
-            StatusUpdate(
-              newStatus = TransientRollback(
-                fork = to match {
-                  case To.CommonBlockRef(ref) => initFork.rollbackTo(ref)
-                  case To.Height(h) => initFork.rollbackTo(h)
-                },
-                utxUpdate = Monoid.empty[UtxUpdate]
-              ),
-              requestNextBlockchainEvent = true
             )
 
           case _ =>
@@ -84,7 +83,7 @@ object StatusTransitions extends ScorexLogging {
                   StatusUpdate(
                     newStatus = Normal(resolved.activeChain),
                     updatedBalances = resolved.newChanges,
-                    updatedLastBlockHeight = LastBlockHeight.Updated(resolved.activeChain.height),
+                    updatedLastBlockHeight = LastBlockHeight.Updated(block.ref.height),
                     utxUpdate = finalUtxUpdate,
                     requestNextBlockchainEvent = true
                   )
@@ -95,8 +94,8 @@ object StatusTransitions extends ScorexLogging {
                       stashChanges = resolved.newChanges,
                       utxUpdate = finalUtxUpdate
                     ),
-                    requestBalances = resolved.lostDiffIndex,
-                    updatedLastBlockHeight = LastBlockHeight.NotChanged
+                    updatedLastBlockHeight = LastBlockHeight.Updated(block.ref.height),
+                    requestBalances = resolved.lostDiffIndex
                     // requestNextBlockchainEvent = true // Because we are waiting for DataReceived
                   )
 
@@ -114,6 +113,16 @@ object StatusTransitions extends ScorexLogging {
                 )
             }
 
+          case RolledBack(to) => // TODO test with higher height
+            val updatedFork = to match {
+              case To.CommonBlockRef(ref) => origStatus.fork.rollbackTo(ref)
+              case To.Height(h) => origStatus.fork.rollbackTo(h)
+            }
+            StatusUpdate(
+              newStatus = origStatus.copy(fork = updatedFork),
+              requestNextBlockchainEvent = true
+            )
+
           case UtxUpdated(newTxs, failedTxs) =>
             StatusUpdate(
               newStatus = origStatus.copy(
@@ -129,16 +138,6 @@ object StatusTransitions extends ScorexLogging {
               newStatus = origStatus.copy(
                 utxUpdate = UtxUpdate(unconfirmedTxs = newTxs, resetCaches = true) // Forget the previous
               )
-            )
-
-          case RolledBack(to) => // TODO test with higher height
-            val fork = to match {
-              case To.CommonBlockRef(ref) => origStatus.fork.rollbackTo(ref)
-              case To.Height(h) => origStatus.fork.rollbackTo(h)
-            }
-            StatusUpdate(
-              newStatus = origStatus.copy(fork = fork),
-              requestNextBlockchainEvent = true
             )
 
           case _ =>

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/StatusTransitions.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/StatusTransitions.scala
@@ -13,7 +13,7 @@ import com.wavesplatform.dex.meta.getSimpleName
 object StatusTransitions extends ScorexLogging {
 
   def apply(origStatus: BlockchainStatus, event: WavesNodeEvent): StatusUpdate = {
-    log.info(s"${origStatus.name} + $event") // TODO why don't we have this in logs?
+    log.info(s"${origStatus.name} + $event")
     val r = origStatus match {
       case origStatus: Normal =>
         event match {
@@ -113,7 +113,7 @@ object StatusTransitions extends ScorexLogging {
                 )
             }
 
-          case RolledBack(to) => // TODO test with higher height
+          case RolledBack(to) =>
             val updatedFork = to match {
               case To.CommonBlockRef(ref) => origStatus.fork.rollbackTo(ref)
               case To.Height(h) => origStatus.fork.rollbackTo(h)

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/StatusUpdate.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/StatusUpdate.scala
@@ -24,7 +24,7 @@ object StatusUpdate {
   object LastBlockHeight {
     case object NotChanged extends LastBlockHeight
     case class Updated(to: Int) extends LastBlockHeight
-    case class RestartRequired(from: Int) extends LastBlockHeight
+    case object RestartRequired extends LastBlockHeight
   }
 
 }

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/WavesChain.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/WavesChain.scala
@@ -51,9 +51,9 @@ case class WavesChain(history: Vector[WavesBlock], height: Int, blocksCapacity: 
             }
             if (blocksCapacity == 0) WavesChain(newHistory.dropRight(1), block.ref.height, blocksCapacity = 0).asRight
             else WavesChain(newHistory, block.ref.height, blocksCapacity = blocksCapacity - 1).asRight
-          } else s"The new block ${block.ref} (reference=${block.reference}) must be after ${prev.ref}".asLeft
+          } else s"The new block ${block.ref} (reference=${block.reference.take(5)}) must be after ${prev.ref}".asLeft
       }
-    else s"The new block ${block.ref} (reference=${block.reference}) must be on height ${height + 1}".asLeft
+    else s"The new block ${block.ref} (reference=${block.reference.take(5)}) must be on height ${height + 1}".asLeft
 
   private def withMicroBlock(microBlock: WavesBlock): Either[String, WavesChain] = history.headOption match {
     case None => s"Can't attach a micro block $microBlock to empty chain".asLeft
@@ -61,7 +61,7 @@ case class WavesChain(history: Vector[WavesBlock], height: Int, blocksCapacity: 
       if (microBlock.ref.height == prev.ref.height && microBlock.reference == prev.ref.id)
         WavesChain(history.prepended(microBlock), microBlock.ref.height, blocksCapacity = blocksCapacity).asRight
       else
-        s"The new micro block ${microBlock.ref} (reference=${microBlock.reference}) must reference the last block ${prev.ref}".asLeft
+        s"The new micro block ${microBlock.ref} (reference=${microBlock.reference.take(5)}) must reference the last block ${prev.ref}".asLeft
   }
 
   def diffIndex: DiffIndex = history.foldMap(_.diffIndex)

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/WavesFork.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/domain/WavesFork.scala
@@ -17,7 +17,7 @@ case class WavesFork private[domain] (origChain: WavesChain, forkChain: WavesCha
   def height: Int = forkChain.height
 
   def withBlock(block: WavesBlock): Status = forkChain.withBlock(block) match {
-    case Left(e) => Status.Failed(withoutLast, e)
+    case Left(e) => Status.Failed(e)
     case Right(updatedForkChain) =>
       if (
         // +1 because we expect a micro block on origChain.height.
@@ -49,24 +49,10 @@ case class WavesFork private[domain] (origChain: WavesChain, forkChain: WavesCha
   def rollbackTo(height: Int): WavesFork = copy(forkChain = forkChain.dropAfter(height)._1)
   def rollbackTo(ref: BlockRef): WavesFork = copy(forkChain = forkChain.dropAfter(ref)._1)
 
-  protected[WavesFork] def withoutLast: WavesFork = copy(forkChain = forkChain.withoutLastLiquidOrFull)
-
   override def toString: String = s"WavesFork(o=$origChain, f=$forkChain)"
 }
 
 object WavesFork {
-
-  def mk(origChain: WavesChain, commonBlockRef: BlockRef): WavesFork = WavesFork(origChain, origChain.dropAfter(commonBlockRef)._1)
-  def mk(origChain: WavesChain, commonHeight: Int): WavesFork = WavesFork(origChain, origChain.dropAfter(commonHeight)._1)
-
-  /**
-   * Create a fork (origChain, origChain - 1 full|liquid block)
-   * Called only if we can't apply a block in a normal state, thus, origChain can't be empty
-   */
-  def mkRolledBackByOne(origChain: WavesChain): WavesFork = {
-    require(!origChain.isEmpty, s"$origChain is empty")
-    WavesFork(origChain, origChain).withoutLast
-  }
 
   sealed trait Status extends Product with Serializable
 
@@ -81,7 +67,7 @@ object WavesFork {
     ) extends Status
 
     case class NotResolved(updatedFork: WavesFork) extends Status
-    case class Failed(updatedFork: WavesFork, reason: String) extends Status
+    case class Failed(reason: String) extends Status
   }
 
 }

--- a/waves-integration/src/test/scala/com/wavesplatform/dex/WavesIntegrationSuiteBase.scala
+++ b/waves-integration/src/test/scala/com/wavesplatform/dex/WavesIntegrationSuiteBase.scala
@@ -6,7 +6,7 @@ import com.wavesplatform.dex.domain.account.Address
 import com.wavesplatform.dex.domain.asset.Asset
 import com.wavesplatform.dex.domain.asset.Asset.IssuedAsset
 import com.wavesplatform.dex.domain.bytes.codec.Base58
-import com.wavesplatform.dex.grpc.integration.clients.domain.TransactionWithChanges
+import com.wavesplatform.dex.grpc.integration.clients.domain.{TransactionWithChanges, WavesBlock, WavesChain}
 import com.wavesplatform.dex.grpc.integration.services.UtxTransaction
 import com.wavesplatform.events.protobuf.StateUpdate
 import com.wavesplatform.protobuf.transaction.SignedTransaction
@@ -16,6 +16,7 @@ import org.scalatest.freespec.AnyFreeSpecLike
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.matchers.{MatchResult, Matcher}
 
+import scala.collection.immutable.Vector
 
 // TODO DEX-994
 trait WavesIntegrationSuiteBase extends AnyFreeSpecLike with Matchers with AllureScalatestContext {
@@ -47,7 +48,6 @@ trait WavesIntegrationSuiteBase extends AnyFreeSpecLike with Matchers with Allur
 
   // TODO Duplicate
   implicit val assetDerivedDiff: Derived[Diff[Asset]] = Derived(assetDiff)
-
 
   // Fixes "Class too large" compiler issue
   implicit val derivedSignedTransactionDiff: Derived[Diff[TransactionWithChanges]] =
@@ -86,5 +86,11 @@ trait WavesIntegrationSuiteBase extends AnyFreeSpecLike with Matchers with Allur
     require(n <= 127) // or we need complex implementation
     UnsafeByteOperations.unsafeWrap(new Array[Byte](n))
   }
+
+  /**
+   * If history is empty, the height is supposed to be 0
+   */
+  protected def mkChain(history: Vector[WavesBlock], blocksCapacity: Int): WavesChain =
+    WavesChain(history, history.headOption.getOrElse(throw new IllegalArgumentException("history is empty")).ref.height, blocksCapacity)
 
 }

--- a/waves-integration/src/test/scala/com/wavesplatform/dex/grpc/integration/clients/combined/CombinedStreamTestSuite.scala
+++ b/waves-integration/src/test/scala/com/wavesplatform/dex/grpc/integration/clients/combined/CombinedStreamTestSuite.scala
@@ -36,7 +36,7 @@ class CombinedStreamTestSuite extends WavesIntegrationSuiteBase with Eventually 
 
       "the height hint is default" in {
         val t = mk()
-        t.cs.currentHeightHint shouldBe 1
+        t.cs.currentProcessedHeight shouldBe 1
       }
     }
 
@@ -51,15 +51,15 @@ class CombinedStreamTestSuite extends WavesIntegrationSuiteBase with Eventually 
       "affects the recovery height hint" in {
         val t = mk()
         t.cs.startFrom(10)
-        t.cs.currentHeightHint shouldBe 10
+        t.cs.currentProcessedHeight shouldBe 10
       }
     }
 
     "updateHeightHint" - {
       "affects the recovery height" in {
         val t = mk()
-        t.cs.updateHeightHint(10)
-        t.cs.currentHeightHint shouldBe 10
+        t.cs.updateProcessedHeight(10)
+        t.cs.currentProcessedHeight shouldBe 10
       }
     }
 
@@ -82,7 +82,7 @@ class CombinedStreamTestSuite extends WavesIntegrationSuiteBase with Eventually 
         val t = mk()
         t.cs.startFrom(10)
         t.cs.restart()
-        t.cs.currentHeightHint shouldBe 10
+        t.cs.currentProcessedHeight shouldBe 10
       }
     }
 

--- a/waves-integration/src/test/scala/com/wavesplatform/dex/grpc/integration/clients/combined/CombinedStreamTestSuite.scala
+++ b/waves-integration/src/test/scala/com/wavesplatform/dex/grpc/integration/clients/combined/CombinedStreamTestSuite.scala
@@ -67,22 +67,22 @@ class CombinedStreamTestSuite extends WavesIntegrationSuiteBase with Eventually 
       "stop blockchainUpdates" in {
         val t = mk()
         t.cs.startFrom(10)
-        t.cs.restartFrom(5)
+        t.cs.restart()
         logged(t.blockchainUpdates.systemStream)(_.tail.head shouldBe SystemEvent.Stopped)
       }
 
       "stops utxEvents" in {
         val t = mk()
         t.cs.startFrom(10)
-        t.cs.restartFrom(5)
+        t.cs.restart()
         logged(t.utxEvents.systemStream)(_.tail.head shouldBe SystemEvent.Stopped)
       }
 
-      "affects the recovery height" in {
+      "doesn't affect the recovery height" in {
         val t = mk()
         t.cs.startFrom(10)
-        t.cs.restartFrom(5)
-        t.cs.currentHeightHint shouldBe 5
+        t.cs.restart()
+        t.cs.currentHeightHint shouldBe 10
       }
     }
 

--- a/waves-integration/src/test/scala/com/wavesplatform/dex/grpc/integration/clients/domain/StatusTransitionsTestSuite.scala
+++ b/waves-integration/src/test/scala/com/wavesplatform/dex/grpc/integration/clients/domain/StatusTransitionsTestSuite.scala
@@ -153,7 +153,6 @@ class StatusTransitionsTestSuite extends WavesIntegrationSuiteBase {
             fork = WavesFork(init.main, mkChain(Vector(block1), 99)),
             utxUpdate = Monoid.empty[UtxUpdate]
           ),
-          updatedLastBlockHeight = StatusUpdate.LastBlockHeight.NotChanged,
           requestNextBlockchainEvent = true
         ))
 
@@ -322,7 +321,7 @@ class StatusTransitionsTestSuite extends WavesIntegrationSuiteBase {
               )
             ),
             requestBalances = DiffIndex(regular = Map(carol -> Set(Waves: Asset)), outgoingLeasing = Set.empty),
-            updatedLastBlockHeight = LastBlockHeight.NotChanged
+            updatedLastBlockHeight = LastBlockHeight.Updated(microBlock.ref.height)
           ))
         }
       }

--- a/waves-integration/src/test/scala/com/wavesplatform/dex/grpc/integration/clients/domain/WavesChainTestSuite.scala
+++ b/waves-integration/src/test/scala/com/wavesplatform/dex/grpc/integration/clients/domain/WavesChainTestSuite.scala
@@ -284,7 +284,14 @@ class WavesChainTestSuite extends WavesIntegrationSuiteBase with ScalaCheckDrive
       "empty +" - {
         val init = WavesChain(emptyChain, 100)
 
-        "block" in { init.withBlock(block1) should matchTo(WavesChain(Vector(block1), 99).asRight[String]) }
+        "block" - {
+          "valid" in { init.withBlock(block1) should matchTo(WavesChain(Vector(block1), 99).asRight[String]) }
+
+          "invalid" in {
+            val block1A = block1.copy(ref = block1.ref.copy(height = block1.ref.height + 2))
+            init.withBlock(block1A) should matchTo("The new block Ref(h=3, 8TZ) (reference=) must be on height 1".asLeft[WavesChain])
+          }
+        }
 
         "micro block" in {
           val microBlock = block1.copy(tpe = WavesBlock.Type.MicroBlock)

--- a/waves-integration/src/test/scala/com/wavesplatform/dex/grpc/integration/clients/domain/WavesForkTestSuite.scala
+++ b/waves-integration/src/test/scala/com/wavesplatform/dex/grpc/integration/clients/domain/WavesForkTestSuite.scala
@@ -70,15 +70,9 @@ class WavesForkTestSuite extends WavesIntegrationSuiteBase with ScalaCheckDriven
           confirmedTxs = mkTransactionWithChangesMap(10)
         )
 
-        val expectedUpdatedFork = WavesFork(
-          mkChain(Vector(block2, block1), 98),
-          WavesChain(Vector.empty, block1.ref.height - 1, 99)
+        fork.withBlock(invalidBlock) should matchTo[Status](
+          Status.Failed("The new block Ref(h=2, ZvGf) (reference=3j) must be after Ref(h=1, 8TZ)")
         )
-
-        fork.withBlock(invalidBlock) should matchTo(Status.Failed(
-          updatedFork = expectedUpdatedFork,
-          reason = "The new block Ref(h=2, ZvGf) (reference=3j) must be after Ref(h=1, 8TZ)"
-        ): Status)
       }
 
       "NotResolved - the height is still less or equal to the previous chain" - {
@@ -93,7 +87,7 @@ class WavesForkTestSuite extends WavesIntegrationSuiteBase with ScalaCheckDriven
             mkChain(Vector(block2, block1), 98)
           )
 
-          fork.withBlock(block2) should matchTo(Status.NotResolved(expectedUpdatedFork): Status)
+          fork.withBlock(block2) should matchTo[Status](Status.NotResolved(expectedUpdatedFork))
         }
 
         "a micro block with a lesser key block height than in the original chain" in {
@@ -118,7 +112,7 @@ class WavesForkTestSuite extends WavesIntegrationSuiteBase with ScalaCheckDriven
             mkChain(Vector(microBlock, block2, block1), 98)
           )
 
-          fork.withBlock(microBlock) should matchTo(Status.NotResolved(expectedUpdatedFork): Status)
+          fork.withBlock(microBlock) should matchTo[Status](Status.NotResolved(expectedUpdatedFork))
         }
 
         "an existed micro block on the same chain" in {
@@ -143,7 +137,7 @@ class WavesForkTestSuite extends WavesIntegrationSuiteBase with ScalaCheckDriven
             mkChain(Vector(microBlock1, block1), 99)
           )
 
-          fork.withBlock(microBlock1) should matchTo(Status.NotResolved(expectedUpdatedFork): Status)
+          fork.withBlock(microBlock1) should matchTo[Status](Status.NotResolved(expectedUpdatedFork))
         }
       }
 
@@ -165,7 +159,7 @@ class WavesForkTestSuite extends WavesIntegrationSuiteBase with ScalaCheckDriven
             mkChain(Vector(block3, block2, block1), 97)
           )
 
-          fork.withBlock(block4) should matchTo(Status.Resolved(
+          fork.withBlock(block4) should matchTo[Status](Status.Resolved(
             activeChain = mkChain(Vector(block4, block3, block2, block1), 96),
             newChanges = BlockchainBalance(
               regular = Map(alice -> Map(usd -> 30L, Waves -> 10)),
@@ -174,7 +168,7 @@ class WavesForkTestSuite extends WavesIntegrationSuiteBase with ScalaCheckDriven
             lostDiffIndex = Monoid.empty[DiffIndex],
             lostTxIds = Map.empty,
             confirmedTxs = block3.confirmedTxs ++ block4.confirmedTxs
-          ): Status)
+          ))
         }
 
         "on a micro block" - {
@@ -195,7 +189,7 @@ class WavesForkTestSuite extends WavesIntegrationSuiteBase with ScalaCheckDriven
               confirmedTxs = mkTransactionWithChangesMap(10)
             )
 
-            fork.withBlock(microBlock) should matchTo(Status.Resolved(
+            fork.withBlock(microBlock) should matchTo[Status](Status.Resolved(
               activeChain = mkChain(Vector(microBlock, block2, block1), 98),
               newChanges = BlockchainBalance(
                 regular = Map(bob -> Map(usd -> 31)),
@@ -204,7 +198,7 @@ class WavesForkTestSuite extends WavesIntegrationSuiteBase with ScalaCheckDriven
               lostDiffIndex = Monoid.empty[DiffIndex],
               lostTxIds = Map.empty,
               confirmedTxs = microBlock.confirmedTxs
-            ): Status)
+            ))
           }
 
           "after the micro block with the same height (same blocks and micro blocks)" in {
@@ -235,13 +229,13 @@ class WavesForkTestSuite extends WavesIntegrationSuiteBase with ScalaCheckDriven
               mkChain(Vector(microBlock1, block1), 99)
             )
 
-            fork.withBlock(microBlock2) should matchTo(Status.Resolved(
+            fork.withBlock(microBlock2) should matchTo[Status](Status.Resolved(
               activeChain = mkChain(Vector(microBlock2, microBlock1, block1), 99),
               newChanges = microBlock2.changes,
               lostDiffIndex = Monoid.empty[DiffIndex],
               lostTxIds = Map.empty,
               confirmedTxs = microBlock2.confirmedTxs
-            ): Status)
+            ))
           }
         }
       }


### PR DESCRIPTION
Solution for an excess blocks removing during stream issues.

Configuration: 
* Updated keep-alive-time documentation and the default value;
* max-cached-latest-block-updates includes micro blocks.

Code:
* WavesChain:
  * checks the height even if there is no history;
  * withoutLastLiquidOrFull is removed, because is not used anymore;
  * dropAfter now ignores a situation when the height is higher than of chain. Added tests for it; 
* CombinedStream contains a better recovery logic, see comments;
* StatusTransitions:
  * requires a restart when we failed to apply a new block to the empty chain
  * updates height always when apply a block or a micro block.

Tests: 
* Added new tests;
* Stabilized WsAddressStreamTestSuite, fixed the connection cut logic.

Other: improved logs.