### PR TITLE
DEX-1337 small fixes

### DIFF
--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/networking/DexClientFaultToleranceTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/networking/DexClientFaultToleranceTestSuite.scala
@@ -66,6 +66,8 @@ class DexClientFaultToleranceTestSuite extends MatcherSuiteBase with HasToxiProx
     }
   }
 
+  // may fail
+  // wait for a task NODE-2309 and node release 1.3.7 for possible solution
   "DEXClient should switch nodes if connection to one of them was lost due to node shutdown" in {
 
     // also works for the cases when nodes are disconnected from the network (not stopped),

--- a/jenkins/tests.Jenkinsfile
+++ b/jenkins/tests.Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
         PATH = "${env.SBT_HOME}/bin:${env.PATH}"
         SCALATEST_EXCLUDE_TAGS = 'com.wavesplatform.it.tags.DexItKafkaRequired com.wavesplatform.it.tags.DexItExternalKafkaRequired com.wavesplatform.it.tags.DexMultipleVersions'
 
-        // usually don't need in tests; saving as config example
+        // usually is not needed in tests; saving as a config example
         // CONFIG_FORCE_kamon_jaeger_http__url = "${DEX_JAEGER_HOST}"
         // CONFIG_FORCE_kamon_modules_jaeger_enabled = "true"
         // CONFIG_FORCE_kamon_enable = "true"

--- a/jenkins/tests.Jenkinsfile
+++ b/jenkins/tests.Jenkinsfile
@@ -14,11 +14,13 @@ pipeline {
         SBT_OPTS = '-Xmx12g -XX:ReservedCodeCacheSize=128m -XX:+CMSClassUnloadingEnabled'
         PATH = "${env.SBT_HOME}/bin:${env.PATH}"
         SCALATEST_EXCLUDE_TAGS = 'com.wavesplatform.it.tags.DexItKafkaRequired com.wavesplatform.it.tags.DexItExternalKafkaRequired com.wavesplatform.it.tags.DexMultipleVersions'
-        CONFIG_FORCE_kamon_jaeger_http__url = "${DEX_JAEGER_HOST}"
-        CONFIG_FORCE_kamon_modules_jaeger_enabled = "true"
-        CONFIG_FORCE_kamon_enable = "true"
-        CONFIG_FORCE_kamon_trace_tick__interval = "10.seconds"
-        CONFIG_FORCE_kamon_trace_adaptive__sampler_throughput = "600"
+
+        // usually don't need in tests; saving as config example
+        // CONFIG_FORCE_kamon_jaeger_http__url = "${DEX_JAEGER_HOST}"
+        // CONFIG_FORCE_kamon_modules_jaeger_enabled = "true"
+        // CONFIG_FORCE_kamon_enable = "true"
+        // CONFIG_FORCE_kamon_trace_tick__interval = "10.seconds"
+        // CONFIG_FORCE_kamon_trace_adaptive__sampler_throughput = "600"
     }
     stages {
         stage('Cleanup') {

--- a/waves-ext/src/main/resources/application.conf
+++ b/waves-ext/src/main/resources/application.conf
@@ -1,13 +1,16 @@
 waves.extensions += "com.wavesplatform.events.BlockchainUpdates"
 waves.extensions += "com.wavesplatform.dex.grpc.integration.DEXExtension"
 
-waves.dex {
-  # gRPC integration settings for Waves Node
-  grpc.integration {
-    # Extension's host
-    host = localhost
-    # Extension's port
-    port = 6887
+waves {
+
+  dex {
+      # gRPC integration settings for Waves Node
+      grpc.integration {
+        # Extension's host
+        host = localhost
+        # Extension's port
+        port = 6887
+      }
   }
 
   blockchain-updates.min-keep-alive = 2s


### PR DESCRIPTION
- turned off tracing for tests in Jenkins (they didn't work, only spawned errors in logs)
- fixed waves-ext config
- added comment about DexClientFaultToleranceTestSuite - we'll wait node version 1.3.7 for possible fix