### PR TITLE
DEX-1146 OrderDynamicFeeTestSuite failed

### DIFF
--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/dex/DexApiSyntax.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/dex/DexApiSyntax.scala
@@ -47,8 +47,11 @@ object DexApiSyntax {
     def waitForTransactionsByOrder(id: Order.Id)(pred: List[ExchangeTransaction] => Boolean): F[List[ExchangeTransaction]] =
       R.repeatUntil(self.getTransactionsByOrder(id), RepeatRequestOptions.default)(pred)
 
-    def waitForCurrentOffset(pred: Long => Boolean): F[HttpOffset] =
+    def waitForCurrentOffset(pred: HttpOffset => Boolean): F[HttpOffset] =
       R.repeatUntil(self.getCurrentOffset, RepeatRequestOptions(1.second, 120))(pred)
+
+    def waitForOldestSnapshotOffset(pred: HttpOffset => Boolean): F[HttpOffset] =
+      R.repeatUntil(self.getOldestSnapshotOffset)(pred)
 
     def waitForWsConnections(pred: HttpWebSocketConnections => Boolean): F[HttpWebSocketConnections] =
       R.repeatUntil(self.wsConnections, RepeatRequestOptions(1.second, 120))(pred)

--- a/dex-it/src/test/scala/com/wavesplatform/it/api/ApiExtensions.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/api/ApiExtensions.scala
@@ -58,12 +58,6 @@ trait ApiExtensions extends NodeApiExtensions {
       _.foreach(tx => wavesNodeApi.waitForTransaction(tx.id()))
     }
 
-  protected def saveSnapshotsAndWait(dexApi: DexApi[Id] = dex1.api): Unit = {
-    val currentOffset = dexApi.getCurrentOffset
-    dexApi.saveSnapshots
-    dexApi.waitForOldestSnapshotOffset(_ >= currentOffset)
-  }
-
   protected def matcherState(
     assetPairs: Seq[AssetPair],
     orders: IndexedSeq[Order],

--- a/dex-it/src/test/scala/com/wavesplatform/it/api/ApiExtensions.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/api/ApiExtensions.scala
@@ -58,6 +58,12 @@ trait ApiExtensions extends NodeApiExtensions {
       _.foreach(tx => wavesNodeApi.waitForTransaction(tx.id()))
     }
 
+  protected def saveSnapshotsAndWait(dexApi: DexApi[Id] = dex1.api): Unit = {
+    val currentOffset = dexApi.getCurrentOffset
+    dexApi.saveSnapshots
+    dexApi.waitForOldestSnapshotOffset(_ >= currentOffset)
+  }
+
   protected def matcherState(
     assetPairs: Seq[AssetPair],
     orders: IndexedSeq[Order],

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/MarketOrderTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/MarketOrderTestSuite.scala
@@ -149,8 +149,7 @@ class MarketOrderTestSuite extends MatcherSuiteBase {
     "fixed fee mode" - {
 
       "processing market order (SELL)" in {
-        saveSnapshotsAndWait() // Otherwise previous matches could be changed
-        dex1.restartWithNewSuiteConfig(ConfigFactory.parseString(s"waves.dex.order-fee.-1.mode = fixed").withFallback(dexInitialSuiteConfig))
+        dex1.safeRestartWithNewSuiteConfig(ConfigFactory.parseString(s"waves.dex.order-fee.-1.mode = fixed").withFallback(dexInitialSuiteConfig))
 
         testFilledMarketOrder(SELL, FeeMode.Fixed)
       }
@@ -392,8 +391,7 @@ class MarketOrderTestSuite extends MatcherSuiteBase {
     }
 
     "should be rejected if user has enough balance to fill market order, but has not enough balance to pay fee in another asset" in {
-      saveSnapshotsAndWait() // Otherwise previous matches could be changed
-      dex1.restartWithNewSuiteConfig(
+      dex1.safeRestartWithNewSuiteConfig(
         ConfigFactory
           .parseString(s"waves.dex.order-fee.-1.fixed.asset = $BtcId\nwaves.dex.order-fee.-1.mode = fixed")
           .withFallback(dexInitialSuiteConfig)
@@ -414,8 +412,7 @@ class MarketOrderTestSuite extends MatcherSuiteBase {
   }
 
   "Market order creation is possible when spendable balance is equal to reservable" in {
-    saveSnapshotsAndWait() // Otherwise previous matches could be changed
-    dex1.restartWithNewSuiteConfig(ConfigFactory.parseString(s"waves.dex.order-fee.-1.mode = dynamic").withFallback(dexInitialSuiteConfig))
+    dex1.safeRestartWithNewSuiteConfig(ConfigFactory.parseString(s"waves.dex.order-fee.-1.mode = dynamic").withFallback(dexInitialSuiteConfig))
 
     val carol = KeyPair("carol".getBytes)
 
@@ -432,8 +429,7 @@ class MarketOrderTestSuite extends MatcherSuiteBase {
   }
 
   "Market order should be executed even if sender balance isn't enough to cover order value" in {
-    saveSnapshotsAndWait() // Otherwise previous matches could be changed
-    dex1.restartWithNewSuiteConfig(ConfigFactory.parseString(s"waves.dex.order-fee.-1.mode = dynamic") withFallback dexInitialSuiteConfig)
+    dex1.safeRestartWithNewSuiteConfig(ConfigFactory.parseString(s"waves.dex.order-fee.-1.mode = dynamic") withFallback dexInitialSuiteConfig)
 
     val carol = mkAccountWithBalance(300.usd -> usd, 5.waves -> Waves)
 

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/MarketOrderTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/MarketOrderTestSuite.scala
@@ -149,6 +149,7 @@ class MarketOrderTestSuite extends MatcherSuiteBase {
     "fixed fee mode" - {
 
       "processing market order (SELL)" in {
+        saveSnapshotsAndWait() // Otherwise previous matches could be changed
         dex1.restartWithNewSuiteConfig(ConfigFactory.parseString(s"waves.dex.order-fee.-1.mode = fixed").withFallback(dexInitialSuiteConfig))
 
         testFilledMarketOrder(SELL, FeeMode.Fixed)
@@ -391,6 +392,7 @@ class MarketOrderTestSuite extends MatcherSuiteBase {
     }
 
     "should be rejected if user has enough balance to fill market order, but has not enough balance to pay fee in another asset" in {
+      saveSnapshotsAndWait() // Otherwise previous matches could be changed
       dex1.restartWithNewSuiteConfig(
         ConfigFactory
           .parseString(s"waves.dex.order-fee.-1.fixed.asset = $BtcId\nwaves.dex.order-fee.-1.mode = fixed")
@@ -411,8 +413,8 @@ class MarketOrderTestSuite extends MatcherSuiteBase {
     }
   }
 
-  "Market order creation is possible when spenadable balance is equal to reservable" in {
-
+  "Market order creation is possible when spendable balance is equal to reservable" in {
+    saveSnapshotsAndWait() // Otherwise previous matches could be changed
     dex1.restartWithNewSuiteConfig(ConfigFactory.parseString(s"waves.dex.order-fee.-1.mode = dynamic").withFallback(dexInitialSuiteConfig))
 
     val carol = KeyPair("carol".getBytes)
@@ -430,7 +432,7 @@ class MarketOrderTestSuite extends MatcherSuiteBase {
   }
 
   "Market order should be executed even if sender balance isn't enough to cover order value" in {
-
+    saveSnapshotsAndWait() // Otherwise previous matches could be changed
     dex1.restartWithNewSuiteConfig(ConfigFactory.parseString(s"waves.dex.order-fee.-1.mode = dynamic") withFallback dexInitialSuiteConfig)
 
     val carol = mkAccountWithBalance(300.usd -> usd, 5.waves -> Waves)

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/compat/DatabaseBackwardCompatTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/compat/DatabaseBackwardCompatTestSuite.scala
@@ -1,7 +1,6 @@
 package com.wavesplatform.it.sync.compat
 
 import com.wavesplatform.dex.api.http.entities.HttpOrderStatus.Status
-import com.wavesplatform.dex.api.http.entities.HttpSuccessfulPlace
 import com.wavesplatform.dex.domain.order.{Order, OrderType}
 import com.wavesplatform.it.api.MatcherCommand
 import com.wavesplatform.it.tags.DexMultipleVersions

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/MakerTakerFeeTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/MakerTakerFeeTestSuite.scala
@@ -123,6 +123,7 @@ class MakerTakerFeeTestSuite extends MatcherSuiteBase with TableDrivenPropertyCh
     val offset2 = offset1 + 1
     val offset3 = offset2 + 1
 
+    saveSnapshotsAndWait() // Otherwise previous matches could be changed
     dex1.restartWithNewSuiteConfig(
       ConfigFactory.parseString(
         s"""

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/MakerTakerFeeTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/MakerTakerFeeTestSuite.scala
@@ -123,8 +123,7 @@ class MakerTakerFeeTestSuite extends MatcherSuiteBase with TableDrivenPropertyCh
     val offset2 = offset1 + 1
     val offset3 = offset2 + 1
 
-    saveSnapshotsAndWait() // Otherwise previous matches could be changed
-    dex1.restartWithNewSuiteConfig(
+    dex1.safeRestartWithNewSuiteConfig(
       ConfigFactory.parseString(
         s"""
            |waves.dex {

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/OrderDynamicFeeTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/OrderDynamicFeeTestSuite.scala
@@ -802,12 +802,15 @@ class OrderDynamicFeeTestSuite extends OrderFeeBaseTestSuite {
 
       broadcastAndAwait(mkTransfer(alice, bob, defaultAssetQuantity / 2, eth, 0.005.waves))
 
+      saveSnapshotsAndWait() // Otherwise previous matches could be changed
       dex1.restartWithNewSuiteConfig(ConfigFactory.parseString("waves.dex.order-fee.-1.mode = percent").withFallback(dexInitialSuiteConfig))
       check()
 
+      saveSnapshotsAndWait() // Otherwise previous matches could be changed
       dex1.restartWithNewSuiteConfig(ConfigFactory.parseString("waves.dex.order-fee.-1.mode = fixed").withFallback(dexInitialSuiteConfig))
       check()
 
+      saveSnapshotsAndWait() // Otherwise previous matches could be changed
       dex1.restartWithNewSuiteConfig(
         ConfigFactory
           .parseString(s"waves.dex.order-fee.-1.fixed.asset = $BtcId\nwaves.dex.order-fee.-1.mode = fixed")

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/OrderDynamicFeeTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/OrderDynamicFeeTestSuite.scala
@@ -802,16 +802,13 @@ class OrderDynamicFeeTestSuite extends OrderFeeBaseTestSuite {
 
       broadcastAndAwait(mkTransfer(alice, bob, defaultAssetQuantity / 2, eth, 0.005.waves))
 
-      saveSnapshotsAndWait() // Otherwise previous matches could be changed
-      dex1.restartWithNewSuiteConfig(ConfigFactory.parseString("waves.dex.order-fee.-1.mode = percent").withFallback(dexInitialSuiteConfig))
+      dex1.safeRestartWithNewSuiteConfig(ConfigFactory.parseString("waves.dex.order-fee.-1.mode = percent").withFallback(dexInitialSuiteConfig))
       check()
 
-      saveSnapshotsAndWait() // Otherwise previous matches could be changed
-      dex1.restartWithNewSuiteConfig(ConfigFactory.parseString("waves.dex.order-fee.-1.mode = fixed").withFallback(dexInitialSuiteConfig))
+      dex1.safeRestartWithNewSuiteConfig(ConfigFactory.parseString("waves.dex.order-fee.-1.mode = fixed").withFallback(dexInitialSuiteConfig))
       check()
 
-      saveSnapshotsAndWait() // Otherwise previous matches could be changed
-      dex1.restartWithNewSuiteConfig(
+      dex1.safeRestartWithNewSuiteConfig(
         ConfigFactory
           .parseString(s"waves.dex.order-fee.-1.fixed.asset = $BtcId\nwaves.dex.order-fee.-1.mode = fixed")
           .withFallback(dexInitialSuiteConfig)

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/OrderFixedFeeTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/OrderFixedFeeTestSuite.scala
@@ -35,6 +35,7 @@ class OrderFixedFeeTestSuite extends OrderFeeBaseTestSuite {
               val pair = AssetPair(asset, Waves)
               val orderAmount = 1
 
+              saveSnapshotsAndWait() // Otherwise previous matches could be changed
               dex1.restartWithNewSuiteConfig(configWithOrderFeeFixed(asset))
               broadcastAndAwait(mkTransfer(alice, bob, wavesNode1.api.balance(alice, asset) / 2, asset, feeAmount = minFee + smartFee))
 
@@ -73,6 +74,7 @@ class OrderFixedFeeTestSuite extends OrderFeeBaseTestSuite {
       }
 
       "should accept orders if sender received amount > than fee amount" in {
+        saveSnapshotsAndWait() // Otherwise previous matches could be changed
         dex1.restartWithNewSuiteConfig(configWithOrderFeeFixed(aliceAsset))
         broadcastAndAwait(mkTransfer(bob, alice, minMatcherFee, aliceAsset))
         val pair = AssetPair(aliceAsset, Waves)

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/OrderFixedFeeTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/OrderFixedFeeTestSuite.scala
@@ -35,8 +35,7 @@ class OrderFixedFeeTestSuite extends OrderFeeBaseTestSuite {
               val pair = AssetPair(asset, Waves)
               val orderAmount = 1
 
-              saveSnapshotsAndWait() // Otherwise previous matches could be changed
-              dex1.restartWithNewSuiteConfig(configWithOrderFeeFixed(asset))
+              dex1.safeRestartWithNewSuiteConfig(configWithOrderFeeFixed(asset))
               broadcastAndAwait(mkTransfer(alice, bob, wavesNode1.api.balance(alice, asset) / 2, asset, feeAmount = minFee + smartFee))
 
               val aliceAssetBalanceBefore = wavesNode1.api.balance(alice, asset)
@@ -74,8 +73,7 @@ class OrderFixedFeeTestSuite extends OrderFeeBaseTestSuite {
       }
 
       "should accept orders if sender received amount > than fee amount" in {
-        saveSnapshotsAndWait() // Otherwise previous matches could be changed
-        dex1.restartWithNewSuiteConfig(configWithOrderFeeFixed(aliceAsset))
+        dex1.safeRestartWithNewSuiteConfig(configWithOrderFeeFixed(aliceAsset))
         broadcastAndAwait(mkTransfer(bob, alice, minMatcherFee, aliceAsset))
         val pair = AssetPair(aliceAsset, Waves)
         placeAndAwaitAtDex(mkOrder(


### PR DESCRIPTION
Now we save snapshots before restart Matcher with a new configuration, that affects matching.